### PR TITLE
fix(providers/gemini): support JSONL transcripts and add /status snapshot

### DIFF
--- a/src/ccgram/providers/gemini.py
+++ b/src/ccgram/providers/gemini.py
@@ -9,8 +9,11 @@ Terminal UI: Gemini CLI uses ``@inquirer/select`` for interactive prompts.
 Permission prompts start with "Action Required" and list numbered options
 with a ``●`` (U+25CF) marker on the selected choice.
 
-Transcript format: single JSON file per session (NOT JSONL) with structure:
-  ``{sessionId, projectHash, startTime, lastUpdated, messages: [...]}``
+Transcript format: incremental JSONL files per session with structure:
+  - Header: ``{"sessionId", "projectHash", "startTime", ...}``
+  - Entries: ``{"id", "timestamp", "type", "content": [...]}``
+  - Updates: ``{"$set": {"lastUpdated": "..."}}``
+
 Messages use ``type`` field with values ``"user"`` / ``"gemini"`` and can
 store content as either a string or a list of ``{text: ...}`` fragments.
 """
@@ -21,7 +24,6 @@ import os
 from pathlib import Path
 import re
 import shlex
-import threading
 import time
 import tomllib
 from typing import Any, cast
@@ -144,12 +146,6 @@ GEMINI_UI_PATTERNS: list[UIPattern] = [
 ]
 
 
-# Cache: file_path -> (mtime_ns, size, parsed_messages)
-# Bounded to prevent unbounded growth; oldest entries evicted when full.
-# Lock required: read_transcript_file runs in asyncio.to_thread() workers.
-_TRANSCRIPT_CACHE_MAX = 64
-_transcript_cache: dict[str, tuple[int, int, list[dict[str, Any]]]] = {}
-_transcript_cache_lock = threading.Lock()
 _TRANSCRIPT_MAX_AGE_SECS = 120.0
 _MAX_TOOL_SUMMARY = 200
 _JSON_READ_ERRORS = (OSError, json.JSONDecodeError)
@@ -306,7 +302,8 @@ def _collect_gemini_sessions(chats_dir: Path) -> list[tuple[float, Path]]:
     """Collect Gemini chat transcripts from a chats directory."""
     result: list[tuple[float, Path]] = []
     try:
-        files = sorted(chats_dir.glob("session-*.json"))
+        # Gemini CLI now uses .jsonl for incremental transcripts.
+        files = sorted(chats_dir.glob("session-*.jsonl"))
     except OSError:
         return result
     for fpath in files:
@@ -318,10 +315,16 @@ def _collect_gemini_sessions(chats_dir: Path) -> list[tuple[float, Path]]:
 
 
 def _read_gemini_session_meta(fpath: Path) -> tuple[str, str] | None:
-    """Read (session_id, project_hash) from a Gemini transcript JSON file."""
+    """Read (session_id, project_hash) from a Gemini transcript JSONL file.
+
+    Gemini's JSONL format stores session metadata in the first line.
+    """
     try:
         with open(fpath, encoding="utf-8") as f:
-            data = json.load(f)
+            line = f.readline()
+            if not line:
+                return None
+            data = json.loads(line)
     except _JSON_READ_ERRORS:
         return None
     if not isinstance(data, dict):
@@ -406,10 +409,11 @@ class GeminiProvider(JsonlProvider):
         supports_resume=True,
         supports_continue=True,
         supports_structured_transcript=True,
-        supports_incremental_read=False,
-        transcript_format="plain",
+        supports_incremental_read=True,
+        transcript_format="jsonl",
         uses_pane_title=True,
         builtin_commands=tuple(_GEMINI_BUILTINS.keys()),
+        supports_status_snapshot=True,
     )
 
     _BUILTINS = _GEMINI_BUILTINS
@@ -445,57 +449,6 @@ class GeminiProvider(JsonlProvider):
         return ""
 
     # ── Gemini-specific transcript parsing ────────────────────────────
-
-    def read_transcript_file(
-        self, file_path: str, last_offset: int
-    ) -> tuple[list[dict[str, Any]], int]:
-        """Read Gemini's single-JSON transcript and return new messages.
-
-        Gemini transcripts are a single JSON object with a ``messages`` array,
-        not JSONL. ``last_offset`` tracks the number of messages already seen.
-        Returns (new_message_entries, updated_offset).
-
-        Uses an mtime+size cache to skip re-parsing when the file is unchanged.
-        """
-
-        try:
-            st = os.stat(file_path)
-        except OSError:
-            return [], last_offset
-
-        with _transcript_cache_lock:
-            cached = _transcript_cache.get(file_path)
-        if cached and cached[0] == st.st_mtime_ns and cached[1] == st.st_size:
-            messages = list(cached[2])
-        else:
-            try:
-                with open(file_path, encoding="utf-8") as f:
-                    data = json.load(f)
-            except (json.JSONDecodeError, OSError):  # fmt: skip
-                return [], last_offset
-
-            if not isinstance(data, dict):
-                return [], last_offset
-
-            messages = data.get("messages", [])
-            if not isinstance(messages, list):
-                return [], last_offset
-
-            # Store a copy to prevent mutation of cached data
-            messages = list(messages)
-            with _transcript_cache_lock:
-                if len(_transcript_cache) >= _TRANSCRIPT_CACHE_MAX:
-                    # Evict first-inserted entry
-                    _transcript_cache.pop(next(iter(_transcript_cache)))
-                _transcript_cache[file_path] = (
-                    st.st_mtime_ns,
-                    st.st_size,
-                    messages,
-                )
-
-        new_entries = messages[last_offset:]
-        new_offset = len(messages)
-        return [m for m in new_entries if isinstance(m, dict)], new_offset
 
     def parse_transcript_entries(
         self,
@@ -665,7 +618,7 @@ class GeminiProvider(JsonlProvider):
     ) -> SessionStartEvent | None:
         """Discover latest Gemini transcript matching cwd.
 
