### PR TITLE
Fix Codex final-answer routing and guardian transcript discovery

### DIFF
--- a/src/ccgram/handlers/message_routing.py
+++ b/src/ccgram/handlers/message_routing.py
@@ -67,8 +67,10 @@ async def handle_new_message(msg: NewMessage, bot: Bot) -> None:  # noqa: C901, 
         if not is_tool_flow:
             if notif_mode == "muted":
                 continue
-            if notif_mode == "errors_only" and not _ERROR_KEYWORDS_RE.search(
-                msg.text or ""
+            if (
+                notif_mode == "errors_only"
+                and msg.phase != "final_answer"
+                and not _ERROR_KEYWORDS_RE.search(msg.text or "")
             ):
                 continue
 

--- a/src/ccgram/monitor_events.py
+++ b/src/ccgram/monitor_events.py
@@ -29,8 +29,9 @@ class NewMessage:
 
     session_id: str
     text: str
-    is_complete: bool  # True when stop_reason is set (final message)
+    is_complete: bool
     content_type: str = "text"  # "text" or "thinking"
+    phase: str | None = None
     tool_use_id: str | None = None
     role: str = "assistant"  # "user" or "assistant"
     tool_name: str | None = None  # For tool_use messages, the tool name

--- a/src/ccgram/providers/base.py
+++ b/src/ccgram/providers/base.py
@@ -49,6 +49,7 @@ class AgentMessage:
     role: MessageRole
     content_type: ContentType
     is_complete: bool = True
+    phase: str | None = None
     tool_use_id: str | None = None
     tool_name: str | None = None
     timestamp: str | None = None

--- a/src/ccgram/providers/codex.py
+++ b/src/ccgram/providers/codex.py
@@ -421,12 +421,14 @@ def _parse_response_message(
     text = _extract_text_blocks(payload.get("content", ""))
     if not text:
         return [], pending
+    phase = payload.get("phase")
     return (
         [
             AgentMessage(
                 text=text,
                 role=cast(MessageRole, role),
                 content_type="text",
+                phase=phase if isinstance(phase, str) and phase else None,
             )
         ],
         pending,
@@ -439,13 +441,31 @@ def _parse_event_message(
 ) -> tuple[list[AgentMessage], dict[str, Any]]:
     """Parse Codex event_msg payloads that carry assistant-visible text."""
     payload_type = payload.get("type", "")
-    if payload_type != "agent_message":
-        return [], pending
-    text = payload.get("message", "")
-    if not isinstance(text, str) or not text:
-        return [], pending
+    if payload_type == "agent_message":
+        text = payload.get("message", "")
+        if not isinstance(text, str) or not text:
+            return [], pending
+        return (
+            [AgentMessage(text=text, role="assistant", content_type="text")],
+            pending,
+        )
+    if payload_type == "task_complete":
+        text = payload.get("last_agent_message", "")
+        if not isinstance(text, str) or not text:
+            return [], pending
+        return (
+            [
+                AgentMessage(
+                    text=text,
+                    role="assistant",
+                    content_type="text",
+                    phase="final_answer",
+                )
+            ],
+            pending,
+        )
     return (
-        [AgentMessage(text=text, role="assistant", content_type="text")],
+        [],
         pending,
     )
 
@@ -473,10 +493,23 @@ def _append_unique_messages(
     for message in candidates:
         signature = (message.role, message.content_type, message.text)
         if signature == current:
+            if dest and _prefer_duplicate_message(dest[-1], message):
+                dest[-1] = message
             continue
         dest.append(message)
         current = signature
     return current
+
+
+def _prefer_duplicate_message(previous: AgentMessage, candidate: AgentMessage) -> bool:
+    """Keep the duplicate carrying richer metadata, such as final_answer."""
+    if previous.phase != candidate.phase:
+        return previous.phase is None and candidate.phase is not None
+    if previous.tool_use_id != candidate.tool_use_id:
+        return previous.tool_use_id is None and candidate.tool_use_id is not None
+    if previous.tool_name != candidate.tool_name:
+        return previous.tool_name is None and candidate.tool_name is not None
+    return False
 
 
 # Transcripts older than this are considered stale and skipped during discovery.
@@ -513,6 +546,22 @@ def _read_codex_session_meta(fpath: Path) -> dict[str, Any] | None:
         return None
     payload = data.get("payload")
     return payload if isinstance(payload, dict) else None
+
+
+def _is_primary_codex_session(meta: dict[str, Any]) -> bool:
+    """Whether session metadata represents a top-level Codex CLI session.
+
+    Hookless discovery should bind a tmux window to the main user-visible
+    conversation, not transient guardian/subagent transcripts created for
+    approvals or delegated work. Those transcripts share the same cwd and can be
+    newer than the main transcript, so they must be filtered out here.
+    """
+    source = meta.get("source")
+    if isinstance(source, str):
+        return True
+    if not isinstance(source, dict):
+        return True
+    return "subagent" not in source
 
 
 class CodexProvider(JsonlProvider):
@@ -692,6 +741,8 @@ class CodexProvider(JsonlProvider):
                 break  # sorted newest-first; remaining are all older
             meta = _read_codex_session_meta(fpath)
             if not meta:
+                continue
+            if not _is_primary_codex_session(meta):
                 continue
             file_cwd = meta.get("cwd", "")
             if file_cwd and str(Path(file_cwd).resolve()) == resolved_cwd:

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -176,8 +176,9 @@ class TranscriptReader:
                 NewMessage(
                     session_id=session_id,
                     text=entry.text,
-                    is_complete=True,
+                    is_complete=entry.is_complete,
                     content_type=entry.content_type,
+                    phase=entry.phase,
                     tool_use_id=entry.tool_use_id,
                     role=entry.role,
                     tool_name=entry.tool_name,

--- a/tests/ccgram/handlers/test_message_routing.py
+++ b/tests/ccgram/handlers/test_message_routing.py
@@ -10,6 +10,7 @@ def _make_msg(
     *,
     text: str = "hello",
     content_type: str = "text",
+    phase: str | None = None,
     tool_name: str = "",
     tool_use_id: str = "",
     role: str = "assistant",
@@ -20,6 +21,7 @@ def _make_msg(
         session_id=session_id,
         text=text,
         content_type=content_type,
+        phase=phase,
         tool_name=tool_name,
         tool_use_id=tool_use_id,
         role=role,
@@ -99,6 +101,15 @@ async def test_errors_only_skips_without_keyword(bot, mock_deps):
 async def test_errors_only_passes_with_error_keyword(bot, mock_deps):
     mock_deps["wq"].get_notification_mode.return_value = "errors_only"
     await handle_new_message(_make_msg(text="got Exception: boom"), bot)
+    mock_deps["eq"].assert_called_once()
+
+
+async def test_errors_only_passes_final_answer_without_keyword(bot, mock_deps):
+    mock_deps["wq"].get_notification_mode.return_value = "errors_only"
+    await handle_new_message(
+        _make_msg(text="normal final answer", phase="final_answer"),
+        bot,
+    )
     mock_deps["eq"].assert_called_once()
 
 

--- a/tests/ccgram/providers/test_jsonl_providers.py
+++ b/tests/ccgram/providers/test_jsonl_providers.py
@@ -119,6 +119,23 @@ class TestCodexTranscriptParsing:
         assert messages[0].text == "hello"
         assert messages[0].role == "assistant"
 
+    def test_parses_final_answer_phase_from_response_item(self) -> None:
+        codex = CodexProvider()
+        entries = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "done"}],
+                },
+            }
+        ]
+        messages, _ = codex.parse_transcript_entries(entries, {})
+        assert len(messages) == 1
+        assert messages[0].phase == "final_answer"
+
     def test_parses_user_input_item(self) -> None:
         codex = CodexProvider()
         entries = [
@@ -171,6 +188,47 @@ class TestCodexTranscriptParsing:
         messages, _ = codex.parse_transcript_entries(entries, {})
         assert len(messages) == 1
         assert messages[0].text == "same text"
+
+    def test_dedupes_event_and_prefers_final_answer_metadata(self) -> None:
+        codex = CodexProvider()
+        entries = [
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "agent_message",
+                    "message": "same text",
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "same text"}],
+                },
+            },
+        ]
+        messages, _ = codex.parse_transcript_entries(entries, {})
+        assert len(messages) == 1
+        assert messages[0].text == "same text"
+        assert messages[0].phase == "final_answer"
+
+    def test_parses_task_complete_as_final_answer_fallback(self) -> None:
+        codex = CodexProvider()
+        entries = [
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "last_agent_message": "finished",
+                },
+            }
+        ]
+        messages, _ = codex.parse_transcript_entries(entries, {})
+        assert len(messages) == 1
+        assert messages[0].text == "finished"
+        assert messages[0].phase == "final_answer"
 
     def test_tracks_function_call_pending(self) -> None:
         codex = CodexProvider()
