### PR TITLE
fix: install Claude hooks via current interpreter

### DIFF
--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -18,8 +18,9 @@ import json
 import logging
 import os
 import re
-import structlog
+import shlex
 import subprocess
+import structlog
 import sys
 import time
 from pathlib import Path
@@ -39,9 +40,11 @@ def _claude_settings_file() -> Path:
     return Path.home() / ".claude" / "settings.json"
 
 
-# Substring marker for detecting ccgram hook in command strings
-_HOOK_COMMAND_MARKER = "ccgram hook"
-# Legacy marker from pre-rename ccbot — used for detection and cleanup
+# Current hook command uses the active Python interpreter to avoid PATH issues.
+_CURRENT_HOOK_MARKER = "ccgram.main hook"
+# Older installs used the console script name directly.
+_PATH_HOOK_MARKER = "ccgram hook"
+# Legacy marker from pre-rename ccbot — used for detection and cleanup.
 _LEGACY_HOOK_MARKER = "ccbot hook"
 
 # Expected number of parts when parsing "session_name\t@id\twindow_name"
@@ -73,8 +76,28 @@ _ASYNC_EVENTS: frozenset[str] = frozenset(
 )
 
 
-def _has_hook_marker(settings: dict, event_type: str, marker: str) -> bool:
-    """Check if a hook with the given marker is installed for an event type."""
+def _current_hook_command() -> str:
+    """Build the hook command bound to the current Python interpreter."""
+    return f"{shlex.quote(sys.executable)} -m ccgram.main hook"
+
+
+def _is_current_hook_command(command: str) -> bool:
+    """Return True when the command matches the current module-based hook style."""
+    return _CURRENT_HOOK_MARKER in command
+
+
+def _is_any_ccgram_hook_command(command: str) -> bool:
+    """Return True for current, old, or legacy hook command styles."""
+    return any(
+        marker in command
+        for marker in (_CURRENT_HOOK_MARKER, _PATH_HOOK_MARKER, _LEGACY_HOOK_MARKER)
+    )
+
+
+def _has_matching_hook(
+    settings: dict, event_type: str, predicate: Any
+) -> bool:
+    """Check if an event has a hook command matching the predicate."""
     hooks = settings.get("hooks", {})
     event_hooks = hooks.get(event_type, [])
 
@@ -86,16 +109,14 @@ def _has_hook_marker(settings: dict, event_type: str, marker: str) -> bool:
             if not isinstance(h, dict):
                 continue
             cmd = h.get("command", "")
-            if marker in cmd:
+            if predicate(cmd):
                 return True
     return False
 
 
 def _has_ccgram_hook(settings: dict, event_type: str) -> bool:
     """Check if ccgram hook (or legacy ccbot hook) is installed."""
-    return _has_hook_marker(
-        settings, event_type, _HOOK_COMMAND_MARKER
-    ) or _has_hook_marker(settings, event_type, _LEGACY_HOOK_MARKER)
+    return _has_matching_hook(settings, event_type, _is_any_ccgram_hook_command)
 
 
 def _is_hook_installed(settings: dict) -> bool:
@@ -108,8 +129,10 @@ def get_installed_events(settings: dict) -> dict[str, bool]:
     return {event: _has_ccgram_hook(settings, event) for event in _HOOK_EVENT_TYPES}
 
 
-def _replace_legacy_hooks(settings: dict, event_type: str) -> None:
-    """Replace legacy 'ccbot hook' command strings with 'ccgram hook'."""
+def _replace_hook_commands(
+    settings: dict, event_type: str, predicate: Any, replacement: str
+) -> None:
+    """Replace matching hook commands for an event with the given command."""
     event_hooks = settings.get("hooks", {}).get(event_type, [])
     for entry in event_hooks:
         if not isinstance(entry, dict):
@@ -118,8 +141,8 @@ def _replace_legacy_hooks(settings: dict, event_type: str) -> None:
             if not isinstance(h, dict):
                 continue
             cmd = h.get("command", "")