-        Gemini stores chats under ``~/.gemini/tmp/<project>/chats/session-*.json``
+        Gemini stores chats under ``~/.gemini/tmp/<project>/chats/session-*.jsonl``
         (project alias) and older versions may use ``<projectHash>`` directory
         names. We match by ``projectHash`` (sha256 of resolved cwd).
         """
@@ -751,3 +704,34 @@ class GeminiProvider(JsonlProvider):
 
         # 5. Ready title or unknown — no status (let activity heuristic handle)
         return None
+
+    def build_status_snapshot(
+        self,
+        transcript_path: str,
+        *,
+        display_name: str,
+        session_id: str = "",
+        cwd: str = "",
+    ) -> str | None:
+        """Build a basic status snapshot for Gemini sessions."""
+        try:
+            size = os.path.getsize(transcript_path)
+        except OSError:
+            return None
+
+        # Show up to 8 chars of ID, but don't truncate if it's already short
+        short_id = session_id[:8] if len(session_id) > 10 else session_id
+
+        return (
+            f"\u2726 [{display_name}] Gemini session active.\n"
+            f"\U0001f4c2 `{cwd}`\n"
+            f"\ud83d\udcc4 `{os.path.basename(transcript_path)}` ({size} bytes)\n"
+            f"\u2b50 ID: `{short_id}`"
+        )
+
+    def has_output_since(self, transcript_path: str, offset: int) -> bool:
+        """Check if any assistant output appeared after *offset*."""
+        try:
+            return os.path.getsize(transcript_path) > offset
+        except OSError:
+            return False

--- a/src/ccgram/providers/gemini.py
+++ b/src/ccgram/providers/gemini.py
@@ -148,6 +148,8 @@ GEMINI_UI_PATTERNS: list[UIPattern] = [
 
 _TRANSCRIPT_MAX_AGE_SECS = 120.0
 _MAX_TOOL_SUMMARY = 200
+_SHORT_SESSION_ID_LEN = 8
+_SHORT_SESSION_ID_THRESHOLD = 10
 _JSON_READ_ERRORS = (OSError, json.JSONDecodeError)
 _TOML_READ_ERRORS = (OSError, tomllib.TOMLDecodeError)
 _GEMINI_SYSTEM_SETTINGS_FILE = "gemini-system-settings.json"
@@ -279,6 +281,62 @@ def _extract_tool_result_text(tool_call: dict[str, Any]) -> str:
             if isinstance(value, str) and value:
                 return value
     return ""
+
+
+def _emit_tool_calls(
+    tool_calls: list[Any],
+    entry: dict[str, Any],
+    pending: dict[str, Any],
+) -> list[AgentMessage]:
+    """Emit tool_use / tool_result messages from a Gemini toolCalls list.
+
+    Skips re-announcing a tool whose id is already in ``pending`` (Gemini
+    re-appends the same message line on every toolCalls update). Emits
+    ``tool_result`` once a result payload becomes available and pops the
+    tool from ``pending``.
+    """
+    out: list[AgentMessage] = []
+    timestamp = entry.get("timestamp")
+    for tc in tool_calls:
+        if not isinstance(tc, dict):
+            continue
+        raw_name = tc.get("displayName") or tc.get("name") or "unknown"
+        tool_name = raw_name if isinstance(raw_name, str) else "unknown"
+        call_id = tc.get("id")
+        tool_use_id = call_id if isinstance(call_id, str) and call_id else None
+        already_announced = bool(tool_use_id) and tool_use_id in pending
+        if tool_use_id:
+            pending[tool_use_id] = tool_name
+        if not already_announced:
+            summary = _summarize_tool_args(tc.get("args"))
+            tool_use_text = (
+                f"**{tool_name}** `{summary}`" if summary else f"**{tool_name}**"
+            )
+            out.append(
+                AgentMessage(
+                    text=tool_use_text,
+                    role="assistant",
+                    content_type="tool_use",
+                    tool_use_id=tool_use_id,
+                    tool_name=tool_name,
+                    timestamp=timestamp,
+                )
+            )
+        result_text = _extract_tool_result_text(tc)
+        if result_text:
+            out.append(
+                AgentMessage(
+                    text=result_text,
+                    role="assistant",
+                    content_type="tool_result",
+                    tool_use_id=tool_use_id,
+                    tool_name=tool_name,
+                    timestamp=timestamp,
+                )
+            )
+            if tool_use_id:
+                pending.pop(tool_use_id, None)
+    return out
 
 
 def _read_project_alias(config_dir: Path, resolved_cwd: str) -> str:
@@ -465,6 +523,12 @@ class GeminiProvider(JsonlProvider):
         """
         messages: list[AgentMessage] = []
         pending = dict(pending_tools)
