### PR TITLE
fix(session_map): preserve parent binding under nested SessionStart

### DIFF
--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 import asyncio
 import fcntl
 import json
+import os
+import time
 import structlog
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import aiofiles
@@ -29,6 +32,48 @@ from .window_resolver import EMDASH_SESSION_PREFIX, is_foreign_window, is_window
 logger = structlog.get_logger()
 
 _LEGACY_SESSION_PREFIX = "ccbot:"
+
+# Default grace window (seconds) for liveness-gated session_id overwrite.
+# Configurable via the CCGRAM_NESTED_SESSION_GRACE_SEC env var.
+_DEFAULT_NESTED_SESSION_GRACE_SEC = 60.0
+
+
+def _nested_session_grace_sec() -> float:
+    """Read the nested-session grace window from the env each call.
+
+    Read-on-call (rather than module-load) keeps tests free to override via
+    monkeypatch.setenv without re-importing the module.
+    """
+    raw = os.getenv("CCGRAM_NESTED_SESSION_GRACE_SEC")
+    if raw is None:
+        return _DEFAULT_NESTED_SESSION_GRACE_SEC
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "CCGRAM_NESTED_SESSION_GRACE_SEC must be a number, got %r — "
+            "using default %.1f",
+            raw,
+            _DEFAULT_NESTED_SESSION_GRACE_SEC,
+        )
+        return _DEFAULT_NESTED_SESSION_GRACE_SEC
+
+
+def _existing_session_is_live(transcript_path: str, grace_sec: float) -> bool:
+    """Return True if the transcript file was modified within grace_sec.
+
+    Heuristic for "the session bound to this window is still actively running":
+    a fresh-mtime transcript means Claude is still appending to it. A stale or
+    missing transcript means the prior session has gone silent and its hold on
+    the window binding can be released.
+    """
+    if not transcript_path:
+        return False
+    try:
+        mtime = Path(transcript_path).stat().st_mtime
+    except OSError:
+        return False
+    return (time.time() - mtime) < grace_sec
 
 
 def parse_session_map(raw: dict[str, Any], prefix: str) -> dict[str, dict[str, str]]:
@@ -471,6 +516,34 @@ class SessionMapSync:
         if mark_external and not state.external:
             state.external = True
             changed = True
