### PR TITLE
Recover stale provider mappings from transcript path

### DIFF
--- a/src/ccgram/handlers/status_polling.py
+++ b/src/ccgram/handlers/status_polling.py
@@ -43,6 +43,7 @@ from telegram.error import BadRequest, TelegramError
 from ..config import config
 from ..providers import (
     detect_provider_from_command,
+    detect_provider_from_transcript_path,
     detect_provider_from_runtime,
     get_provider_for_window,
     should_probe_pane_title_for_provider_detection,
@@ -1010,6 +1011,14 @@ async def _maybe_discover_transcript(
             )
         if detected and detected != state.provider_name:
             session_manager.set_window_provider(window_id, detected, cwd=w.cwd or None)
+        elif not detected and state.transcript_path:
+            inferred = detect_provider_from_transcript_path(state.transcript_path)
+            if inferred and inferred != state.provider_name:
+                session_manager.set_window_provider(
+                    window_id,
+                    inferred,
+                    cwd=w.cwd or None,
+                )
 
     # If provider is explicitly set and supports hooks, trust hook delivery
     if state.provider_name:

--- a/src/ccgram/providers/__init__.py
+++ b/src/ccgram/providers/__init__.py
@@ -124,6 +124,20 @@ def detect_provider_from_command(pane_current_command: str) -> str:
     return ""
 
 
+def detect_provider_from_transcript_path(transcript_path: str) -> str:
+    """Infer provider name from a persisted transcript path when possible."""
+    normalized = transcript_path.strip().lower().replace("\\", "/")
+    if not normalized:
+        return ""
+    if "/.codex/sessions/" in normalized:
+        return "codex"
+    if "/.claude/projects/" in normalized:
+        return "claude"
+    if "/.gemini/" in normalized and "/chats/" in normalized:
+        return "gemini"
+    return ""
+
+
 def should_probe_pane_title_for_provider_detection(pane_current_command: str) -> bool:
     """Return True when any provider needs pane-title context to detect runtime."""
     _ensure_registered()
@@ -231,6 +245,7 @@ __all__ = [
     "StatusUpdate",
     "UnknownProviderError",
     "detect_provider_from_command",
+    "detect_provider_from_transcript_path",
     "detect_provider_from_runtime",
     "get_provider",
     "get_provider_for_window",

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -25,7 +25,11 @@ from telegram.error import TelegramError
 
 from .config import config
 from .monitor_state import MonitorState, TrackedSession
-from .providers import get_provider_for_window
+from .providers import (
+    detect_provider_from_transcript_path,
+    get_provider_for_window,
+    registry,
+)
 from .session import parse_session_map
 from .tmux_manager import tmux_manager
 from .utils import (
@@ -49,6 +53,28 @@ _PathResolveError = (OSError, ValueError)
 _SessionMapError = (json.JSONDecodeError, OSError)
 
 _MSG_PREVIEW_LENGTH = 80
+
+
+def _resolve_provider_for_file(window_id: str, file_path: Path):
+    """Prefer transcript-path provider hints when a hookful state goes stale."""
+    provider = get_provider_for_window(window_id)
+    inferred = detect_provider_from_transcript_path(str(file_path))
+    current = provider.capabilities.name
+    if (
+        inferred
+        and inferred != current
+        and provider.capabilities.supports_hook
+        and registry.is_valid(inferred)
+    ):
+        logger.warning(
+            "Provider mismatch for window %s: state=%s transcript=%s; using %s",
+            window_id,
+            current,
+            file_path,
+            inferred,
+        )
+        return registry.get(inferred)
+    return provider
 
 
 @dataclass
@@ -319,7 +345,7 @@ class SessionMonitor:
 
         Detects file truncation (e.g. after /clear) and resets offset.
         """
-        provider = get_provider_for_window(window_id)
+        provider = _resolve_provider_for_file(window_id, file_path)
 
         # Whole-file providers (Gemini): read entire JSON, track by message count
         if not provider.capabilities.supports_incremental_read:
@@ -428,7 +454,7 @@ class SessionMonitor:
         and parsing. Appends any new messages to the provided list.
         """
         tracked = self.state.get_session(session_id)
-        provider = get_provider_for_window(window_id)
+        provider = _resolve_provider_for_file(window_id, file_path)
 
         if tracked is None:
             # For new sessions, initialize offset to skip old messages.

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from ccgram.monitor_state import TrackedSession
+from ccgram.providers.claude import ClaudeProvider
+from ccgram.providers.codex import CodexProvider
 from ccgram.session_monitor import NewWindowEvent, SessionMonitor
 
 
@@ -151,6 +153,53 @@ class TestPerWindowProviderResolution:
         )
         assert len(new_messages) == 1
         assert "hello" in new_messages[0].text
+
+    async def test_process_session_file_prefers_transcript_provider_when_stale(
+        self, tmp_path
+    ) -> None:
+        """A stale hookful provider should not suppress Codex transcript parsing."""
+        session_file = (
+            tmp_path
+            / ".codex"
+            / "sessions"
+            / "2026"
+            / "03"
+            / "23"
+            / "transcript.jsonl"
+        )
+        session_file.parent.mkdir(parents=True)
+        session_file.write_text(
+            '{"timestamp":"2026-03-23T00:00:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello codex"}]}}\n'
+        )
+
+        monitor = SessionMonitor(
+            projects_path=tmp_path / "projects",
+            state_file=tmp_path / "ms.json",
+        )
+        tracked = TrackedSession(
+            session_id="sess-stale",
+            file_path=str(session_file),
+            last_byte_offset=0,
+        )
+        monitor.state.update_session(tracked)
+
+        new_messages = []
+        with patch(
+            "ccgram.session_monitor.get_provider_for_window",
+            return_value=ClaudeProvider(),
+        ), patch(
+            "ccgram.session_monitor.registry.is_valid",
+            return_value=True,
+        ), patch(
+            "ccgram.session_monitor.registry.get",
+            return_value=CodexProvider(),
+        ):
+            await monitor._process_session_file(
+                "sess-stale", session_file, new_messages, window_id="@42"
+            )
+
+        assert len(new_messages) == 1
+        assert new_messages[0].text == "hello codex"
 
     async def test_check_for_updates_maps_session_to_window(self, tmp_path) -> None:
         """check_for_updates passes correct window_id to _process_session_file."""

--- a/tests/ccgram/test_status_polling.py
+++ b/tests/ccgram/test_status_polling.py
@@ -1359,6 +1359,89 @@ class TestMaybeDiscoverTranscript:
             provider_name="gemini",
         )
 
+    async def test_rebinds_stale_claude_window_to_codex_from_transcript_path(
+        self,
+    ) -> None:
+        from ccgram.handlers.status_polling import _maybe_discover_transcript
+        from ccgram.providers.base import SessionStartEvent
+
+        codex_event = SessionStartEvent(
+            session_id="codex-uuid",
+            cwd="/Users/alexei/Workspace/ccgram",
+            transcript_path="/Users/alexei/.codex/sessions/2026/03/23/test.jsonl",
+            window_key="ccgram:@7",
+        )
+        mock_codex = MagicMock()
+        mock_codex.capabilities.supports_hook = False
+        mock_codex.capabilities.name = "codex"
+        mock_codex.discover_transcript.return_value = codex_event
+
+        mock_claude = MagicMock()
+        mock_claude.capabilities.supports_hook = True
+        mock_claude.capabilities.name = "claude"
+
+        mock_state = MagicMock(
+            session_id="old-claude-id",
+            cwd="/Users/alexei/Workspace/ccgram",
+            transcript_path="/Users/alexei/.codex/sessions/old.jsonl",
+            provider_name="claude",
+        )
+
+        def _provider_for_window(_: str) -> MagicMock:
+            if mock_state.provider_name == "codex":
+                return mock_codex
+            return mock_claude
+
+        def _set_window_provider(
+            window_id: str, provider_name: str, *, cwd: str | None = None
+        ) -> None:
+            assert window_id == "@7"
+            mock_state.provider_name = provider_name
+            if cwd:
+                mock_state.cwd = cwd
+
+        with (
+            patch("ccgram.handlers.status_polling.session_manager") as mock_sm,
+            patch(
+                "ccgram.handlers.status_polling.get_provider_for_window",
+                side_effect=_provider_for_window,
+            ),
+            patch(
+                "ccgram.handlers.status_polling.detect_provider_from_command",
+                return_value="",
+            ),
+            patch(
+                "ccgram.handlers.status_polling.should_probe_pane_title_for_provider_detection",
+                return_value=False,
+            ),
+            patch("ccgram.handlers.status_polling.config") as mock_config,
+            patch("ccgram.handlers.status_polling.tmux_manager") as mock_tmux,
+        ):
+            mock_sm.window_states = {"@7": mock_state}
+            mock_sm.set_window_provider.side_effect = _set_window_provider
+            mock_tmux.find_window_by_id = AsyncMock(
+                return_value=MagicMock(
+                    pane_current_command="node",
+                    cwd="/Users/alexei/Workspace/ccgram",
+                )
+            )
+            mock_config.tmux_session_name = "ccgram"
+            await _maybe_discover_transcript("@7")
+
+        mock_sm.set_window_provider.assert_called_once_with(
+            "@7",
+            "codex",
+            cwd="/Users/alexei/Workspace/ccgram",
+        )
+        mock_codex.discover_transcript.assert_called_once()
+        mock_sm.register_hookless_session.assert_called_once_with(
+            window_id="@7",
+            session_id="codex-uuid",
+            cwd="/Users/alexei/Workspace/ccgram",
+            transcript_path="/Users/alexei/.codex/sessions/2026/03/23/test.jsonl",
+            provider_name="codex",
+        )
+
 
 class TestDeadWindowNotification:
     async def test_marks_notified_even_when_send_fails(self) -> None:


### PR DESCRIPTION
## Summary
- infer provider type from `transcript_path` when window state is stale
- let status polling correct a poisoned hookful provider state before skipping hookless transcript rediscovery
- let session monitoring choose the transcript-matching parser so Codex/Gemini transcripts are not silently parsed as zero messages
- add regression tests for both the status-polling recovery path and the session-monitor parser fallback

## Test Plan
- uv run --with pytest --with pytest-asyncio python -m pytest tests/ccgram/test_status_polling.py tests/ccgram/test_session_monitor.py