+        # Gemini's JSONL transcript re-appends the same message id on every
+        # toolCalls update (see chatRecordingService.pushMessage upstream).
+        # Track seen message ids to avoid duplicate text emission; track
+        # tool_use ids in `pending` so we only announce a tool once and emit
+        # tool_result on the update that carries the result payload.
+        seen_msg_ids: set[str] = pending.setdefault("__seen_msg_ids__", set())
 
         for entry in entries:
             msg_type = entry.get("type", "")
@@ -472,54 +536,15 @@ class GeminiProvider(JsonlProvider):
             if not role:
                 continue
 
-            # Gemini tool calls are attached to a gemini turn and may contain
-            # both input args and immediate result payloads.
+            entry_id = entry.get("id")
+            msg_id = entry_id if isinstance(entry_id, str) else ""
+
             tool_calls = entry.get("toolCalls", [])
             if isinstance(tool_calls, list):
-                for tc in tool_calls:
-                    if not isinstance(tc, dict):
-                        continue
-                    raw_name = tc.get("displayName") or tc.get("name") or "unknown"
-                    tool_name = raw_name if isinstance(raw_name, str) else "unknown"
-                    call_id = tc.get("id")
-                    tool_use_id = (
-                        call_id if isinstance(call_id, str) and call_id else None
-                    )
-                    if tool_use_id:
-                        pending[tool_use_id] = tool_name
-                    summary = _summarize_tool_args(tc.get("args"))
-                    tool_use_text = (
-                        f"**{tool_name}** `{summary}`"
-                        if summary
-                        else f"**{tool_name}**"
-                    )
-                    messages.append(
-                        AgentMessage(
-                            text=tool_use_text,
-                            role="assistant",
-                            content_type="tool_use",
-                            tool_use_id=tool_use_id,
-                            tool_name=tool_name,
-                            timestamp=entry.get("timestamp"),
-                        )
-                    )
-                    result_text = _extract_tool_result_text(tc)
-                    if result_text:
-                        messages.append(
-                            AgentMessage(
-                                text=result_text,
-                                role="assistant",
-                                content_type="tool_result",
-                                tool_use_id=tool_use_id,
-                                tool_name=tool_name,
-                                timestamp=entry.get("timestamp"),
-                            )
-                        )
-                        if tool_use_id:
-                            pending.pop(tool_use_id, None)
+                messages.extend(_emit_tool_calls(tool_calls, entry, pending))
 
             text = _entry_text(entry)