-            if _LEGACY_HOOK_MARKER in cmd:
-                h["command"] = cmd.replace(_LEGACY_HOOK_MARKER, _HOOK_COMMAND_MARKER)
+            if predicate(cmd):
+                h["command"] = replacement
 
 
 def _install_hook() -> int:
@@ -145,24 +168,33 @@ def _install_hook() -> int:
 
     installed_count = 0
     already_count = 0
+    current_command = _current_hook_command()
 
     for event_type in _HOOK_EVENT_TYPES:
-        has_new = _has_hook_marker(settings, event_type, _HOOK_COMMAND_MARKER)
-        has_legacy = _has_hook_marker(settings, event_type, _LEGACY_HOOK_MARKER)
+        has_current = _has_matching_hook(
+            settings, event_type, _is_current_hook_command
+        )
+        has_known = _has_matching_hook(
+            settings, event_type, _is_any_ccgram_hook_command
+        )
 
-        if has_legacy and not has_new:
-            # Replace legacy "ccbot hook" entries with "ccgram hook"
-            _replace_legacy_hooks(settings, event_type)
+        if has_known and not has_current:
+            _replace_hook_commands(
+                settings,
+                event_type,
+                _is_any_ccgram_hook_command,
+                current_command,
+            )
             installed_count += 1
             continue
 
-        if has_new:
+        if has_current:
             already_count += 1
             continue
 
         hook_config: dict[str, Any] = {
             "type": "command",
-            "command": "ccgram hook",
+            "command": current_command,
             "timeout": 5,
         }
         if event_type in _ASYNC_EVENTS:
@@ -245,10 +277,7 @@ def _uninstall_hook() -> int:
                 h
                 for h in inner_hooks
                 if not isinstance(h, dict)
-                or (
-                    _HOOK_COMMAND_MARKER not in h.get("command", "")
-                    and _LEGACY_HOOK_MARKER not in h.get("command", "")
-                )
+                or not _is_any_ccgram_hook_command(h.get("command", ""))
             ]
             if filtered:
                 entry["hooks"] = filtered

--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -24,6 +24,7 @@ import structlog
 import sys
 import time
 from pathlib import Path
+from collections.abc import Callable
 from typing import Any
 
 logger = structlog.get_logger()
@@ -95,7 +96,7 @@ def _is_any_ccgram_hook_command(command: str) -> bool:
 
 
 def _has_matching_hook(
-    settings: dict, event_type: str, predicate: Any
+    settings: dict, event_type: str, predicate: Callable[[str], bool]
 ) -> bool:
     """Check if an event has a hook command matching the predicate."""
     hooks = settings.get("hooks", {})
@@ -130,7 +131,7 @@ def get_installed_events(settings: dict) -> dict[str, bool]:
 
 
 def _replace_hook_commands(
-    settings: dict, event_type: str, predicate: Any, replacement: str
+    settings: dict, event_type: str, predicate: Callable[[str], bool], replacement: str
 ) -> None:
     """Replace matching hook commands for an event with the given command."""
     event_hooks = settings.get("hooks", {}).get(event_type, [])
@@ -171,9 +172,7 @@ def _install_hook() -> int:
     current_command = _current_hook_command()
 
     for event_type in _HOOK_EVENT_TYPES:
-        has_current = _has_matching_hook(
-            settings, event_type, _is_current_hook_command
-        )
+        has_current = _has_matching_hook(settings, event_type, _is_current_hook_command)
         has_known = _has_matching_hook(
             settings, event_type, _is_any_ccgram_hook_command
         )

--- a/tests/ccgram/test_hook.py
+++ b/tests/ccgram/test_hook.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import shlex
 import subprocess
 import sys
 from unittest.mock import patch
@@ -19,6 +20,10 @@ from ccgram.hook import (
 )
 
 