@@ -1291,12 +1349,21 @@ def _write_gemini_session(
 
 
 def _write_codex_session(
-    sessions_dir: Path, date_parts: str, name: str, session_id: str, cwd: str
+    sessions_dir: Path,
+    date_parts: str,
+    name: str,
+    session_id: str,
+    cwd: str,
+    *,
+    source: object = "cli",
 ) -> Path:
     day_dir = sessions_dir / date_parts
     day_dir.mkdir(parents=True, exist_ok=True)
     fpath = day_dir / f"{name}.jsonl"
-    meta = {"type": "session_meta", "payload": {"id": session_id, "cwd": cwd}}
+    meta = {
+        "type": "session_meta",
+        "payload": {"id": session_id, "cwd": cwd, "source": source},
+    }
     fpath.write_text(json.dumps(meta) + "\n")
     return fpath
 
@@ -1411,6 +1478,45 @@ class TestCodexDiscoverTranscript:
             event = codex.discover_transcript("/my/project", "ccgram:@7")
         assert event is not None
         assert event.session_id == "uuid-fresh"
+
+    def test_skips_newer_guardian_subagent_transcript(self, tmp_path: Path) -> None:
+        sessions_dir = tmp_path / ".codex" / "sessions"
+        _write_codex_session(
+            sessions_dir, "2026/03/01", "main", "uuid-main", "/my/project"
+        )
+        time.sleep(0.05)
+        _write_codex_session(
+            sessions_dir,
+            "2026/03/02",
+            "guardian",
+            "uuid-guardian",
+            "/my/project",
+            source={"subagent": {"other": "guardian"}},
+        )
+
+        codex = CodexProvider()
+        with patch.object(Path, "home", return_value=tmp_path):
+            event = codex.discover_transcript("/my/project", "ccgram:@7")
+        assert event is not None
+        assert event.session_id == "uuid-main"
+
+    def test_returns_none_when_only_guardian_subagent_matches(
+        self, tmp_path: Path
+    ) -> None:
+        sessions_dir = tmp_path / ".codex" / "sessions"
+        _write_codex_session(
+            sessions_dir,
+            "2026/03/02",
+            "guardian",
+            "uuid-guardian",
+            "/my/project",
+            source={"subagent": {"other": "guardian"}},
+        )
+
+        codex = CodexProvider()
+        with patch.object(Path, "home", return_value=tmp_path):
+            event = codex.discover_transcript("/my/project", "ccgram:@7")
+        assert event is None
 
 
 class TestCodexDiscoverTranscriptMaxAge:


### PR DESCRIPTION
  ## Summary

  This PR fixes two Codex-specific issues in Telegram delivery and hookless session discovery:

  1. Final assistant answers could be dropped in `errors_only` notification mode.
  2. Hookless transcript discovery could bind a tmux window to a guardian/subagent transcript instead of the main Codex session.

  ## What Changed

  - Preserve Codex message `phase` metadata through transcript parsing and routing.
  - Treat Codex `task_complete.last_agent_message` as a `final_answer` fallback.
  - In `errors_only` mode, allow final answers through even when they do not match error keywords.
  - Ignore Codex transcripts whose `session_meta.payload.source` indicates a subagent/guardian session during hookless discovery.
  - Add regression coverage for both final-answer routing and guardian transcript filtering.

  ## Why

  Codex emits some final answers with explicit final-answer metadata, and in some cases also via `task_complete` events. Without preserving that metadata, `errors_only` routing can suppress a normal final response.

  Separately, guardian approval sessions write their own transcripts under the same cwd as the main Codex session. Hookless discovery previously selected the newest matching transcript by cwd, which allowed transient guardian sessions to steal the window binding.

  ## Tests

  - `env PYTHONPATH=src /home/{user}/codex/.conda/envs/ccgram/bin/python -m pytest tests/ccgram/providers/test_jsonl_providers.py -q`
  - `env PYTHONPATH=src /home/{user}/codex/.conda/envs/ccgram/bin/python -m pytest tests/ccgram/handlers/test_message_routing.py -q`

  ## Branch

  - Fork: `zhangraytk/ccgram`
  - Branch: `fix/codex-telegram-routing`