-            if text:
+            if text and msg_id not in seen_msg_ids:
                 messages.append(
                     AgentMessage(
                         text=text,
@@ -528,6 +553,9 @@ class GeminiProvider(JsonlProvider):
                         timestamp=entry.get("timestamp"),
                     )
                 )
+
+            if msg_id:
+                seen_msg_ids.add(msg_id)
 
         return messages, pending
 
@@ -709,7 +737,7 @@ class GeminiProvider(JsonlProvider):
         self,
         transcript_path: str,
         *,
-        display_name: str,
+        display_name: str = "",
         session_id: str = "",
         cwd: str = "",
     ) -> str | None:
@@ -719,8 +747,11 @@ class GeminiProvider(JsonlProvider):
         except OSError:
             return None
 
-        # Show up to 8 chars of ID, but don't truncate if it's already short
-        short_id = session_id[:8] if len(session_id) > 10 else session_id
+        short_id = (
+            session_id[:_SHORT_SESSION_ID_LEN]
+            if len(session_id) > _SHORT_SESSION_ID_THRESHOLD
+            else session_id
+        )
 
         return (
             f"\u2726 [{display_name}] Gemini session active.\n"

--- a/tests/ccgram/providers/test_contracts.py
+++ b/tests/ccgram/providers/test_contracts.py
@@ -511,7 +511,7 @@ class TestStatusSnapshot:
 
     def test_supports_status_snapshot_flag(self, provider: AgentProvider) -> None:
         caps = provider.capabilities
-        if caps.name == "codex":
+        if caps.name in ("codex", "gemini"):
             assert caps.supports_status_snapshot is True
         else:
             assert caps.supports_status_snapshot is False

--- a/tests/ccgram/providers/test_jsonl_providers.py
+++ b/tests/ccgram/providers/test_jsonl_providers.py
@@ -913,6 +913,46 @@ class TestGeminiTranscriptParsing:
         assert gemini.is_user_transcript_entry({"type": "user"}) is True
         assert gemini.is_user_transcript_entry({"type": "gemini"}) is False
 
+    def test_dedup_repeated_message_id(self) -> None:
+        # Gemini's JSONL transcript re-appends the same message line on every
+        # toolCalls update. The parser must dedup by id across calls.
+        gemini = GeminiProvider()
+        first = [
+            {
+                "id": "msg-1",
+                "type": "gemini",
+                "content": "checking the file",
+                "toolCalls": [
+                    {"id": "tc-1", "name": "read_file", "args": {"path": "x"}}
+                ],
+            }
+        ]
+        msgs1, pending = gemini.parse_transcript_entries(first, {})
+        # First emission: text once + tool_use once, no result yet.
+        assert [m.content_type for m in msgs1] == ["tool_use", "text"]
+        assert "tc-1" in pending
+
+        # Same message id re-appended with the result attached.
+        second = [
+            {
+                "id": "msg-1",
+                "type": "gemini",
+                "content": "checking the file",
+                "toolCalls": [
+                    {
+                        "id": "tc-1",
+                        "name": "read_file",
+                        "args": {"path": "x"},
+                        "resultDisplay": "ok",
+                    }
+                ],
+            }
+        ]
+        msgs2, pending = gemini.parse_transcript_entries(second, pending)
+        # Second emission: only tool_result. No duplicate text or tool_use.
+        assert [m.content_type for m in msgs2] == ["tool_result"]
+        assert "tc-1" not in pending
+
 
 class TestGeminiTerminalStatus:
     SHELL_PERMISSION_PANE = (
@@ -1180,153 +1220,6 @@ class TestExtractContentBlocks:
         assert result == {"t1": "Read"}
 
 
-_SAMPLE_GEMINI_TRANSCRIPT: dict = {
-    "sessionId": "gemini-sess-1",
-    "projectHash": "abc123",
-    "startTime": "2026-01-01T00:00:00Z",
-    "lastUpdated": "2026-01-01T00:05:00Z",
-    "messages": [
-        {"type": "user", "content": "hello gemini"},
-        {"type": "gemini", "content": "hi there!"},
-        {"type": "user", "content": "what is 2+2?"},
-        {"type": "gemini", "content": "4"},
-    ],
-}
-
-
-class TestGeminiReadTranscriptFile:
-    def test_reads_all_messages_from_zero(self, tmp_path) -> None:
-        f = tmp_path / "transcript.json"
-        f.write_text(json.dumps(_SAMPLE_GEMINI_TRANSCRIPT))
-        gemini = GeminiProvider()
-        entries, offset = gemini.read_transcript_file(str(f), 0)
-        assert len(entries) == 4
-        assert offset == 4
-        assert entries[0]["content"] == "hello gemini"
-        assert entries[3]["content"] == "4"
-
-    def test_returns_only_new_messages(self, tmp_path) -> None:
-        f = tmp_path / "transcript.json"
-        f.write_text(json.dumps(_SAMPLE_GEMINI_TRANSCRIPT))
-        gemini = GeminiProvider()
-        entries, offset = gemini.read_transcript_file(str(f), 2)
-        assert len(entries) == 2
-        assert offset == 4
-        assert entries[0]["content"] == "what is 2+2?"
-
-    def test_no_new_messages_when_offset_at_end(self, tmp_path) -> None:
-        f = tmp_path / "transcript.json"
-        f.write_text(json.dumps(_SAMPLE_GEMINI_TRANSCRIPT))
-        gemini = GeminiProvider()
-        entries, offset = gemini.read_transcript_file(str(f), 4)
-        assert entries == []
-        assert offset == 4
-
-    def test_detects_new_messages_after_file_update(self, tmp_path) -> None:
-        f = tmp_path / "transcript.json"
-        data = dict(_SAMPLE_GEMINI_TRANSCRIPT)
-        data["messages"] = list(data["messages"][:2])
-        f.write_text(json.dumps(data))
-        gemini = GeminiProvider()
-
-        entries, offset = gemini.read_transcript_file(str(f), 0)
-        assert len(entries) == 2
-        assert offset == 2
-
-        data["messages"] = list(_SAMPLE_GEMINI_TRANSCRIPT["messages"])
-        f.write_text(json.dumps(data))
-
-        entries, offset = gemini.read_transcript_file(str(f), 2)
-        assert len(entries) == 2
-        assert offset == 4
-
-    def test_handles_invalid_json(self, tmp_path) -> None:
-        f = tmp_path / "transcript.json"
-        f.write_text("{not valid json")
-        gemini = GeminiProvider()
-        entries, offset = gemini.read_transcript_file(str(f), 0)
-        assert entries == []
-        assert offset == 0
-
-    def test_handles_missing_file(self, tmp_path) -> None:
-        gemini = GeminiProvider()
-        entries, offset = gemini.read_transcript_file(
-            str(tmp_path / "nonexistent.json"), 0
-        )
-        assert entries == []
-        assert offset == 0
-
-    def test_handles_no_messages_key(self, tmp_path) -> None:
-        f = tmp_path / "transcript.json"
-        f.write_text(json.dumps({"sessionId": "s1"}))
-        gemini = GeminiProvider()
-        entries, offset = gemini.read_transcript_file(str(f), 0)
-        assert entries == []
-        assert offset == 0
-
-    def test_handles_non_dict_messages(self, tmp_path) -> None:
-        f = tmp_path / "transcript.json"
-        data = dict(_SAMPLE_GEMINI_TRANSCRIPT)
-        data["messages"] = [{"type": "user", "content": "ok"}, "not a dict", 42]
-        f.write_text(json.dumps(data))
-        gemini = GeminiProvider()
-        entries, offset = gemini.read_transcript_file(str(f), 0)
-        assert len(entries) == 1
-        assert offset == 3
-
-    def test_handles_non_dict_root(self, tmp_path) -> None:
-        f = tmp_path / "transcript.json"
-        f.write_text(json.dumps([1, 2, 3]))
-        gemini = GeminiProvider()
-        entries, offset = gemini.read_transcript_file(str(f), 0)
-        assert entries == []
-        assert offset == 0
-
-
-class TestGeminiMtimeCache:
-    @pytest.fixture(autouse=True)
-    def _clear_cache(self):
-        from ccgram.providers.gemini import _transcript_cache
-
-        _transcript_cache.clear()
-        yield
-        _transcript_cache.clear()
-
-    def test_cache_hit_skips_reparse(self, tmp_path) -> None:
-        f = tmp_path / "transcript.json"
-        f.write_text(json.dumps(_SAMPLE_GEMINI_TRANSCRIPT))
-        gemini = GeminiProvider()
-
-        entries1, _ = gemini.read_transcript_file(str(f), 0)
-        assert len(entries1) == 4
-
-        with patch(
-            "ccgram.providers.gemini.json.load",
-            side_effect=AssertionError("should not be called"),
-        ):
-            entries2, offset2 = gemini.read_transcript_file(str(f), 0)
-        assert len(entries2) == 4
-        assert offset2 == 4
-
-    def test_cache_invalidated_on_file_change(self, tmp_path) -> None:
-        f = tmp_path / "transcript.json"
-        data = dict(_SAMPLE_GEMINI_TRANSCRIPT)
-        data["messages"] = list(data["messages"][:2])
-        f.write_text(json.dumps(data))
-        gemini = GeminiProvider()
-
-        entries1, offset1 = gemini.read_transcript_file(str(f), 0)
-        assert len(entries1) == 2
-        assert offset1 == 2
-
-        data["messages"] = list(_SAMPLE_GEMINI_TRANSCRIPT["messages"])
-        f.write_text(json.dumps(data))
-
-        entries2, offset2 = gemini.read_transcript_file(str(f), 2)
-        assert len(entries2) == 2
-        assert offset2 == 4
-
-
 def _write_gemini_session(
     tmp_dir: Path,
     project_dir: str,
@@ -1336,15 +1229,14 @@ def _write_gemini_session(
 ) -> Path:
     chats_dir = tmp_dir / ".gemini" / "tmp" / project_key / "chats"
     chats_dir.mkdir(parents=True, exist_ok=True)
-    fpath = chats_dir / f"{session_name}.json"
-    payload = {
+    fpath = chats_dir / f"{session_name}.jsonl"
+    header = {
         "sessionId": session_id,
         "projectHash": hashlib.sha256(project_dir.encode()).hexdigest(),
         "startTime": "2026-03-01T00:00:00.000Z",
         "lastUpdated": "2026-03-01T00:00:00.000Z",
-        "messages": [],
     }
-    fpath.write_text(json.dumps(payload))
+    fpath.write_text(json.dumps(header) + "\n")
     return fpath
 
 
@@ -1685,9 +1577,10 @@ class TestDiscoverTranscriptContract:
 
 
 class TestGeminiCapabilityFlag:
-    def test_gemini_does_not_support_incremental_read(self) -> None:
+    def test_gemini_supports_incremental_read(self) -> None:
         gemini = GeminiProvider()
-        assert gemini.capabilities.supports_incremental_read is False
+        assert gemini.capabilities.supports_incremental_read is True
+        assert gemini.capabilities.transcript_format == "jsonl"
 
     def test_codex_supports_incremental_read(self) -> None:
         codex = CodexProvider()

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -773,21 +773,28 @@ class TestScanProjects:
         assert result == []
 
 
-class TestWholeFileTranscriptReading:
-    """Test _read_new_lines delegation for providers with supports_incremental_read=False."""
+class TestGeminiTranscriptReading:
+    """Test _read_new_lines delegation for Gemini with supports_incremental_read=True."""
 
-    _GEMINI_TRANSCRIPT = {
+    _GEMINI_META = {
         "sessionId": "g1",
-        "messages": [
-            {"type": "user", "content": "hello"},
-            {"type": "gemini", "content": "hi there"},
-            {"type": "user", "content": "thanks"},
-        ],
+        "projectHash": "h1",
     }
+    _GEMINI_MESSAGES = [
+        {"type": "user", "content": [{"text": "hello"}]},
+        {"type": "gemini", "content": [{"text": "hi there"}]},
+        {"type": "user", "content": [{"text": "thanks"}]},
+    ]
 
-    async def test_gemini_reads_whole_file(self, tmp_path) -> None:
-        transcript = tmp_path / "transcript.json"
-        transcript.write_text(json.dumps(self._GEMINI_TRANSCRIPT))
+    def _write_jsonl(self, path, meta, messages):
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(json.dumps(meta) + "\n")
+            for msg in messages:
+                f.write(json.dumps(msg) + "\n")
+
+    async def test_gemini_reads_jsonl_incrementally(self, tmp_path) -> None:
+        transcript = tmp_path / "transcript.jsonl"
+        self._write_jsonl(transcript, self._GEMINI_META, self._GEMINI_MESSAGES)
 
         monitor = SessionMonitor(
             projects_path=tmp_path / "projects",
@@ -803,54 +810,45 @@ class TestWholeFileTranscriptReading:
             "ccgram.transcript_reader.get_provider_for_window",
             return_value=_make_gemini_provider(),
         ):
+            # First read: gets everything
             entries = await monitor._read_new_lines(tracked, transcript, window_id="@5")
+            assert len(entries) == 4  # meta + 3 messages
+            assert entries[0]["sessionId"] == "g1"
+            assert entries[1]["type"] == "user"
 
-        assert len(entries) == 3
-        assert tracked.last_byte_offset == 3
-
-    async def test_gemini_incremental_after_update(self, tmp_path) -> None:
-        transcript = tmp_path / "transcript.json"
-        data = dict(self._GEMINI_TRANSCRIPT)
-        data["messages"] = list(data["messages"][:2])
-        transcript.write_text(json.dumps(data))
-
-        monitor = SessionMonitor(
-            projects_path=tmp_path / "projects",
-            state_file=tmp_path / "ms.json",
-        )
-        tracked = TrackedSession(
-            session_id="g1",
-            file_path=str(transcript),
-            last_byte_offset=2,
-        )
-
-        data["messages"] = list(self._GEMINI_TRANSCRIPT["messages"])
-        transcript.write_text(json.dumps(data))
-
-        with patch(
-            "ccgram.transcript_reader.get_provider_for_window",
-            return_value=_make_gemini_provider(),
-        ):
+            # Second read: nothing new
             entries = await monitor._read_new_lines(tracked, transcript, window_id="@5")
+            assert len(entries) == 0
 
-        assert len(entries) == 1
-        assert entries[0]["content"] == "thanks"
-        assert tracked.last_byte_offset == 3
+            # Third read: append a message
+            with open(transcript, "a", encoding="utf-8") as f:
+                f.write(json.dumps({"type": "gemini", "content": [{"text": "bye"}]}) + "\n")
+
+            entries = await monitor._read_new_lines(tracked, transcript, window_id="@5")
+            assert len(entries) == 1
+            assert entries[0]["type"] == "gemini"
 
     async def test_gemini_end_to_end_process_session(self, tmp_path) -> None:
-        transcript = tmp_path / "transcript.json"
-        transcript.write_text(json.dumps(self._GEMINI_TRANSCRIPT))
+        transcript = tmp_path / "transcript.jsonl"
+        self._write_jsonl(transcript, self._GEMINI_META, self._GEMINI_MESSAGES)
 
         monitor = SessionMonitor(
             projects_path=tmp_path / "projects",
             state_file=tmp_path / "ms.json",
         )
+        # We start tracking with offset pointing at the end of the file
+        # (simulating a session that was already active at startup)
+        st = transcript.stat()
         tracked = TrackedSession(
             session_id="g1",
             file_path=str(transcript),
-            last_byte_offset=0,
+            last_byte_offset=st.st_size,
         )
         monitor.state.update_session(tracked)
+
+        # Append new message
+        with open(transcript, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"type": "gemini", "content": [{"text": "new!"}]}) + "\n")
 
         new_messages: list = []
         with patch(
@@ -861,9 +859,9 @@ class TestWholeFileTranscriptReading:
                 "g1", transcript, new_messages, window_id="@5"
             )
 
-        assert len(new_messages) == 3
-        assert new_messages[0].text == "hello"
-        assert new_messages[1].text == "hi there"
+        assert len(new_messages) == 1
+        assert new_messages[0].text == "new!"
+        assert new_messages[0].role == "assistant"
 
 
 def _make_gemini_provider():

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -822,7 +822,9 @@ class TestGeminiTranscriptReading:
 
             # Third read: append a message
             with open(transcript, "a", encoding="utf-8") as f:
-                f.write(json.dumps({"type": "gemini", "content": [{"text": "bye"}]}) + "\n")
+                f.write(
+                    json.dumps({"type": "gemini", "content": [{"text": "bye"}]}) + "\n"
+                )
 
             entries = await monitor._read_new_lines(tracked, transcript, window_id="@5")
             assert len(entries) == 1
@@ -848,7 +850,9 @@ class TestGeminiTranscriptReading:
 
         # Append new message
         with open(transcript, "a", encoding="utf-8") as f:
-            f.write(json.dumps({"type": "gemini", "content": [{"text": "new!"}]}) + "\n")
+            f.write(
+                json.dumps({"type": "gemini", "content": [{"text": "new!"}]}) + "\n"
+            )
 
         new_messages: list = []
         with patch(


### PR DESCRIPTION
This PR adapts the Gemini provider to the new JSONL transcript format used by Gemini CLI. It also adds support for the /status command (snapshot) for Gemini sessions. Tests have been updated to reflect the new JSONL incremental reading behavior.