### PR TITLE
fix(session_map): preserve primary binding under nested SessionStart

### DIFF
--- a/src/ccgram/handlers/topic_orchestration.py
+++ b/src/ccgram/handlers/topic_orchestration.py
@@ -260,7 +260,9 @@ async def _rebind_existing_topic_by_name(
         )
         return False
 
-    thread_router.bind_thread(user_id, thread_id, event.window_id, window_name=topic_name)
+    thread_router.bind_thread(
+        user_id, thread_id, event.window_id, window_name=topic_name
+    )
     thread_router.set_group_chat_id(user_id, thread_id, chat_id)
     logger.info(
         "Rebound existing topic thread %d from stale window %s to new window %s (%s)",

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 import asyncio
 import fcntl
 import json
+import os
+import time
 import structlog
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import aiofiles
@@ -29,6 +32,93 @@ from .window_resolver import EMDASH_SESSION_PREFIX, is_foreign_window, is_window
 logger = structlog.get_logger()
 
 _LEGACY_SESSION_PREFIX = "ccbot:"
+_DEFAULT_PRIMARY_SESSION_GRACE_SEC = 60.0
+
+
+def _primary_session_grace_sec() -> float:
+    raw = os.getenv("CCGRAM_NESTED_SESSION_GRACE_SEC")
+    if raw is None:
+        return _DEFAULT_PRIMARY_SESSION_GRACE_SEC
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "CCGRAM_NESTED_SESSION_GRACE_SEC must be a number, got %r; using default %.1f",
+            raw,
+            _DEFAULT_PRIMARY_SESSION_GRACE_SEC,
+        )
+        return _DEFAULT_PRIMARY_SESSION_GRACE_SEC
+
+
+def _transcript_mtime(transcript_path: str) -> float | None:
+    if not transcript_path:
+        return None
+    try:
+        return Path(transcript_path).stat().st_mtime
+    except OSError:
+        return None
+
+
+def _transcript_is_fresh(transcript_path: str, *, now: float | None = None) -> bool:
+    mtime = _transcript_mtime(transcript_path)
+    if mtime is None:
+        return False
+    reference = time.time() if now is None else now
+    return reference - mtime < _primary_session_grace_sec()
+
+
+def _prefer_existing_primary(
+    window_id: str,
+    incoming: dict[str, Any],
+) -> dict[str, str] | None:
+    from .window_state_store import window_store
+
+    state = window_store.window_states.get(window_id)
+    if not state or not state.session_id:
+        return None
+
+    incoming_sid = incoming.get("session_id", "")
+    if not incoming_sid or incoming_sid == state.session_id:
+        return None
+
+    existing_mtime = _transcript_mtime(state.transcript_path)
+    incoming_mtime = _transcript_mtime(incoming.get("transcript_path", ""))
+    existing_is_fresh = _transcript_is_fresh(state.transcript_path)
+    existing_is_newer = existing_mtime is not None and (
+        incoming_mtime is None or existing_mtime >= incoming_mtime
+    )
+    if not existing_is_fresh and not existing_is_newer:
+        return None
+
+    logger.info(
+        "Preserving primary session for window_id %s: existing %s, incoming %s treated as nested",
+        window_id,
+        state.session_id,
+        incoming_sid,
+    )
+    return {
+        "session_id": state.session_id,
+        "cwd": state.cwd,
+        "window_name": incoming.get("window_name", "") or state.window_name,
+        "transcript_path": state.transcript_path,
+        "provider_name": incoming.get("provider_name", "") or state.provider_name,
+    }
+
+
+def effective_session_map_info(
+    window_id: str,
+    info: dict[str, Any],
+) -> dict[str, str]:
+    preferred = _prefer_existing_primary(window_id, info)
+    if preferred is not None:
+        return preferred
+    return {
+        "session_id": info.get("session_id", ""),
+        "cwd": info.get("cwd", ""),
+        "window_name": info.get("window_name", ""),
+        "transcript_path": info.get("transcript_path", ""),
+        "provider_name": info.get("provider_name", ""),
+    }
 
 
 def parse_session_map(raw: dict[str, Any], prefix: str) -> dict[str, dict[str, str]]:
