### PR TITLE
feat(config): configurable topic emoji color scheme

### DIFF
--- a/src/ccgram/cli.py
+++ b/src/ccgram/cli.py
@@ -71,6 +71,7 @@ _FLAG_TO_ENV: list[tuple[str, str]] = [
     ("whisper_provider", "CCGRAM_WHISPER_PROVIDER"),
     ("ack_reaction", "CCGRAM_ACK_REACTION"),
     ("hide_tool_calls", "CCGRAM_HIDE_TOOL_CALLS"),
+    ("status_mode", "CCGRAM_STATUS_MODE"),
 ]
 
 
@@ -200,6 +201,13 @@ def apply_args_to_env(**kwargs: object) -> None:
     default=None,
     envvar="CCGRAM_HIDE_TOOL_CALLS",
     help="Hide tool_use/tool_result messages globally (per-window override via /toolcalls).",
+)
+@click.option(
+    "--status-mode",
+    type=click.Choice(["system", "user"], case_sensitive=False),
+    default=None,
+    envvar="CCGRAM_STATUS_MODE",
+    help="Topic emoji color scheme: 'system' (green=active) or 'user' (green=ready for me).",
 )
 def run_cmd(**kwargs: object) -> None:
     """Start the bot with optional overrides."""

--- a/src/ccgram/config.py
+++ b/src/ccgram/config.py
@@ -185,6 +185,15 @@ class Config:
             "CCGRAM_HIDE_TOOL_CALLS", ""
         ).lower() in ("1", "true", "yes")
 
