### PR TITLE
[codex] fix(dev): avoid focusing created restart tmux window

### DIFF
--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -89,7 +89,7 @@ ensure_target() {
 	fi
 	if ! tmux list-windows -t "${TMUX_SESSION}" -F '#{window_name}' | grep -qx "${TMUX_WINDOW}"; then
 		echo "Creating window '${TMUX_WINDOW}' in session '${TMUX_SESSION}'..."
-		tmux new-window -t "${TMUX_SESSION}" -n "${TMUX_WINDOW}" -c "${PROJECT_DIR}"
+		tmux new-window -ad -t "${TMUX_SESSION}" -n "${TMUX_WINDOW}" -c "${PROJECT_DIR}"
 	fi
 }
 


### PR DESCRIPTION
## Summary

- Create the missing dev supervisor window in detached mode.
- Insert it after the target session instead of making it the current tmux window.

## Why

`scripts/restart.sh status/start/restart` calls `ensure_target()` before sending keys or capturing output. When the `ccgram` tmux session already exists but the `__main__` window is missing, `tmux new-window` currently creates that window and makes it current for attached clients.

That can steal focus from whatever window the developer is actively using in the same tmux session. Using `new-window -d` keeps the current window unchanged while still creating the target window for subsequent `send-keys` and `capture-pane` calls.

## Validation

- `bash -n scripts/restart.sh`
