### PR TITLE
Fix lost queue tasks after RetryAfter

### DIFF
--- a/src/ccgram/handlers/message_queue.py
+++ b/src/ccgram/handlers/message_queue.py
@@ -505,42 +505,51 @@ async def _message_queue_worker(bot: Bot, user_id: int) -> None:
         try:
             task = await queue.get()
             try:
-                if task.task_type == "content":
-                    extra = await _handle_content_task(bot, user_id, task, queue, lock)
-                    for _ in range(extra):
-                        queue.task_done()
-                elif task.task_type == "status_update":
-                    # Flush batch before status
-                    thread_id = task.thread_id or 0
-                    bkey = (user_id, thread_id)
-                    if bkey in _active_batches:
-                        await _flush_batch(bot, user_id, thread_id)
-                    collapsed_task, dropped = await _coalesce_status_updates(
-                        queue, task, lock
-                    )
-                    if dropped > 0:
-                        for _ in range(dropped):
-                            queue.task_done()
-                    await _process_status_update_task(bot, user_id, collapsed_task)
-                elif task.task_type == "status_clear":
-                    thread_id = task.thread_id or 0
-                    bkey = (user_id, thread_id)
-                    if bkey in _active_batches:
-                        await _flush_batch(bot, user_id, thread_id)
-                    await _do_clear_status_message(bot, user_id, thread_id)
-            except RetryAfter as e:
-                retry_secs = min(
-                    60,
-                    (
-                        e.retry_after
-                        if isinstance(e.retry_after, int)
-                        else int(e.retry_after.total_seconds())
-                    ),
-                )
-                logger.warning(
-                    "Flood control for user %s, pausing %ss", user_id, retry_secs
-                )
-                await asyncio.sleep(retry_secs)
+                while True:
+                    try:
+                        if task.task_type == "content":
+                            extra = await _handle_content_task(
+                                bot, user_id, task, queue, lock
+                            )
+                            for _ in range(extra):
+                                queue.task_done()
+                        elif task.task_type == "status_update":
+                            # Flush batch before status
+                            thread_id = task.thread_id or 0
+                            bkey = (user_id, thread_id)
+                            if bkey in _active_batches:
+                                await _flush_batch(bot, user_id, thread_id)
+                            collapsed_task, dropped = await _coalesce_status_updates(
+                                queue, task, lock
+                            )
+                            if dropped > 0:
+                                for _ in range(dropped):
+                                    queue.task_done()
+                            await _process_status_update_task(
+                                bot, user_id, collapsed_task
+                            )
+                        elif task.task_type == "status_clear":
+                            thread_id = task.thread_id or 0
+                            bkey = (user_id, thread_id)
+                            if bkey in _active_batches:
+                                await _flush_batch(bot, user_id, thread_id)
+                            await _do_clear_status_message(bot, user_id, thread_id)
+                        break
+                    except RetryAfter as e:
+                        retry_secs = min(
+                            60,
+                            (
+                                e.retry_after
+                                if isinstance(e.retry_after, int)
+                                else int(e.retry_after.total_seconds())
+                            ),
+                        )
+                        logger.warning(
+                            "Flood control for user %s, pausing %ss",
+                            user_id,
+                            retry_secs,
+                        )
+                        await asyncio.sleep(retry_secs)
             except (TelegramError, OSError):  # fmt: skip
                 logger.exception(
                     "Error processing message task for user %s (thread %s)",

--- a/tests/ccgram/test_tool_batching.py
+++ b/tests/ccgram/test_tool_batching.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from telegram.error import RetryAfter
 
 from ccgram.handlers.message_queue import (
     BATCH_MAX_ENTRIES,
@@ -18,6 +19,7 @@ from ccgram.handlers.message_queue import (
     _process_batch_task,
     clear_batch_for_topic,
     format_batch_message,
+    get_or_create_queue,
     shutdown_workers,
 )
 from ccgram.session import (
@@ -803,6 +805,40 @@ class TestShutdownClearsBatches:
         _active_batches[(2, 5)] = ToolBatch(window_id="@1", thread_id=5)
         await shutdown_workers()
         assert len(_active_batches) == 0
+
+
+# --- RetryAfter queue behavior ---
+
+
+class TestQueueWorkerRetryAfter:
+    @patch("ccgram.handlers.message_queue.asyncio.sleep", new_callable=AsyncMock)
+    @patch(
+        "ccgram.handlers.message_queue._handle_content_task", new_callable=AsyncMock
+    )
+    async def test_retry_after_retries_same_task(
+        self, mock_handle, mock_sleep
+    ) -> None:
+        await shutdown_workers()
+        mock_handle.side_effect = [RetryAfter(1), 0]
+
+        bot = AsyncMock()
+        queue = get_or_create_queue(bot, 1)
+        queue.put_nowait(
+            MessageTask(
+                task_type="content",
+                window_id="@0",
+                parts=["hello"],
+                content_type="text",
+                thread_id=10,
+            )
+        )
+
+        try:
+            await asyncio.wait_for(queue.join(), timeout=1)
+            assert mock_handle.await_count == 2
+            mock_sleep.assert_awaited_once()
+        finally:
+            await shutdown_workers()
 
 
 # --- C1 fix: tool_result not silently dropped ---


### PR DESCRIPTION
## Summary
- retry the same message queue task after `RetryAfter` instead of dropping it after sleeping
- preserve existing batching/status-clear behavior while keeping the worker loop alive across flood-control pauses
- add a regression test that proves a content task is retried and eventually completes

## Test Plan
- uv run --with pytest --with pytest-asyncio python -m pytest tests/ccgram/test_tool_batching.py
