### PR TITLE
fix(telegram): reset polling client after transport errors

### DIFF
--- a/src/ccgram/bot.py
+++ b/src/ccgram/bot.py
@@ -156,6 +156,7 @@ from .handlers.file_handler import handle_document_message, handle_photo_message
 from .handlers.text_handler import handle_text_message
 from .session import session_manager
 from .session_monitor import NewMessage, NewWindowEvent, SessionMonitor
+from .telegram_request import ResilientPollingHTTPXRequest
 from .tmux_manager import tmux_manager
 from .utils import task_done_callback
 
@@ -1691,6 +1692,7 @@ def create_bot() -> Application:
     application = (
         Application.builder()
         .token(config.telegram_bot_token)
+        .get_updates_request(ResilientPollingHTTPXRequest(connection_pool_size=1))
         .post_init(post_init)
         .post_shutdown(post_shutdown)
         .build()

--- a/src/ccgram/telegram_request.py
+++ b/src/ccgram/telegram_request.py
@@ -1,0 +1,47 @@
+"""Telegram request helpers for resilient long polling."""
+
+import asyncio
+
+import httpx
+import structlog
+from telegram.error import NetworkError, TimedOut
+from telegram.request import HTTPXRequest
+
+logger = structlog.get_logger()
+
+
+class ResilientPollingHTTPXRequest(HTTPXRequest):
+    """Reset the polling HTTP client after transient transport failures.
+
+    PTB uses a dedicated request object for ``getUpdates`` with a single
+    connection. If that connection gets stuck in a bad proxy/tunnel state,
+    subsequent polls can queue behind it forever. Rebuilding the client after a
+    timeout/network failure gives the polling loop a fresh pool on the next
+    retry.
+    """
+
+    async def _reset_client(self, *, reason: str) -> None:
+        old_client = self._client
+        self._client = self._build_client()
+
+        try:
+            async with asyncio.timeout(1.0):
+                await old_client.aclose()
+        except (TimeoutError, RuntimeError, OSError, httpx.HTTPError) as exc:
+            logger.debug(
+                "Ignoring error while closing stale polling client after %s: %s",
+                reason,
+                exc,
+            )
+
+    async def do_request(self, *args, **kwargs):  # type: ignore[override]
+        try:
+            return await super().do_request(*args, **kwargs)
+        except (TimedOut, NetworkError) as exc:
+            await self._reset_client(reason=exc.__class__.__name__)
+            logger.warning(
+                "Reset Telegram polling HTTP client after %s: %s",
+                exc.__class__.__name__,
+                exc,
+            )
+            raise

--- a/tests/ccgram/test_telegram_request.py
+++ b/tests/ccgram/test_telegram_request.py
@@ -1,0 +1,63 @@
+"""Tests for resilient Telegram polling requests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from telegram.error import NetworkError, TimedOut
+from telegram.request import HTTPXRequest
+
+from ccgram.bot import create_bot
+from ccgram.telegram_request import ResilientPollingHTTPXRequest
+
+
+class TestResilientPollingHTTPXRequest:
+    async def test_rebuilds_client_after_timeout(self) -> None:
+        request = ResilientPollingHTTPXRequest()
+        old_client = request._client
+
+        with (
+            patch.object(
+                HTTPXRequest,
+                "do_request",
+                AsyncMock(side_effect=TimedOut("pool timeout")),
+            ),
+            pytest.raises(TimedOut),
+        ):
+            await request.do_request("https://example.com", "POST")
+
+        assert request._client is not old_client
+        assert old_client.is_closed
+        assert not request._client.is_closed
+
+    async def test_rebuilds_client_after_network_error(self) -> None:
+        request = ResilientPollingHTTPXRequest()
+        old_client = request._client
+
+        with (
+            patch.object(
+                HTTPXRequest,
+                "do_request",
+                AsyncMock(side_effect=NetworkError("proxy broken")),
+            ),
+            pytest.raises(NetworkError),
+        ):
+            await request.do_request("https://example.com", "POST")
+
+        assert request._client is not old_client
+        assert old_client.is_closed
+        assert not request._client.is_closed
+
+
+class TestCreateBotPollingRequest:
+    @patch("ccgram.bot.config")
+    def test_uses_resilient_request_for_get_updates(
+        self, mock_config: MagicMock
+    ) -> None:
+        mock_config.telegram_bot_token = "fake:token"
+
+        app = create_bot()
+
+        assert isinstance(app.bot._request[0], ResilientPollingHTTPXRequest)
+        assert isinstance(app.bot._request[1], HTTPXRequest)
+        assert not isinstance(app.bot._request[1], ResilientPollingHTTPXRequest)
+        assert app.bot._request[0]._client._transport._pool._max_connections == 1


### PR DESCRIPTION
## Summary
  - reset the dedicated Telegram polling HTTP client after transient transport errors
  - route `getUpdates` through the resilient polling request path
  - add regression coverage for timeout and network-error recovery

## Test Plan
  - make test
  - uv run python -m pytest tests/ccgram/test_telegram_request.py