@@ -48,15 +138,9 @@ def parse_session_map(raw: dict[str, Any], prefix: str) -> dict[str, dict[str, s
             continue
         if not isinstance(info, dict):
             continue
-        session_id = info.get("session_id", "")
-        if session_id:
-            result[window_name] = {
-                "session_id": session_id,
-                "cwd": info.get("cwd", ""),
-                "window_name": info.get("window_name", ""),
-                "transcript_path": info.get("transcript_path", ""),
-                "provider_name": info.get("provider_name", ""),
-            }
+        effective = effective_session_map_info(window_name, info)
+        if effective["session_id"]:
+            result[window_name] = effective
     return result
 
 
@@ -459,12 +543,13 @@ class SessionMapSync:
         from .thread_router import thread_router
         from .window_state_store import window_store
 
-        new_sid = info.get("session_id", "")
+        effective = effective_session_map_info(window_id, info)
+        new_sid = effective["session_id"]
         if not new_sid:
             return False
-        new_cwd = info.get("cwd", "")
-        new_wname = info.get("window_name", "")
-        new_transcript = info.get("transcript_path", "")
+        new_cwd = effective["cwd"]
+        new_wname = effective["window_name"]
+        new_transcript = effective["transcript_path"]
         changed = False
 
         state = window_store.get_window_state(window_id)
@@ -487,7 +572,7 @@ class SessionMapSync:
         if new_transcript and state.transcript_path != new_transcript:
             state.transcript_path = new_transcript
             changed = True
-        new_provider = info.get("provider_name", "").lower()
+        new_provider = effective["provider_name"].lower()
         if new_provider and state.provider_name != new_provider:
             state.provider_name = new_provider
             changed = True

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -90,7 +90,7 @@ def _prefer_existing_primary(
     if not existing_is_fresh and not existing_is_newer:
         return None
 
-    logger.info(
+    logger.debug(
         "Preserving primary session for window_id %s: existing %s, incoming %s treated as nested",
         window_id,
         state.session_id,

--- a/tests/ccgram/test_session_map_primary.py
+++ b/tests/ccgram/test_session_map_primary.py
@@ -1,0 +1,124 @@
+"""Session map primary election regression tests."""
+
+import json
+import os
+import time
+from pathlib import Path
+
+from ccgram.session_map import parse_session_map, session_map_sync
+from ccgram.window_state_store import WindowState, window_store
+
+
+def _write_transcript(path: Path, age_seconds: float) -> None:
+    path.write_text('{"type":"assistant"}\n')
+    mtime = time.time() - age_seconds
+    os.utime(path, (mtime, mtime))
+
+
+def _info(session_id: str, transcript: Path) -> dict[str, str]:
+    return {
+        "session_id": session_id,
+        "cwd": "/repo",
+        "window_name": "repo",
+        "transcript_path": str(transcript),
+        "provider_name": "claude",
+    }
+
+
+def test_parse_session_map_preserves_fresh_existing_primary(tmp_path: Path) -> None:
+    parent = tmp_path / "parent.jsonl"
+    child = tmp_path / "child.jsonl"
+    _write_transcript(parent, 2)
+    _write_transcript(child, 0)
+    window_store.window_states["@7"] = WindowState(
+        session_id="parent", cwd="/repo", transcript_path=str(parent)
+    )
+
+    parsed = parse_session_map({"ccgram:@7": _info("child", child)}, "ccgram:")
+
+    assert parsed["@7"]["session_id"] == "parent"
+    assert parsed["@7"]["transcript_path"] == str(parent)
+
+
+def test_parse_session_map_preserves_existing_primary_when_newer_than_candidate(
+    tmp_path: Path,
+) -> None:
+    parent = tmp_path / "parent.jsonl"
+    child = tmp_path / "child.jsonl"
+    _write_transcript(parent, 120)
+    _write_transcript(child, 180)
+    window_store.window_states["@7"] = WindowState(
+        session_id="parent", cwd="/repo", transcript_path=str(parent)
+    )
+
+    parsed = parse_session_map({"ccgram:@7": _info("child", child)}, "ccgram:")
+
+    assert parsed["@7"]["session_id"] == "parent"
+
+
+def test_parse_session_map_adopts_newer_stale_candidate(tmp_path: Path) -> None:
+    parent = tmp_path / "parent.jsonl"
+    new = tmp_path / "new.jsonl"
+    _write_transcript(parent, 180)
+    _write_transcript(new, 2)
+    window_store.window_states["@7"] = WindowState(
+        session_id="parent", cwd="/repo", transcript_path=str(parent)
+    )
+
+    parsed = parse_session_map({"ccgram:@7": _info("new", new)}, "ccgram:")
+
+    assert parsed["@7"]["session_id"] == "new"
+
+
+def test_parse_session_map_adopts_when_existing_state_was_cleared(
+    tmp_path: Path,
+) -> None:
+    transcript = tmp_path / "new.jsonl"
+    _write_transcript(transcript, 0)
+    window_store.window_states["@7"] = WindowState()
+
+    parsed = parse_session_map({"ccgram:@7": _info("new", transcript)}, "ccgram:")
+
+    assert parsed["@7"]["session_id"] == "new"
+
+
+async def test_load_session_map_preserves_primary_window_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    parent = tmp_path / "parent.jsonl"
+    child = tmp_path / "child.jsonl"
+    _write_transcript(parent, 2)
+    _write_transcript(child, 0)
+    session_map_file = tmp_path / "session_map.json"
+    session_map_file.write_text(json.dumps({"ccgram:@7": _info("child", child)}))
+    monkeypatch.setattr("ccgram.session_map.config.session_map_file", session_map_file)
+    monkeypatch.setattr("ccgram.session_map.config.tmux_session_name", "ccgram")
+    monkeypatch.setattr(session_map_sync, "_schedule_save", lambda: None)
+    window_store.window_states["@7"] = WindowState(
+        session_id="parent",
+        cwd="/repo",
+        window_name="repo",
+        transcript_path=str(parent),
+    )
+
+    await session_map_sync.load_session_map()
+
+    state = window_store.window_states["@7"]
+    assert state.session_id == "parent"
+    assert state.transcript_path == str(parent)
+
+
+def test_grace_env_allows_adopting_candidate(tmp_path: Path, monkeypatch) -> None:
+    parent = tmp_path / "parent.jsonl"
+    new = tmp_path / "new.jsonl"
+    _write_transcript(parent, 5)
+    _write_transcript(new, 1)
+    monkeypatch.setenv("CCGRAM_NESTED_SESSION_GRACE_SEC", "1")
+    window_store.window_states["@7"] = WindowState(
+        session_id="parent", cwd="/repo", transcript_path=str(parent)
+    )
+
+    parsed = parse_session_map({"ccgram:@7": _info("new", new)}, "ccgram:")
+
+    assert parsed["@7"]["session_id"] == "new"

--- a/tests/integration/test_monitor_flow.py
+++ b/tests/integration/test_monitor_flow.py
@@ -14,6 +14,7 @@ import pytest
 
 from ccgram.claude_task_state import get_claude_task_snapshot
 from ccgram.session_monitor import SessionMonitor
+from ccgram.window_state_store import WindowState, window_store
 
 pytestmark = pytest.mark.integration
 
@@ -196,6 +197,53 @@ async def test_file_truncation_resets_offset(
     new_messages = await monitor.check_for_updates(current)
     assert len(new_messages) == 1
     assert new_messages[0].text == "after truncation"
+
+
+async def test_nested_session_start_does_not_steal_forwarding(state_dir) -> None:
+    parent_id = TEST_SESSION_ID
+    child_id = "11111111-2222-3333-4444-555555555555"
+    parent_transcript = state_dir / "parent.jsonl"
+    child_transcript = state_dir / "child.jsonl"
+    _write_jsonl(parent_transcript, [_make_assistant_entry("parent old")])
+    _write_jsonl(
+        child_transcript, [_make_assistant_entry("child done", session_id=child_id)]
+    )
+    window_store.window_states["@0"] = WindowState(
+        session_id=parent_id,
+        cwd="/tmp/test",
+        window_name="test",
+        transcript_path=str(parent_transcript),
+        provider_name="claude",
+    )
+    (state_dir / "session_map.json").write_text(
+        json.dumps(
+            {
+                "ccgram:@0": {
+                    "session_id": child_id,
+                    "cwd": "/tmp/test",
+                    "window_name": "test",
+                    "transcript_path": str(child_transcript),
+                    "provider_name": "claude",
+                }
+            }
+        )
+    )
+
+    monitor = _make_monitor(state_dir)
+    current = await monitor._load_current_session_map()
+    assert current["@0"]["session_id"] == parent_id
+    assert await monitor.check_for_updates(current) == []
+
+    _append_jsonl(parent_transcript, [_make_assistant_entry("parent new")])
+    _bump_mtime(parent_transcript)
+    current = await monitor._detect_and_cleanup_changes()
+    new_messages = await monitor.check_for_updates(current)
+
+    assert current["@0"]["session_id"] == parent_id
+    assert len(new_messages) == 1
+    assert new_messages[0].session_id == parent_id
+    assert new_messages[0].text == "parent new"
+    assert monitor.state.get_session(child_id) is None
 
 
 async def test_session_change_cleanup(state_dir, session_map_with_transcript) -> None:


### PR DESCRIPTION
## Summary

Closes #62.

Fixes nested Claude `SessionStart` events stealing a window\u2019s primary session binding. `session_map.json` remains the raw hook feed, but `session_map.py` now elects an effective primary before state sync, lifecycle reconciliation, and transcript forwarding consume it.

## Why

A nested teammate process can emit `SessionStart` from the same tmux pane as its parent. The raw hook entry uses the same window key, so the child can replace the parent and make Telegram tail a finished child transcript while the parent keeps running.

## Fix

- Preserve the existing primary session when its transcript is fresh or newer than the incoming candidate.
- Allow replacement when the existing binding is stale, missing, or cleared.
- Keep the grace window configurable with `CCGRAM_NESTED_SESSION_GRACE_SEC`.
- Apply primary election in the parsed/effective session map so monitor forwarding and persisted window state agree.

## Tests

- `make test`
- `make test-integration`
- `uv run pyright src/ccgram/session_map.py`
- `uv run ruff check src/ccgram/session_map.py tests/ccgram/test_session_map_primary.py tests/integration/test_monitor_flow.py`
- `uv run ruff format --check src/ccgram/session_map.py tests/ccgram/test_session_map_primary.py tests/integration/test_monitor_flow.py`