### PR TITLE
feat(handlers): add toggle to suppress tool-call messages

### DIFF
--- a/src/ccgram/bot.py
+++ b/src/ccgram/bot.py
@@ -284,6 +284,59 @@ async def verbose_command(update: Update, _context: ContextTypes.DEFAULT_TYPE) -
         )
 
 
+async def toolcalls_command(
+    update: Update, _context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Cycle tool-call visibility for this topic: default \u2192 shown \u2192 hidden \u2192 default."""
+    user = update.effective_user
+    if not user or not is_user_allowed(user.id):
+        return
+    if not update.message:
+        return
+
+    thread_id = _get_thread_id(update)
+    if thread_id is None:
+        if (
+            update.message
+            and update.effective_chat
+            and is_general_topic(update.message)
+        ):
+            await handle_general_topic_message(
+                update.get_bot(), update.message, update.effective_chat.id
+            )
+        else:
+            await safe_reply(update.message, "\u274c Use this command inside a topic.")
+        return
+
+    window_id = thread_router.get_window_for_thread(user.id, thread_id)
+    if not window_id:
+        await safe_reply(
+            update.message, "\u274c This topic is not bound to any session."
+        )
+        return
+
+    new_mode = session_manager.cycle_tool_call_visibility(window_id)
+    if new_mode == "shown":
+        await safe_reply(
+            update.message,
+            "\u26a1 Tool calls *shown* for this topic (overrides global default).",
+        )
+    elif new_mode == "hidden":
+        await safe_reply(
+            update.message,
+            "\U0001f507 Tool calls *hidden* for this topic (overrides global default).",
+        )
+    else:
+        # new_mode == "default" \u2014 describe the resolved global behavior
+        from .config import config
+
+        resolved = "hidden" if config.hide_tool_calls else "shown"
+        await safe_reply(
+            update.message,
+            f"\U0001f504 Tool calls follow the global default (currently *{resolved}*).",
+        )
+
+
 async def inline_query_handler(
     update: Update, _context: ContextTypes.DEFAULT_TYPE
 ) -> None:
@@ -609,6 +662,9 @@ def create_bot() -> Application:
     application.add_handler(CommandHandler("send", send_command, filters=_group_filter))
     application.add_handler(
         CommandHandler("verbose", verbose_command, filters=_group_filter)
+    )
+    application.add_handler(
+        CommandHandler("toolcalls", toolcalls_command, filters=_group_filter)
     )
     application.add_handler(
         CommandHandler("restore", restore_command, filters=_group_filter)

--- a/src/ccgram/cli.py
+++ b/src/ccgram/cli.py
@@ -70,6 +70,7 @@ _FLAG_TO_ENV: list[tuple[str, str]] = [
     ("claude_config_dir", "CLAUDE_CONFIG_DIR"),
     ("whisper_provider", "CCGRAM_WHISPER_PROVIDER"),
     ("ack_reaction", "CCGRAM_ACK_REACTION"),
+    ("hide_tool_calls", "CCGRAM_HIDE_TOOL_CALLS"),
 ]
 
 
@@ -192,6 +193,13 @@ def apply_args_to_env(**kwargs: object) -> None:
     default=None,
     envvar="CCGRAM_ACK_REACTION",
     help='React to forwarded messages with emoji (e.g., "👀"). Empty=disabled.',
+)
+@click.option(
+    "--hide-tool-calls",
+    is_flag=True,
+    default=None,
+    envvar="CCGRAM_HIDE_TOOL_CALLS",
+    help="Hide tool_use/tool_result messages globally (per-window override via /toolcalls).",
 )
 def run_cmd(**kwargs: object) -> None:
     """Start the bot with optional overrides."""

--- a/src/ccgram/config.py
+++ b/src/ccgram/config.py
@@ -179,6 +179,12 @@ class Config:
         self._init_send()
         self._init_lifecycle()
 
+        # Global default for hiding tool_use/tool_result content in Telegram.
+        # Per-window override via WindowState.tool_call_visibility takes precedence.
+        self.hide_tool_calls: bool = os.getenv(
+            "CCGRAM_HIDE_TOOL_CALLS", ""
+        ).lower() in ("1", "true", "yes")
+
         logger.debug(
             "Config initialized: dir=%s, token=%s..., allowed_users=%d, "
             "tmux_session=%s",

--- a/src/ccgram/handlers/message_queue.py
+++ b/src/ccgram/handlers/message_queue.py
@@ -211,6 +211,13 @@ async def _handle_content_task(
 
     Returns the number of additional merged tasks (caller must call task_done for each).
     """
+    from ..window_query import is_tool_calls_hidden
+
+    if task.content_type in ("tool_use", "tool_result") and is_tool_calls_hidden(
+        task.window_id
+    ):
+        return 0
+
     if is_batch_eligible(task):
         followup = await process_tool_event(bot, user_id, task)
         if followup is not None:

--- a/src/ccgram/handlers/message_queue.py
+++ b/src/ccgram/handlers/message_queue.py
@@ -17,6 +17,7 @@ from telegram.error import RetryAfter, TelegramError
 from ..thread_router import thread_router
 from ..topic_state_registry import topic_state
 from ..utils import task_done_callback
+from ..window_query import is_tool_calls_hidden
 from .message_sender import edit_with_fallback, rate_limit_send_message, send_kwargs
 from .message_task import (
     ContentTask,
@@ -211,8 +212,6 @@ async def _handle_content_task(
 
     Returns the number of additional merged tasks (caller must call task_done for each).
     """
-    from ..window_query import is_tool_calls_hidden
-
     if task.content_type in ("tool_use", "tool_result") and is_tool_calls_hidden(
         task.window_id
     ):

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -557,6 +557,7 @@ class SessionManager:
             approval_mode=ws.approval_mode,
             notification_mode=ws.notification_mode,
             batch_mode=ws.batch_mode,
+            tool_call_visibility=ws.tool_call_visibility,
             transcript_path=Path(ws.transcript_path) if ws.transcript_path else None,
             window_name=ws.window_name,
             session_id=ws.session_id,
@@ -681,6 +682,20 @@ class SessionManager:
         new_mode = "verbose" if current == "batched" else "batched"
         self.set_batch_mode(window_id, new_mode)
         return new_mode
+
+    # --- Tool-call visibility ---
+
+    def get_tool_call_visibility(self, window_id: str) -> str:
+        """Get tool-call visibility for a window (default: 'default')."""
+        return window_store.get_tool_call_visibility(window_id)
+
+    def set_tool_call_visibility(self, window_id: str, mode: str) -> None:
+        """Set tool-call visibility for a window."""
+        window_store.set_tool_call_visibility(window_id, mode)
+
+    def cycle_tool_call_visibility(self, window_id: str) -> str:
+        """Cycle tool-call visibility: default → shown → hidden → default. Returns new mode."""
+        return window_store.cycle_tool_call_visibility(window_id)
 
 
 session_manager = SessionManager()

--- a/src/ccgram/window_query.py
+++ b/src/ccgram/window_query.py
@@ -20,6 +20,8 @@ from .window_state_store import (
     BATCH_MODES,
     DEFAULT_APPROVAL_MODE,
     DEFAULT_BATCH_MODE,
+    DEFAULT_TOOL_CALL_VISIBILITY,
+    TOOL_CALL_VISIBILITY_MODES,
     window_store,
 )
 from .window_view import WindowView
@@ -37,6 +39,7 @@ def view_window(window_id: str) -> WindowView | None:
         approval_mode=ws.approval_mode,
         notification_mode=ws.notification_mode,
         batch_mode=ws.batch_mode,
+        tool_call_visibility=ws.tool_call_visibility,
         transcript_path=Path(ws.transcript_path) if ws.transcript_path else None,
         window_name=ws.window_name,
         session_id=ws.session_id,
@@ -69,6 +72,31 @@ def get_batch_mode(window_id: str) -> str:
     state = window_store.window_states.get(window_id)
     mode = state.batch_mode if state else DEFAULT_BATCH_MODE
     return mode if mode in BATCH_MODES else DEFAULT_BATCH_MODE
+
+
+def get_tool_call_visibility(window_id: str) -> str:
+    """Get raw per-window tool-call visibility (default/shown/hidden)."""
+    state = window_store.window_states.get(window_id)
+    mode = state.tool_call_visibility if state else DEFAULT_TOOL_CALL_VISIBILITY
+    return mode if mode in TOOL_CALL_VISIBILITY_MODES else DEFAULT_TOOL_CALL_VISIBILITY
+
+
+def is_tool_calls_hidden(window_id: str) -> bool:
+    """Resolved boolean: should tool_use/tool_result be suppressed for this window?
+
+    Composes the per-window override with the global ``config.hide_tool_calls``
+    default. Per-window ``shown``/``hidden`` always wins; ``default`` falls
+    through to the global setting.
+    """
+    visibility = get_tool_call_visibility(window_id)
+    if visibility == "hidden":
+        return True
+    if visibility == "shown":
+        return False
+    # visibility == "default" — fall through to global config
+    from .config import config
+
+    return config.hide_tool_calls
 
 
 def get_session_id_for_window(window_id: str) -> str | None:

--- a/src/ccgram/window_state_store.py
+++ b/src/ccgram/window_state_store.py
@@ -29,6 +29,9 @@ DEFAULT_BATCH_MODE = "batched"
 
 NOTIFICATION_MODES: tuple[str, ...] = ("all", "errors_only", "muted")
 
+TOOL_CALL_VISIBILITY_MODES: tuple[str, ...] = ("default", "shown", "hidden")
+DEFAULT_TOOL_CALL_VISIBILITY: str = "default"
+
 WINDOW_ORIGINS: frozenset[str] = frozenset(
     {"manual_discovered", "ccgram_created", "external"}
 )
@@ -112,6 +115,7 @@ class WindowState:
         provider_name: Name of the agent provider for this window
         approval_mode: "normal" | "yolo"
         batch_mode: "batched" | "verbose"
+        tool_call_visibility: "default" | "shown" | "hidden"
         external: True for windows owned by external tools (emdash) — never killed by ccgram
         origin: Lifecycle origin. Manual/external windows are never auto-killed by ccgram.
         panes: Per-pane runtime state, keyed by tmux pane id (e.g. ``%5``).
@@ -127,6 +131,7 @@ class WindowState:
     provider_name: str = ""
     approval_mode: str = DEFAULT_APPROVAL_MODE
     batch_mode: str = DEFAULT_BATCH_MODE
+    tool_call_visibility: str = DEFAULT_TOOL_CALL_VISIBILITY
     external: bool = False
     origin: str = DEFAULT_WINDOW_ORIGIN
     panes: dict[str, PaneInfo] = field(default_factory=dict)
@@ -149,6 +154,8 @@ class WindowState:
             d["approval_mode"] = self.approval_mode
         if self.batch_mode != DEFAULT_BATCH_MODE:
             d["batch_mode"] = self.batch_mode
+        if self.tool_call_visibility != DEFAULT_TOOL_CALL_VISIBILITY:
+            d["tool_call_visibility"] = self.tool_call_visibility
         if self.external:
             d["external"] = True
         if self.origin != DEFAULT_WINDOW_ORIGIN:
@@ -180,6 +187,9 @@ class WindowState:
             provider_name=data.get("provider_name", ""),
             approval_mode=data.get("approval_mode", DEFAULT_APPROVAL_MODE),
             batch_mode=data.get("batch_mode", DEFAULT_BATCH_MODE),
+            tool_call_visibility=data.get(
+                "tool_call_visibility", DEFAULT_TOOL_CALL_VISIBILITY
+            ),
             external=data.get("external", False),
             origin=(
                 data.get("origin", DEFAULT_WINDOW_ORIGIN)
@@ -497,6 +507,35 @@ class WindowStateStore:
         current = self.get_batch_mode(window_id)
         new_mode = "verbose" if current == "batched" else "batched"
         self.set_batch_mode(window_id, new_mode)
+        return new_mode
+
+    # ------------------------------------------------------------------
+    # Tool-call visibility
+    # ------------------------------------------------------------------
+
+    _TOOL_CALL_VISIBILITY_MODES = TOOL_CALL_VISIBILITY_MODES
+
+    def get_tool_call_visibility(self, window_id: str) -> str:
+        """Get tool-call visibility for a window (default: 'default')."""
+        state = self.window_states.get(window_id)
+        return state.tool_call_visibility if state else DEFAULT_TOOL_CALL_VISIBILITY
+
+    def set_tool_call_visibility(self, window_id: str, mode: str) -> None:
+        """Set tool-call visibility for a window."""
+        if mode not in self._TOOL_CALL_VISIBILITY_MODES:
+            raise ValueError(f"Invalid tool_call_visibility: {mode!r}")
+        state = self.get_window_state(window_id)
+        if state.tool_call_visibility != mode:
+            state.tool_call_visibility = mode
+            self._schedule_save()
+
+    def cycle_tool_call_visibility(self, window_id: str) -> str:
+        """Cycle tool-call visibility: default → shown → hidden → default. Returns new mode."""
+        current = self.get_tool_call_visibility(window_id)
+        modes = self._TOOL_CALL_VISIBILITY_MODES
+        idx = modes.index(current) if current in modes else 0
+        new_mode = modes[(idx + 1) % len(modes)]
+        self.set_tool_call_visibility(window_id, new_mode)
         return new_mode
 
     # ------------------------------------------------------------------

--- a/src/ccgram/window_view.py
+++ b/src/ccgram/window_view.py
@@ -27,6 +27,7 @@ class WindowView:
     approval_mode: str
     notification_mode: str
     batch_mode: str
+    tool_call_visibility: str
     transcript_path: Path | None
     window_name: str
     session_id: str

--- a/tests/ccgram/handlers/test_message_queue.py
+++ b/tests/ccgram/handlers/test_message_queue.py
@@ -11,6 +11,7 @@ from ccgram.handlers.message_queue import (
     _can_merge_tasks,
     _coalesce_status_updates,
     _dispatch,
+    _handle_content_task,
     _merge_content_tasks,
     get_or_create_queue,
     shutdown_workers,
@@ -375,3 +376,122 @@ class TestMessageQueueWorker:
 
         assert worker.done()
         assert not worker.exception() if not worker.cancelled() else True
+
+
+class TestToolCallsGate:
+    @patch(
+        "ccgram.handlers.message_queue._process_content_task", new_callable=AsyncMock
+    )
+    @patch("ccgram.handlers.message_queue.process_tool_event", new_callable=AsyncMock)
+    @patch("ccgram.handlers.message_queue.flush_if_active", new_callable=AsyncMock)
+    @patch("ccgram.handlers.message_queue.is_batch_eligible", return_value=True)
+    @patch("ccgram.window_query.is_tool_calls_hidden", return_value=True)
+    async def test_hidden_suppresses_tool_use(
+        self,
+        mock_hidden,
+        mock_eligible,
+        mock_flush,
+        mock_tool_event,
+        mock_process,
+        bot,
+        queue,
+        lock,
+    ):
+        ct = _content_task("tool", content_type="tool_use")
+        extra = await _handle_content_task(bot, 1, ct, queue, lock)
+        assert extra == 0
+        mock_tool_event.assert_not_awaited()
+        mock_process.assert_not_awaited()
+        mock_flush.assert_not_awaited()
+
+    @patch(
+        "ccgram.handlers.message_queue._process_content_task", new_callable=AsyncMock
+    )
+    @patch("ccgram.handlers.message_queue.process_tool_event", new_callable=AsyncMock)
+    @patch("ccgram.handlers.message_queue.flush_if_active", new_callable=AsyncMock)
+    @patch("ccgram.handlers.message_queue.is_batch_eligible", return_value=True)
+    @patch("ccgram.window_query.is_tool_calls_hidden", return_value=True)
+    async def test_hidden_suppresses_tool_result(
+        self,
+        mock_hidden,
+        mock_eligible,
+        mock_flush,
+        mock_tool_event,
+        mock_process,
+        bot,
+        queue,
+        lock,
+    ):
+        ct = _content_task("res", content_type="tool_result", tool_use_id="t1")
+        extra = await _handle_content_task(bot, 1, ct, queue, lock)
+        assert extra == 0
+        mock_tool_event.assert_not_awaited()
+        mock_process.assert_not_awaited()
+
+    @patch(
+        "ccgram.handlers.message_queue._process_content_task", new_callable=AsyncMock
+    )
+    @patch("ccgram.handlers.message_queue.process_tool_event", new_callable=AsyncMock)
+    @patch("ccgram.handlers.message_queue.is_batch_eligible", return_value=True)
+    @patch("ccgram.window_query.is_tool_calls_hidden", return_value=False)
+    async def test_shown_allows_tool_use(
+        self,
+        mock_hidden,
+        mock_eligible,
+        mock_tool_event,
+        mock_process,
+        bot,
+        queue,
+        lock,
+    ):
+        ct = _content_task("tool", content_type="tool_use")
+        mock_tool_event.return_value = None
+        extra = await _handle_content_task(bot, 1, ct, queue, lock)
+        assert extra == 0
+        mock_tool_event.assert_awaited_once_with(bot, 1, ct)
+
+    @patch(
+        "ccgram.handlers.message_queue._process_content_task", new_callable=AsyncMock
+    )
+    @patch("ccgram.handlers.message_queue.flush_if_active", new_callable=AsyncMock)
+    @patch("ccgram.handlers.message_queue.is_batch_eligible", return_value=False)
+    @patch("ccgram.window_query.is_tool_calls_hidden", return_value=True)
+    async def test_text_unaffected_when_hidden(
+        self,
+        mock_hidden,
+        mock_eligible,
+        mock_flush,
+        mock_process,
+        bot,
+        queue,
+        lock,
+    ):
+        ct = _content_task("hello", content_type="text")
+        extra = await _handle_content_task(bot, 1, ct, queue, lock)
+        assert extra == 0
+        mock_flush.assert_awaited_once_with(bot, 1, ct)
+        mock_process.assert_awaited_once()
+
+    @patch("ccgram.handlers.message_queue._tool_msg_ids", {})
+    @patch(
+        "ccgram.handlers.message_queue._process_content_task", new_callable=AsyncMock
+    )
+    @patch("ccgram.handlers.message_queue.process_tool_event", new_callable=AsyncMock)
+    @patch("ccgram.handlers.message_queue.is_batch_eligible", return_value=True)
+    @patch("ccgram.window_query.is_tool_calls_hidden", return_value=True)
+    async def test_hidden_does_not_register_tool_msg_ids(
+        self,
+        mock_hidden,
+        mock_eligible,
+        mock_tool_event,
+        mock_process,
+        bot,
+        queue,
+        lock,
+    ):
+        from ccgram.handlers import message_queue as mq
+
+        mq._tool_msg_ids.clear()
+        ct = _content_task("tool", content_type="tool_use", tool_use_id="t-xyz")
+        await _handle_content_task(bot, 1, ct, queue, lock)
+        assert not mq._tool_msg_ids

--- a/tests/ccgram/handlers/test_message_queue.py
+++ b/tests/ccgram/handlers/test_message_queue.py
@@ -385,7 +385,7 @@ class TestToolCallsGate:
     @patch("ccgram.handlers.message_queue.process_tool_event", new_callable=AsyncMock)
     @patch("ccgram.handlers.message_queue.flush_if_active", new_callable=AsyncMock)
     @patch("ccgram.handlers.message_queue.is_batch_eligible", return_value=True)
-    @patch("ccgram.window_query.is_tool_calls_hidden", return_value=True)
+    @patch("ccgram.handlers.message_queue.is_tool_calls_hidden", return_value=True)
     async def test_hidden_suppresses_tool_use(
         self,
         mock_hidden,
@@ -410,7 +410,7 @@ class TestToolCallsGate:
     @patch("ccgram.handlers.message_queue.process_tool_event", new_callable=AsyncMock)
     @patch("ccgram.handlers.message_queue.flush_if_active", new_callable=AsyncMock)
     @patch("ccgram.handlers.message_queue.is_batch_eligible", return_value=True)
-    @patch("ccgram.window_query.is_tool_calls_hidden", return_value=True)
+    @patch("ccgram.handlers.message_queue.is_tool_calls_hidden", return_value=True)
     async def test_hidden_suppresses_tool_result(
         self,
         mock_hidden,
@@ -433,7 +433,7 @@ class TestToolCallsGate:
     )
     @patch("ccgram.handlers.message_queue.process_tool_event", new_callable=AsyncMock)
     @patch("ccgram.handlers.message_queue.is_batch_eligible", return_value=True)
-    @patch("ccgram.window_query.is_tool_calls_hidden", return_value=False)
+    @patch("ccgram.handlers.message_queue.is_tool_calls_hidden", return_value=False)
     async def test_shown_allows_tool_use(
         self,
         mock_hidden,
@@ -455,7 +455,7 @@ class TestToolCallsGate:
     )
     @patch("ccgram.handlers.message_queue.flush_if_active", new_callable=AsyncMock)
     @patch("ccgram.handlers.message_queue.is_batch_eligible", return_value=False)
-    @patch("ccgram.window_query.is_tool_calls_hidden", return_value=True)
+    @patch("ccgram.handlers.message_queue.is_tool_calls_hidden", return_value=True)
     async def test_text_unaffected_when_hidden(
         self,
         mock_hidden,
@@ -478,7 +478,7 @@ class TestToolCallsGate:
     )
     @patch("ccgram.handlers.message_queue.process_tool_event", new_callable=AsyncMock)
     @patch("ccgram.handlers.message_queue.is_batch_eligible", return_value=True)
-    @patch("ccgram.window_query.is_tool_calls_hidden", return_value=True)
+    @patch("ccgram.handlers.message_queue.is_tool_calls_hidden", return_value=True)
     async def test_hidden_does_not_register_tool_msg_ids(
         self,
         mock_hidden,

--- a/tests/ccgram/handlers/test_topic_lifecycle.py
+++ b/tests/ccgram/handlers/test_topic_lifecycle.py
@@ -77,6 +77,7 @@ def _window_view(origin: str) -> WindowView:
         approval_mode="normal",
         notification_mode="all",
         batch_mode="batched",
+        tool_call_visibility="default",
         transcript_path=None,
         window_name="test",
         session_id="s1",

--- a/tests/ccgram/test_config.py
+++ b/tests/ccgram/test_config.py
@@ -122,6 +122,26 @@ class TestShowHiddenDirs:
 
 
 @pytest.mark.usefixtures("_base_env")
+class TestHideToolCalls:
+    def test_hide_tool_calls_default_false(self, monkeypatch):
+        monkeypatch.delenv("CCGRAM_HIDE_TOOL_CALLS", raising=False)
+        cfg = Config()
+        assert cfg.hide_tool_calls is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "True", "YES", "Yes"])
+    def test_hide_tool_calls_enabled(self, monkeypatch, value):
+        monkeypatch.setenv("CCGRAM_HIDE_TOOL_CALLS", value)
+        cfg = Config()
+        assert cfg.hide_tool_calls is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off"])
+    def test_hide_tool_calls_disabled(self, monkeypatch, value):
+        monkeypatch.setenv("CCGRAM_HIDE_TOOL_CALLS", value)
+        cfg = Config()
+        assert cfg.hide_tool_calls is False
+
+
+@pytest.mark.usefixtures("_base_env")
 class TestMessagingConfig:
     def test_msg_auto_spawn_default_false(self):
         cfg = Config()

--- a/tests/ccgram/test_window_query_tool_calls.py
+++ b/tests/ccgram/test_window_query_tool_calls.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from ccgram.window_query import get_tool_call_visibility, is_tool_calls_hidden
+from ccgram.window_state_store import WindowState, window_store
+
+
+@pytest.fixture(autouse=True)
+def _isolate_store():
+    saved = dict(window_store.window_states)
+    window_store.window_states.clear()
+    yield
+    window_store.window_states.clear()
+    window_store.window_states.update(saved)
+
+
+class TestGetToolCallVisibility:
+    def test_no_state_returns_default(self):
+        assert get_tool_call_visibility("@404") == "default"
+
+    @pytest.mark.parametrize("mode", ["default", "shown", "hidden"])
+    def test_returns_stored_mode(self, mode: str):
+        window_store.window_states["@0"] = WindowState(tool_call_visibility=mode)
+        assert get_tool_call_visibility("@0") == mode
+
+    def test_invalid_value_falls_back_to_default(self):
+        window_store.window_states["@0"] = WindowState(tool_call_visibility="garbage")
+        assert get_tool_call_visibility("@0") == "default"
+
+
+class TestIsToolCallsHidden:
+    def test_hidden_overrides_global_false(self):
+        window_store.window_states["@0"] = WindowState(tool_call_visibility="hidden")
+        from ccgram.config import config
+
+        original = config.hide_tool_calls
+        try:
+            config.hide_tool_calls = False
+            assert is_tool_calls_hidden("@0") is True
+        finally:
+            config.hide_tool_calls = original
+
+    def test_hidden_overrides_global_true(self):
+        window_store.window_states["@0"] = WindowState(tool_call_visibility="hidden")
+        from ccgram.config import config
+
+        original = config.hide_tool_calls
+        try:
+            config.hide_tool_calls = True
+            assert is_tool_calls_hidden("@0") is True
+        finally:
+            config.hide_tool_calls = original
+
+    def test_shown_overrides_global_true(self):
+        window_store.window_states["@0"] = WindowState(tool_call_visibility="shown")
+        from ccgram.config import config
+
+        original = config.hide_tool_calls
+        try:
+            config.hide_tool_calls = True
+            assert is_tool_calls_hidden("@0") is False
+        finally:
+            config.hide_tool_calls = original
+
+    def test_shown_overrides_global_false(self):
+        window_store.window_states["@0"] = WindowState(tool_call_visibility="shown")
+        from ccgram.config import config
+
+        original = config.hide_tool_calls
+        try:
+            config.hide_tool_calls = False
+            assert is_tool_calls_hidden("@0") is False
+        finally:
+            config.hide_tool_calls = original
+
+    def test_default_falls_through_to_global_true(self):
+        window_store.window_states["@0"] = WindowState(tool_call_visibility="default")
+        from ccgram.config import config
+
+        original = config.hide_tool_calls
+        try:
+            config.hide_tool_calls = True
+            assert is_tool_calls_hidden("@0") is True
+        finally:
+            config.hide_tool_calls = original
+
+    def test_default_falls_through_to_global_false(self):
+        window_store.window_states["@0"] = WindowState(tool_call_visibility="default")
+        from ccgram.config import config
+
+        original = config.hide_tool_calls
+        try:
+            config.hide_tool_calls = False
+            assert is_tool_calls_hidden("@0") is False
+        finally:
+            config.hide_tool_calls = original
+
+    def test_no_state_falls_through_to_global(self):
+        from ccgram.config import config
+
+        original = config.hide_tool_calls
+        try:
+            config.hide_tool_calls = True
+            assert is_tool_calls_hidden("@missing") is True
+            config.hide_tool_calls = False
+            assert is_tool_calls_hidden("@missing") is False
+        finally:
+            config.hide_tool_calls = original

--- a/tests/ccgram/test_window_state_store.py
+++ b/tests/ccgram/test_window_state_store.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import pytest
 
+from ccgram.session import SessionManager
 from ccgram.window_state_store import (
     DEFAULT_PANE_STATE,
+    DEFAULT_TOOL_CALL_VISIBILITY,
+    TOOL_CALL_VISIBILITY_MODES,
     PaneInfo,
     WindowState,
     WindowStateStore,
+    window_store,
 )
 
 
@@ -506,3 +510,93 @@ class TestPruneStaleWindowStates:
             bound_window_ids=set(),
         )
         assert changed is False
+
+
+@pytest.fixture
+def mgr(monkeypatch) -> SessionManager:
+    monkeypatch.setattr(SessionManager, "_load_state", lambda self: None)
+    monkeypatch.setattr(SessionManager, "_save_state", lambda self: None)
+    window_store.window_states.clear()
+    return SessionManager()
+
+
+class TestToolCallVisibilityConstants:
+    def test_modes_tuple(self):
+        assert TOOL_CALL_VISIBILITY_MODES == ("default", "shown", "hidden")
+
+    def test_default_value(self):
+        assert DEFAULT_TOOL_CALL_VISIBILITY == "default"
+
+
+class TestToolCallVisibilityStore:
+    def test_get_default(self, mgr: SessionManager) -> None:
+        assert mgr.get_tool_call_visibility("@0") == "default"
+
+    def test_get_nonexistent_window(self, mgr: SessionManager) -> None:
+        assert mgr.get_tool_call_visibility("@999") == "default"
+
+    def test_set_valid(self, mgr: SessionManager) -> None:
+        mgr.set_tool_call_visibility("@0", "hidden")
+        assert mgr.get_tool_call_visibility("@0") == "hidden"
+        mgr.set_tool_call_visibility("@0", "shown")
+        assert mgr.get_tool_call_visibility("@0") == "shown"
+        mgr.set_tool_call_visibility("@0", "default")
+        assert mgr.get_tool_call_visibility("@0") == "default"
+
+    def test_set_invalid_raises(self, mgr: SessionManager) -> None:
+        with pytest.raises(ValueError, match="Invalid tool_call_visibility"):
+            mgr.set_tool_call_visibility("@0", "bogus")
+
+    @pytest.mark.parametrize(
+        ("start", "expected"),
+        [
+            ("default", "shown"),
+            ("shown", "hidden"),
+            ("hidden", "default"),
+        ],
+    )
+    def test_cycle(self, mgr: SessionManager, start: str, expected: str) -> None:
+        mgr.set_tool_call_visibility("@0", start)
+        assert mgr.cycle_tool_call_visibility("@0") == expected
+        assert mgr.get_tool_call_visibility("@0") == expected
+
+    def test_cycle_full_circle(self, mgr: SessionManager) -> None:
+        assert mgr.cycle_tool_call_visibility("@1") == "shown"
+        assert mgr.cycle_tool_call_visibility("@1") == "hidden"
+        assert mgr.cycle_tool_call_visibility("@1") == "default"
+
+
+class TestToolCallVisibilitySerialization:
+    @pytest.mark.parametrize(
+        ("mode", "expect_key"),
+        [("default", False), ("shown", True), ("hidden", True)],
+    )
+    def test_to_dict(self, mode: str, expect_key: bool) -> None:
+        ws = WindowState(session_id="s1", cwd="/tmp", tool_call_visibility=mode)
+        d = ws.to_dict()
+        if expect_key:
+            assert d["tool_call_visibility"] == mode
+        else:
+            assert "tool_call_visibility" not in d
+
+    @pytest.mark.parametrize(
+        ("data", "expected"),
+        [
+            ({"session_id": "s1", "cwd": "/tmp"}, "default"),
+            (
+                {"session_id": "s1", "cwd": "/tmp", "tool_call_visibility": "shown"},
+                "shown",
+            ),
+            (
+                {"session_id": "s1", "cwd": "/tmp", "tool_call_visibility": "hidden"},
+                "hidden",
+            ),
+        ],
+    )
+    def test_from_dict(self, data: dict[str, str], expected: str) -> None:
+        assert WindowState.from_dict(data).tool_call_visibility == expected
+
+    @pytest.mark.parametrize("mode", list(TOOL_CALL_VISIBILITY_MODES))
+    def test_roundtrip(self, mode: str) -> None:
+        ws = WindowState(session_id="s1", cwd="/tmp", tool_call_visibility=mode)
+        assert WindowState.from_dict(ws.to_dict()).tool_call_visibility == mode

--- a/tests/ccgram/test_window_view.py
+++ b/tests/ccgram/test_window_view.py
@@ -42,6 +42,7 @@ class TestWindowViewProjection:
             approval_mode="normal",
             notification_mode="all",
             batch_mode="batched",
+            tool_call_visibility="default",
             transcript_path=Path("/tmp/log.jsonl"),
             window_name="",
             session_id="",


### PR DESCRIPTION
Closes #64.

## Summary

- Add env var `CCGRAM_HIDE_TOOL_CALLS` (also `--hide-tool-calls` CLI flag) to set the global default for tool-call message suppression.
- Add `/toolcalls` Telegram slash command cycling per-window through `default → shown → hidden → default`. `"default"` inherits the global config; `"shown"`/`"hidden"` override per-window.
- Gate in `_handle_content_task` suppresses `tool_use` / `tool_result` BEFORE `is_batch_eligible` runs. When hidden, no batch state mutation, no `_tool_msg_ids` registration, no enqueue.
- Hook events (SubagentStart/Stop, TaskCompleted, TeammateIdle, StopFailure) bypass the gate via `enqueue_status_update → StatusUpdateTask` — they continue to flow when tool calls are hidden.
- Default behavior is identical to current; existing users see no change unless they set the env var or use `/toolcalls`.

## Implementation

- New `tool_call_visibility: str = "default"` field on `WindowState`. Constants `TOOL_CALL_VISIBILITY_MODES = ("default", "shown", "hidden")`.
- `get/set/cycle_tool_call_visibility` on `WindowStateStore` mirroring the existing `notification_mode` pattern.
- Sparse serialization: `to_dict()` omits the field when value is `"default"`; `from_dict()` defaults to `"default"` when key absent.
- New `is_tool_calls_hidden(window_id)` resolver in `window_query.py`: lazy-imports `config` to avoid cycles; returns `True`/`False`/falls through to `config.hide_tool_calls`.
- New `toolcalls_command` handler in `bot.py` with response text showing the resolved state.

## Note on ContentType

The gate operates on the narrower `handlers/message_task.ContentType` (`text` | `tool_use` | `tool_result`), not the broader `providers/base.ContentType`. Type narrowing for the literal-tuple check is correct under pyright.

## Test plan

- [x] Unit: 48 new tests covering env var loading (case-insensitive `1`/`true`/`yes`), cycle ordering (`default → shown → hidden → default`), sparse serialization roundtrip, resolver three-branch logic, gate behavior (hidden suppresses tool_use/tool_result, shown allows, text unaffected, no `_tool_msg_ids` registration when hidden).
- [x] `make check`: fmt clean, lint passes, pyright `0 errors, 0 warnings`, 3767 unit tests pass + 30 skipped. Pre-existing `test_tmux_manager.py` integration failures are unrelated to this change (verified via baseline stash).
- [x] Live verify on local daemon: `/toolcalls` cycle works in Telegram (default/shown/hidden response messages render correctly); `CCGRAM_HIDE_TOOL_CALLS=1` in `~/.ccgram/.env` correctly applies as global default after restart; per-window override survives the restart.

## Known UX edge case (documented, not handled)

Mid-flight toggle from `hidden → shown`: a `tool_result` for a previously-suppressed `tool_use` will arrive without its ancestor in `_tool_msg_ids`, so the result sends as a standalone message lacking context. Won't crash, looks orphaned. Requires a `tool_use` mid-batch to actually surface.

## Pattern alignment

Per-window mechanism mirrors the existing `notification_mode` (per-window field, `cycle_*` helper, sparse serialization). The hybrid env-var-default-plus-override is new for ccgram but is a familiar Unix idiom.