+
+        # Liveness-gated overwrite: if a different session_id arrives for a
+        # window whose existing session is still actively writing its
+        # transcript, treat the new SessionStart as nested (e.g. an Agent
+        # Teams teammate spawned in the same tmux pane) and preserve the
+        # existing parent binding. Other field updates (provider_name,
+        # window_name) below still proceed. The grace window auto-releases
+        # the hold once the parent's transcript stops being modified, so
+        # `/clear`, a fresh CLI restart, or `claude --resume` of a different
+        # session all unblock naturally.
+        if (
+            state.session_id
+            and new_sid != state.session_id
+            and _existing_session_is_live(
+                state.transcript_path, _nested_session_grace_sec()
+            )
+        ):
+            logger.info(
+                "Skip session_id overwrite for window_id %s: "
+                "existing %s still live, new %s treated as nested",
+                window_id,
+                state.session_id,
+                new_sid,
+            )
+            new_sid = state.session_id
+            new_cwd = state.cwd
+            new_transcript = state.transcript_path
+
         if state.session_id != new_sid or state.cwd != new_cwd:
             logger.info(
                 "Session map: window_id %s updated sid=%s, cwd=%s",

--- a/tests/ccgram/test_session_map.py
+++ b/tests/ccgram/test_session_map.py
@@ -1,0 +1,340 @@
+"""Tests for session_map.py — focus on liveness-gated session_id overwrite.
+
+Regression coverage for the window→session binding bug where nested
+SessionStart events from Agent Teams teammates would clobber a still-live
+parent session's binding. See `_existing_session_is_live` and the gate
+inside `_sync_window_from_session_map`.
+"""
+
+import json
+import logging
+import os
+import time
+
+import pytest
+import structlog
+
+from ccgram.session_map import session_map_sync
+from ccgram.thread_router import thread_router
+from ccgram.window_state_store import WindowState, window_store
+
+
+@pytest.fixture(autouse=True)
+def _configure_structlog_for_caplog():
+    """Route structlog through stdlib logging so pytest's caplog captures it."""
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.format_exc_info,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        wrapper_class=structlog.stdlib.BoundLogger,
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=False,
+    )
+    yield
+    structlog.reset_defaults()
+
+
+@pytest.fixture(autouse=True)
+def _wire_schedule_save():
+    """Stub _schedule_save singletons so SessionMapSync can be tested in isolation.
+
+    Production wiring is done by SessionManager.__init__; tests here exercise
+    SessionMapSync directly, so no-op stubs on the relevant singletons are
+    enough to keep the unwired-save guard quiet.
+    """
+    sms_orig = session_map_sync._schedule_save
+    tr_orig = thread_router._schedule_save
+    session_map_sync._schedule_save = lambda: None
+    thread_router._schedule_save = lambda: None
+    yield
+    session_map_sync._schedule_save = sms_orig
+    thread_router._schedule_save = tr_orig
+    thread_router.reset()
+
+
+def _write_session_map(path, entries: dict) -> None:
+    path.write_text(json.dumps(entries))
+
+
+def _set_mtime(path, age_seconds: float) -> None:
+    """Set file mtime to (now - age_seconds)."""
+    mtime = time.time() - age_seconds
+    os.utime(path, (mtime, mtime))
+
+
+class TestLivenessGatedOverwrite:
+    """The key regression: a nested teammate must not clobber the parent."""
+
+    async def test_skips_overwrite_when_existing_transcript_fresh(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Parent's transcript modified within grace_sec → new sid is ignored."""
+        # Parent transcript: present, modified seconds ago (fresh).
+        parent_transcript = tmp_path / "parent.jsonl"
+        parent_transcript.write_text('{"type": "assistant"}\n')
+        _set_mtime(parent_transcript, age_seconds=2.0)
+
+        # Pre-seed the window state as if the parent had registered first.
+        window_store.window_states["@44"] = WindowState(
+            session_id="parent-uuid",
+            cwd="/tmp/parent-project",
+            window_name="parent-window",
+            transcript_path=str(parent_transcript),
+            provider_name="claude",
+        )
+
+        # session_map.json now contains the teammate's entry under the same key.
+        teammate_transcript = tmp_path / "teammate.jsonl"
+        teammate_transcript.write_text('{"type": "assistant"}\n')
+        session_map_file = tmp_path / "session_map.json"
+        _write_session_map(
+            session_map_file,
+            {
+                "ccgram:@44": {
+                    "session_id": "teammate-uuid",
+                    "cwd": "/tmp/teammate-project",
+                    "window_name": "parent-window",
+                    "transcript_path": str(teammate_transcript),
+                    "provider_name": "claude",
+                }
+            },
+        )
+
+        monkeypatch.setattr(
+            "ccgram.session_map.config.session_map_file", session_map_file
+        )
+        monkeypatch.setattr("ccgram.session_map.config.tmux_session_name", "ccgram")
+
+        with caplog.at_level(logging.INFO, logger="ccgram.session_map"):
+            await session_map_sync.load_session_map()
+
+        # Binding is preserved: parent still owns the window.
+        state = window_store.get_window_state("@44")
+        assert state.session_id == "parent-uuid"
+        assert state.cwd == "/tmp/parent-project"
+        assert state.transcript_path == str(parent_transcript)
+
+        # Skip log emitted, naming both sessions and the window_id.
+        assert "Skip session_id overwrite" in caplog.text
+        assert "@44" in caplog.text
+        assert "parent-uuid" in caplog.text
+        assert "teammate-uuid" in caplog.text
+
+    async def test_overwrites_when_existing_transcript_stale(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """Parent gone silent past grace_sec → new sid wins (lock auto-releases)."""
+        parent_transcript = tmp_path / "parent.jsonl"
+        parent_transcript.write_text('{"type": "assistant"}\n')
+        # 120s old — well beyond default grace_sec=60.
+        _set_mtime(parent_transcript, age_seconds=120.0)
+
+        window_store.window_states["@44"] = WindowState(
+            session_id="parent-uuid",
+            cwd="/tmp/parent-project",
+            window_name="parent-window",
+            transcript_path=str(parent_transcript),
+            provider_name="claude",
+        )
+
+        new_transcript = tmp_path / "new.jsonl"
+        new_transcript.write_text('{"type": "assistant"}\n')
+        session_map_file = tmp_path / "session_map.json"
+        _write_session_map(
+            session_map_file,
+            {
+                "ccgram:@44": {
+                    "session_id": "new-uuid",
+                    "cwd": "/tmp/new-project",
+                    "window_name": "parent-window",
+                    "transcript_path": str(new_transcript),
+                    "provider_name": "claude",
+                }
+            },
+        )
+
+        monkeypatch.setattr(
+            "ccgram.session_map.config.session_map_file", session_map_file
+        )
+        monkeypatch.setattr("ccgram.session_map.config.tmux_session_name", "ccgram")
+
+        await session_map_sync.load_session_map()
+
+        # Binding flipped: parent went silent, new session takes over.
+        state = window_store.get_window_state("@44")
+        assert state.session_id == "new-uuid"
+        assert state.cwd == "/tmp/new-project"
+        assert state.transcript_path == str(new_transcript)
+
+    async def test_first_registration_unaffected(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """Empty-state windows still register normally (gate only fires on conflict)."""
+        transcript = tmp_path / "first.jsonl"
+        transcript.write_text('{"type": "assistant"}\n')
+        session_map_file = tmp_path / "session_map.json"
+        _write_session_map(
+            session_map_file,
+            {
+                "ccgram:@7": {
+                    "session_id": "first-uuid",
+                    "cwd": "/tmp/first",
+                    "window_name": "first",
+                    "transcript_path": str(transcript),
+                    "provider_name": "claude",
+                }
+            },
+        )
+
+        monkeypatch.setattr(
+            "ccgram.session_map.config.session_map_file", session_map_file
+        )
+        monkeypatch.setattr("ccgram.session_map.config.tmux_session_name", "ccgram")
+
+        await session_map_sync.load_session_map()
+
+        state = window_store.get_window_state("@7")
+        assert state.session_id == "first-uuid"
+        assert state.cwd == "/tmp/first"
+
+    async def test_same_session_id_update_unaffected(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """Same session_id refresh (e.g. cwd change) still applies even if fresh."""
+        transcript = tmp_path / "same.jsonl"
+        transcript.write_text('{"type": "assistant"}\n')
+        _set_mtime(transcript, age_seconds=2.0)
+
+        window_store.window_states["@9"] = WindowState(
+            session_id="stable-uuid",
+            cwd="/tmp/old-cwd",
+            transcript_path=str(transcript),
+            provider_name="claude",
+        )
+
+        session_map_file = tmp_path / "session_map.json"
+        _write_session_map(
+            session_map_file,
+            {
+                "ccgram:@9": {
+                    "session_id": "stable-uuid",
+                    "cwd": "/tmp/new-cwd",
+                    "window_name": "win",
+                    "transcript_path": str(transcript),
+                    "provider_name": "claude",
+                }
+            },
+        )
+
+        monkeypatch.setattr(
+            "ccgram.session_map.config.session_map_file", session_map_file
+        )
+        monkeypatch.setattr("ccgram.session_map.config.tmux_session_name", "ccgram")
+
+        await session_map_sync.load_session_map()
+
+        state = window_store.get_window_state("@9")
+        assert state.session_id == "stable-uuid"
+        # cwd update for the same session_id is allowed.
+        assert state.cwd == "/tmp/new-cwd"
+
+    async def test_grace_sec_env_override(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """CCGRAM_NESTED_SESSION_GRACE_SEC env var tunes the lock window."""
+        # Parent transcript is 5s old. Default grace=60 would protect; setting
+        # grace=1 should release.
+        parent_transcript = tmp_path / "parent.jsonl"
+        parent_transcript.write_text('{"type": "assistant"}\n')
+        _set_mtime(parent_transcript, age_seconds=5.0)
+
+        window_store.window_states["@44"] = WindowState(
+            session_id="parent-uuid",
+            cwd="/tmp/parent",
+            transcript_path=str(parent_transcript),
+            provider_name="claude",
+        )
+
+        new_transcript = tmp_path / "new.jsonl"
+        new_transcript.write_text('{"type": "assistant"}\n')
+        session_map_file = tmp_path / "session_map.json"
+        _write_session_map(
+            session_map_file,
+            {
+                "ccgram:@44": {
+                    "session_id": "new-uuid",
+                    "cwd": "/tmp/new",
+                    "window_name": "win",
+                    "transcript_path": str(new_transcript),
+                    "provider_name": "claude",
+                }
+            },
+        )
+
+        monkeypatch.setenv("CCGRAM_NESTED_SESSION_GRACE_SEC", "1.0")
+        monkeypatch.setattr(
+            "ccgram.session_map.config.session_map_file", session_map_file
+        )
+        monkeypatch.setattr("ccgram.session_map.config.tmux_session_name", "ccgram")
+
+        await session_map_sync.load_session_map()
+
+        # Tighter grace window → existing 5s-old session counts as stale.
+        state = window_store.get_window_state("@44")
+        assert state.session_id == "new-uuid"
+
+    async def test_missing_transcript_releases_lock(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """If the existing transcript path no longer exists, treat as stale."""
+        # Reference a path that doesn't exist.
+        window_store.window_states["@44"] = WindowState(
+            session_id="parent-uuid",
+            cwd="/tmp/parent",
+            transcript_path=str(tmp_path / "vanished.jsonl"),
+            provider_name="claude",
+        )
+
+        new_transcript = tmp_path / "new.jsonl"
+        new_transcript.write_text('{"type": "assistant"}\n')
+        session_map_file = tmp_path / "session_map.json"
+        _write_session_map(
+            session_map_file,
+            {
+                "ccgram:@44": {
+                    "session_id": "new-uuid",
+                    "cwd": "/tmp/new",
+                    "window_name": "win",
+                    "transcript_path": str(new_transcript),
+                    "provider_name": "claude",
+                }
+            },
+        )
+
+        monkeypatch.setattr(
+            "ccgram.session_map.config.session_map_file", session_map_file
+        )
+        monkeypatch.setattr("ccgram.session_map.config.tmux_session_name", "ccgram")
+
+        await session_map_sync.load_session_map()
+
+        state = window_store.get_window_state("@44")
+        assert state.session_id == "new-uuid"


### PR DESCRIPTION
## Summary

Fix a window→session binding bug where a nested `SessionStart` event from a child Claude Code process (e.g. an Agent Teams teammate spawned in the same tmux pane) overwrites the parent's binding in `state.json`, and the binding is never restored when the nested process exits. After the bug fires, ccgram tails a frozen child transcript instead of the parent's live transcript, and Telegram forwarding silently breaks until the user hand-edits `~/.ccgram/state.json` and restarts ccgram.

## Bug trace

Two-layer unconditional overwrite:

- `hook.py::_update_session_map` writes `session_map.json` with the new session's data, replacing any prior entry for the same `session_window_key`.
- `session_map.py::_sync_window_from_session_map` propagates the disk change into in-memory `WindowState.session_id` whenever the file value differs.

`session_lifecycle.py::reconcile` then drops the prior session's transcript from the read set. No mechanism re-promotes the parent when the nested session exits.

Reproduction observed locally (`~/.ccgram/events.jsonl`):

```
ts=…852  SessionStart  @44  session=1476da52  (parent)
ts=…047  SessionStart  @44  session=2e94bab7  (nested teammate — overwrite)
ts=…310  Stop          @44  session=2e94bab7  (teammate done)
ts=…454  Stop          @44  session=1476da52  (parent active again — but binding still on teammate)
```

## Fix

Liveness-gated overwrite in `_sync_window_from_session_map`. Before replacing `state.session_id`, check whether the existing binding's `transcript_path` was modified within a grace window (default 60s, configurable via `CCGRAM_NESTED_SESSION_GRACE_SEC`). If fresh, the existing session is still actively writing — treat the new SessionStart as nested and preserve the parent binding. Other field updates (`window_name`, `provider_name`, `external`) flow through normally.

The gate auto-releases when the prior session goes silent for `grace_sec`, so `/clear`, `claude --resume`, or pane respawn unblock naturally without explicit unlock plumbing.

Diff: 73 lines added in `src/ccgram/session_map.py` (imports + 2 helpers + gate block).

## Test plan

Added `tests/ccgram/test_session_map.py` with 6 regression tests:

- skips overwrite when existing transcript is fresh
- overwrites when existing transcript is stale (≥grace_sec)
- baseline registration of new window (no existing binding)
- same-sid update path (idempotent)
- env-var override (`CCGRAM_NESTED_SESSION_GRACE_SEC`)
- missing-transcript file releases the lock (defensive degrade)

Test fixtures use real tmp files + `os.utime` for mtime control (matching the `test_session.py` style). Lint + format pass via `ruff`.

Unit suite green: `3,667 passed, 30 skipped`.

Also live-verified locally: installed the patched build via `uv tool install --reinstall .`, restarted the ccgram daemon, then spawned a probe teammate via `TeamCreate` from a parent pane — confirmed in `events.jsonl` that the teammate's `SessionStart` fired and `state.json`'s `session_id` for that window was preserved (would have been clobbered pre-patch).

## Considered alternatives

Considered four other mechanisms before picking the daemon-layer mtime gate:

- **First-seen-locked at the hook write layer** — clean, but no auto-recovery from parent crash without explicit `SessionEnd` (which doesn't fire on `kill -9` / OS crash).
- **PID-ancestry detection at hook time** — fragile (`ps` flag + `comm` truncation differ across BSD/Linux; brittle for wrapper-script setups; adds per-`SessionStart` subprocess latency).
- **Track-all-sessions schema extension with primary election** — most general (also enables forwarding teammate transcripts) but ~100 LOC across 4 files + `state.json` schema migration risk.
- **Asking upstream Claude Code to expose `parent_session_id` in the hook payload** — cleanest long-term, but unbounded time horizon; requires an interim workaround anyway.

Picked the daemon-layer mtime gate as the smallest patch that fixes the bug with bounded self-recovering failure modes. Happy to revisit if you'd prefer a different shape.

## Pre-existing test surface (note for reviewer)

Confirmed by stashing this PR and running pristine `upstream/main`:

- `tests/ccgram/handlers/test_shell_commands.py::TestHandleShellMessage::test_send_failure_replies_error` fails on pristine HEAD (mock not asserted).
- `tests/e2e/*` and `tests/integration/test_tmux_manager.py` fail when run in an environment with an active ccgram session (tmux pane resolution interference). Spot-checked failures on pristine `upstream/main` to confirm pre-existing.

Neither set is introduced by this PR.