+def _expected_module_command() -> str:
+    return f"{shlex.quote(sys.executable)} -m ccgram.main hook"
+
+
 class TestInstallHook:
     def test_install_into_empty_settings(self, tmp_path, monkeypatch) -> None:
         settings_file = tmp_path / "settings.json"
@@ -31,7 +36,9 @@ class TestInstallHook:
         settings = json.loads(settings_file.read_text())
         session_start = settings["hooks"]["SessionStart"]
         assert len(session_start) == 1
-        assert session_start[0]["hooks"][0]["command"] == "ccgram hook"
+        assert (
+            session_start[0]["hooks"][0]["command"] == _expected_module_command()
+        )
 
     def test_install_adds_to_existing_matcher_group(
         self, tmp_path, monkeypatch
@@ -64,9 +71,9 @@ class TestInstallHook:
         assert len(session_start) == 1
         hooks_list = session_start[0]["hooks"]
         assert len(hooks_list) == 2
-        assert hooks_list[1]["command"] == "ccgram hook"
+        assert hooks_list[1]["command"] == _expected_module_command()
 
-    def test_install_skips_when_already_present_with_wrapper(
+    def test_install_rewrites_wrapped_relative_command(
         self, tmp_path, monkeypatch
     ) -> None:
         settings_file = tmp_path / "settings.json"
@@ -94,8 +101,9 @@ class TestInstallHook:
         updated = json.loads(settings_file.read_text())
         hooks_list = updated["hooks"]["SessionStart"][0]["hooks"]
         assert len(hooks_list) == 1
+        assert hooks_list[0]["command"] == _expected_module_command()
 
-    def test_install_skips_when_already_present_with_full_path(
+    def test_install_rewrites_full_path_command(
         self, tmp_path, monkeypatch
     ) -> None:
         settings_file = tmp_path / "settings.json"
@@ -123,8 +131,11 @@ class TestInstallHook:
         updated = json.loads(settings_file.read_text())
         hooks_list = updated["hooks"]["SessionStart"][0]["hooks"]
         assert len(hooks_list) == 1
+        assert hooks_list[0]["command"] == _expected_module_command()
 
-    def test_install_uses_path_relative_command(self, tmp_path, monkeypatch) -> None:
+    def test_install_uses_current_python_module_command(
+        self, tmp_path, monkeypatch
+    ) -> None:
         settings_file = tmp_path / "settings.json"
         settings_file.parent.mkdir(parents=True, exist_ok=True)
         monkeypatch.setattr("ccgram.hook._claude_settings_file", lambda: settings_file)
@@ -133,8 +144,8 @@ class TestInstallHook:
 
         updated = json.loads(settings_file.read_text())
         cmd = updated["hooks"]["SessionStart"][0]["hooks"][0]["command"]
-        assert cmd == "ccgram hook"
-        assert "/" not in cmd
+        assert cmd == _expected_module_command()
+        assert " -m ccgram.main hook" in cmd
 
 
 class TestInstallMultipleEvents:
@@ -151,7 +162,10 @@ class TestInstallMultipleEvents:
         for event_type in _HOOK_EVENT_TYPES:
             assert event_type in settings["hooks"]
             hooks_list = settings["hooks"][event_type][0]["hooks"]
-            assert any("ccgram hook" in h.get("command", "") for h in hooks_list)
+            assert any(
+                h.get("command", "") == _expected_module_command()
+                for h in hooks_list
+            )
 
     def test_async_flag_on_subagent_events(self, tmp_path, monkeypatch) -> None:
         settings_file = tmp_path / "settings.json"
@@ -183,7 +197,7 @@ class TestInstallMultipleEvents:
                 h
                 for entry in entries
                 for h in entry.get("hooks", [])
-                if "ccgram hook" in h.get("command", "")
+                if h.get("command", "") == _expected_module_command()
             ]
             assert len(ccgram_hooks) == 1, (
                 f"{event_type} has {len(ccgram_hooks)} ccgram hooks"
@@ -291,6 +305,27 @@ class TestIsHookInstalled:
                             {
                                 "type": "command",
                                 "command": "/usr/bin/ccgram hook",
+                                "timeout": 5,
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+        assert _is_hook_installed(settings) is True
+
+    def test_python_module_command_matches(self) -> None:
+        settings = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": (
+                                    f"{shlex.quote(sys.executable)} "
+                                    "-m ccgram.main hook"
+                                ),
                                 "timeout": 5,
                             }
                         ]
@@ -470,6 +505,38 @@ class TestUninstallHook:
                             {
                                 "type": "command",
                                 "command": "ccgram hook 2>/dev/null || true",
+                                "timeout": 5,
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+        settings_file.write_text(json.dumps(settings))
+        monkeypatch.setattr("ccgram.hook._claude_settings_file", lambda: settings_file)
+
+        result = _uninstall_hook()
+        assert result == 0
+
+        updated = json.loads(settings_file.read_text())
+        assert not _is_hook_installed(updated)
+        assert updated["hooks"]["SessionStart"] == []
+
+    def test_uninstall_removes_python_module_variant(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        settings_file = tmp_path / "settings.json"
+        settings = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": (
+                                    f"{shlex.quote(sys.executable)} "
+                                    "-m ccgram.main hook"
+                                ),
                                 "timeout": 5,
                             }
                         ]