+        # Color mapping for the topic state emoji prefix.
+        # "system" (default): green=active, yellow=idle (system POV: green=working).
+        # "user": green=idle, yellow=active (user POV: green=ready for me).
+        # Invalid values fall back to "system".
+        raw_status_mode = os.getenv("CCGRAM_STATUS_MODE", "").strip().lower()
+        self.status_mode: str = (
+            raw_status_mode if raw_status_mode in ("system", "user") else "system"
+        )
+
         logger.debug(
             "Config initialized: dir=%s, token=%s..., allowed_users=%d, "
             "tmux_session=%s",

--- a/src/ccgram/handlers/topic_emoji.py
+++ b/src/ccgram/handlers/topic_emoji.py
@@ -25,10 +25,13 @@ from ..topic_state_registry import topic_state
 
 logger = structlog.get_logger()
 
-# Emoji prefixes for session states
-EMOJI_ACTIVE = "\U0001f7e2"  # Green circle
-EMOJI_IDLE = "\U0001f7e1"  # Yellow circle (your turn / attention needed)
-EMOJI_DONE = "\u2705"  # Check mark (Claude exited normally)
+# Color circles used for the active/idle state prefix.
+# Which color maps to which state depends on ``config.status_mode`` (see
+# ``_state_emoji_map``). The constants are color-named (not state-named) so
+# that ``strip_emoji_prefix`` and tests work regardless of mode.
+EMOJI_GREEN_CIRCLE = "\U0001f7e2"
+EMOJI_YELLOW_CIRCLE = "\U0001f7e1"
+EMOJI_DONE = "\u2705"  # Check mark (agent exited normally)
 EMOJI_DEAD = "\U0001f4a5"  # Collision / crash
 EMOJI_YOLO = "\U0001f3b2"  # Dice (risk/gamble — auto-approve mode)
 EMOJI_RC = "\U0001f4e1"  # Satellite dish (Remote Control active)
@@ -36,6 +39,34 @@ _EMOJI_DEAD_OLD = (
     "\u26ab",
     "\u274c",
 )  # Legacy dead emoji (black circle pre-2026-02, cross mark pre-2026-03)
+
+# Backward-compatible aliases — original (system-mode) defaults.
+EMOJI_ACTIVE = EMOJI_GREEN_CIRCLE
+EMOJI_IDLE = EMOJI_YELLOW_CIRCLE
+
+# State → emoji mapping.
+#   system mode (default): green=active (working), yellow=idle (paused).
+#   user mode:             green=idle (waiting for me), yellow=active (busy).
+_STATE_EMOJI_SYSTEM: dict[str, str] = {
+    "active": EMOJI_GREEN_CIRCLE,
+    "idle": EMOJI_YELLOW_CIRCLE,
+    "done": EMOJI_DONE,
+    "dead": EMOJI_DEAD,
+}
+_STATE_EMOJI_USER: dict[str, str] = {
+    "active": EMOJI_YELLOW_CIRCLE,
+    "idle": EMOJI_GREEN_CIRCLE,
+    "done": EMOJI_DONE,
+    "dead": EMOJI_DEAD,
+}
+
+
+def _state_emoji_map() -> dict[str, str]:
+    """Return the active state→emoji table for the configured status mode."""
+    from ..config import config
+
+    return _STATE_EMOJI_USER if config.status_mode == "user" else _STATE_EMOJI_SYSTEM
+
 
 # Debounce: state must be stable for this many seconds before updating topic name.
 # Prevents rapid active↔idle toggling from flooding chat with rename messages.
@@ -123,12 +154,7 @@ def _compose_topic_name(
 ) -> str:
     """Build the full Telegram topic title from state badges and clean name."""
     parts: list[str] = []
-    emoji = {
-        "active": EMOJI_ACTIVE,
-        "idle": EMOJI_IDLE,
-        "done": EMOJI_DONE,
-        "dead": EMOJI_DEAD,
-    }.get(state, "")
+    emoji = _state_emoji_map().get(state, "")
     if emoji:
         parts.append(emoji)
     if rc_active:
@@ -280,13 +306,7 @@ async def update_topic_emoji(
     rc_active = _resolve_rc_mode(chat_id, thread_id)
     state_token = (state, approval_mode, rc_active)
 
-    emoji = {
-        "active": EMOJI_ACTIVE,
-        "idle": EMOJI_IDLE,
-        "done": EMOJI_DONE,
-        "dead": EMOJI_DEAD,
-    }.get(state, "")
-
+    emoji = _state_emoji_map().get(state, "")
     if not emoji:
         return
 

--- a/tests/ccgram/handlers/test_topic_emoji.py
+++ b/tests/ccgram/handlers/test_topic_emoji.py
@@ -12,7 +12,9 @@ from ccgram.handlers.topic_emoji import (
     EMOJI_ACTIVE,
     EMOJI_DEAD,
     EMOJI_DONE,
+    EMOJI_GREEN_CIRCLE,
     EMOJI_IDLE,
+    EMOJI_YELLOW_CIRCLE,
     EMOJI_YOLO,
     clear_topic_emoji_state,
     format_topic_name_for_mode,
@@ -615,3 +617,53 @@ class TestRemoteControlBadge:
             message_thread_id=42,
             name=f"{EMOJI_ACTIVE} {EMOJI_RC} {EMOJI_YOLO} myproject",
         )
+
+
+class TestStatusMode:
+    @pytest.fixture
+    def _user_mode(self, monkeypatch):
+        from ccgram.config import config
+
+        monkeypatch.setattr(config, "status_mode", "user")
+        yield
+
+    def test_default_uses_system_mode(self) -> None:
+        from ccgram.handlers.topic_emoji import _state_emoji_map
+
+        # Without any monkeypatch, default config.status_mode is "system".
+        table = _state_emoji_map()
+        assert table["active"] == EMOJI_GREEN_CIRCLE
+        assert table["idle"] == EMOJI_YELLOW_CIRCLE
+
+    def test_user_mode_swaps_active_idle_colors(self, _user_mode) -> None:
+        from ccgram.handlers.topic_emoji import _state_emoji_map
+
+        table = _state_emoji_map()
+        assert table["active"] == EMOJI_YELLOW_CIRCLE
+        assert table["idle"] == EMOJI_GREEN_CIRCLE
+        # done/dead are unchanged across modes.
+        assert table["done"] == EMOJI_DONE
+        assert table["dead"] == EMOJI_DEAD
+
+    async def test_user_mode_emits_yellow_for_active(self, _user_mode) -> None:
+        bot = AsyncMock()
+        await _debounced_update(bot, -100, 42, "active", "myproject")
+        bot.edit_forum_topic.assert_called_once_with(
+            chat_id=-100,
+            message_thread_id=42,
+            name=f"{EMOJI_YELLOW_CIRCLE} myproject",
+        )
+
+    async def test_user_mode_emits_green_for_idle(self, _user_mode) -> None:
+        bot = AsyncMock()
+        await _debounced_update(bot, -100, 42, "idle", "myproject")
+        bot.edit_forum_topic.assert_called_once_with(
+            chat_id=-100,
+            message_thread_id=42,
+            name=f"{EMOJI_GREEN_CIRCLE} myproject",
+        )
+
+    def test_strip_handles_both_modes(self) -> None:
+        # Whichever mode wrote the prefix, both colors are always strippable.
+        assert strip_emoji_prefix(f"{EMOJI_GREEN_CIRCLE} x") == "x"
+        assert strip_emoji_prefix(f"{EMOJI_YELLOW_CIRCLE} x") == "x"

--- a/tests/ccgram/test_config.py
+++ b/tests/ccgram/test_config.py
@@ -142,6 +142,28 @@ class TestHideToolCalls:
 
 
 @pytest.mark.usefixtures("_base_env")
+class TestStatusMode:
+    def test_default_is_system(self, monkeypatch):
+        monkeypatch.delenv("CCGRAM_STATUS_MODE", raising=False)
+        assert Config().status_mode == "system"
+
+    @pytest.mark.parametrize("value", ["user", "USER", "User", " user "])
+    def test_user_mode_normalized(self, monkeypatch, value):
+        monkeypatch.setenv("CCGRAM_STATUS_MODE", value)
+        assert Config().status_mode == "user"
+
+    @pytest.mark.parametrize("value", ["system", "SYSTEM", " System "])
+    def test_system_mode_normalized(self, monkeypatch, value):
+        monkeypatch.setenv("CCGRAM_STATUS_MODE", value)
+        assert Config().status_mode == "system"
+
+    @pytest.mark.parametrize("value", ["", "garbage", "1", "off", "default"])
+    def test_invalid_falls_back_to_system(self, monkeypatch, value):
+        monkeypatch.setenv("CCGRAM_STATUS_MODE", value)
+        assert Config().status_mode == "system"
+
+
+@pytest.mark.usefixtures("_base_env")
 class TestMessagingConfig:
     def test_msg_auto_spawn_default_false(self):
         cfg = Config()


### PR DESCRIPTION
Closes #44.

## Summary

Adds \`CCGRAM_STATUS_MODE\` env var (and \`--status-mode\` CLI flag) to swap the green/yellow circle assignment on topic state emojis:

- **system** (default, current behavior): 🟢 active (working) / 🟡 idle (waiting)
- **user** (issue's request): 🟢 idle (ready for me) / 🟡 active (busy)

\`done\` (✅) and \`dead\` (💥) are unchanged across modes.

## Design

Same pattern as \`CCGRAM_HIDE_TOOL_CALLS\` (#65) — global env → \`config.status_mode\` field → consumed at the emoji map. No per-window override (YAGNI; users want one mode for all topics).

The constants in \`topic_emoji.py\` were renamed from state-based (\`EMOJI_ACTIVE\`/\`EMOJI_IDLE\`) to color-based (\`EMOJI_GREEN_CIRCLE\`/\`EMOJI_YELLOW_CIRCLE\`) so the names don't lie under user mode. Backward-compat aliases (\`EMOJI_ACTIVE = EMOJI_GREEN_CIRCLE\`, \`EMOJI_IDLE = EMOJI_YELLOW_CIRCLE\`) preserve the existing API.

\`strip_emoji_prefix\` already strips both color circles, so no migration is needed when toggling modes — old prefixes from the previous mode are still cleaned correctly.

## Test plan

- [x] Config: default → system, normalized (case + whitespace) for system/user, invalid values fall back to system.
- [x] Emoji map: default returns system table; \`config.status_mode = "user"\` swaps active/idle colors; done/dead unchanged.
- [x] End-to-end: \`update_topic_emoji("active")\` under user mode emits the yellow circle.
- [x] \`strip_emoji_prefix\` still cleans both colors regardless of mode.
- [x] \`make check\`: lint/pyright clean, 4306 unit + 97 integration tests pass.