--- a/tests/ccgram/test_hook.py
+++ b/tests/ccgram/test_hook.py
@@ -36,9 +36,7 @@ class TestInstallHook:
         settings = json.loads(settings_file.read_text())
         session_start = settings["hooks"]["SessionStart"]
         assert len(session_start) == 1
-        assert (
-            session_start[0]["hooks"][0]["command"] == _expected_module_command()
-        )
+        assert session_start[0]["hooks"][0]["command"] == _expected_module_command()
 
     def test_install_adds_to_existing_matcher_group(
         self, tmp_path, monkeypatch
@@ -103,9 +101,7 @@ class TestInstallHook:
         assert len(hooks_list) == 1
         assert hooks_list[0]["command"] == _expected_module_command()
 
-    def test_install_rewrites_full_path_command(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    def test_install_rewrites_full_path_command(self, tmp_path, monkeypatch) -> None:
         settings_file = tmp_path / "settings.json"
         settings = {
             "hooks": {
@@ -163,8 +159,7 @@ class TestInstallMultipleEvents:
             assert event_type in settings["hooks"]
             hooks_list = settings["hooks"][event_type][0]["hooks"]
             assert any(
-                h.get("command", "") == _expected_module_command()
-                for h in hooks_list
+                h.get("command", "") == _expected_module_command() for h in hooks_list
             )
 
     def test_async_flag_on_subagent_events(self, tmp_path, monkeypatch) -> None:
@@ -323,8 +318,7 @@ class TestIsHookInstalled:
                             {
                                 "type": "command",
                                 "command": (
-                                    f"{shlex.quote(sys.executable)} "
-                                    "-m ccgram.main hook"
+                                    f"{shlex.quote(sys.executable)} -m ccgram.main hook"
                                 ),
                                 "timeout": 5,
                             }
@@ -534,8 +528,7 @@ class TestUninstallHook:
                             {
                                 "type": "command",
                                 "command": (
-                                    f"{shlex.quote(sys.executable)} "
-                                    "-m ccgram.main hook"
+                                    f"{shlex.quote(sys.executable)} -m ccgram.main hook"
                                 ),
                                 "timeout": 5,
                             }


### PR DESCRIPTION
## Summary
- install Claude hook commands via the active Python interpreter instead of relying on `ccgram` being on PATH
- rewrite existing `ccgram hook` and legacy `ccbot hook` entries to the module-based command during install
- extend hook tests to cover rewrite, detection, and uninstall behavior for the supported command variants

## Test Plan
- `uv run ruff check src/ccgram/hook.py tests/ccgram/test_hook.py`
- `uv run python -m pytest tests/ccgram/test_hook.py -q`