### PR TITLE
fix(providers/codex): exclude codex_exec sessions from primary detection

### DIFF
--- a/src/ccgram/providers/codex.py
+++ b/src/ccgram/providers/codex.py
@@ -553,12 +553,28 @@ def _is_primary_codex_session(meta: dict[str, Any]) -> bool:
 
     Hookless discovery should bind a tmux window to the main user-visible
     conversation, not transient guardian/subagent transcripts created for
-    approvals or delegated work. Those transcripts share the same cwd and can be
+    approvals or delegated work, nor non-interactive ``codex exec`` runs that
+    happen to share a cwd with a real interactive session. All of those write
+    JSONL transcripts under the same ``~/.codex/sessions/`` tree and can be
     newer than the main transcript, so they must be filtered out here.
+
+    Filtering precedence:
+
+    * ``originator == "codex_exec"`` -> non-interactive ``codex exec``; never
+      bind regardless of ``source``. Some ``codex exec`` runs report
+      ``source = "exec"`` and others report no ``source`` field at all, so the
+      originator check must happen before the ``source`` branches below.
+    * Non-dict ``source`` (string such as ``"cli"`` / ``"exec"``, or missing) ->
+      treated as a primary session. This covers ``codex_cli_rs`` interactive
+      sessions and Codex Desktop variants that legitimately set
+      ``source = "exec"`` but whose ``originator`` is not ``codex_exec``.
+    * Dict ``source`` -> filter out anything carrying a ``subagent`` key
+      (guardian / delegated work).
     """
+    originator = meta.get("originator")
+    if isinstance(originator, str) and originator == "codex_exec":
+        return False
     source = meta.get("source")
-    if isinstance(source, str):
-        return True
     if not isinstance(source, dict):
         return True
     return "subagent" not in source

--- a/tests/ccgram/providers/test_jsonl_providers.py
+++ b/tests/ccgram/providers/test_jsonl_providers.py
@@ -1248,14 +1248,21 @@ def _write_codex_session(
     cwd: str,
     *,
     source: object = "cli",
+    originator: object = "codex_cli_rs",
 ) -> Path:
+    """Write a fake Codex session JSONL.
+
+    ``source`` and ``originator`` mirror the keys real Codex writes into the
+    ``session_meta`` payload. Pass ``originator=None`` to omit the field
+    entirely (simulating older transcripts that predate the field).
+    """
     day_dir = sessions_dir / date_parts
     day_dir.mkdir(parents=True, exist_ok=True)
     fpath = day_dir / f"{name}.jsonl"
-    meta = {
-        "type": "session_meta",
-        "payload": {"id": session_id, "cwd": cwd, "source": source},
-    }
+    payload: dict[str, object] = {"id": session_id, "cwd": cwd, "source": source}
+    if originator is not None:
+        payload["originator"] = originator
+    meta = {"type": "session_meta", "payload": payload}
     fpath.write_text(json.dumps(meta) + "\n")
     return fpath
 
@@ -1408,6 +1415,97 @@ class TestCodexDiscoverTranscript:
         codex = CodexProvider()
         with patch.object(Path, "home", return_value=tmp_path):
             event = codex.discover_transcript("/my/project", "ccgram:@7")
+        assert event is None
+
+    def test_skips_codex_exec_session(self, tmp_path: Path) -> None:
+        """``codex exec`` runs (originator=codex_exec) must not be claimed by
+        hookless discovery, even if a real interactive session exists in the
+        same cwd. The interactive session wins."""
+        sessions_dir = tmp_path / ".codex" / "sessions"
+        _write_codex_session(
+            sessions_dir,
+            "2026/03/01",
+            "main",
+            "uuid-main",
+            "/my/project",
+        )
+        time.sleep(0.05)
+        _write_codex_session(
+            sessions_dir,
+            "2026/03/02",
+            "exec-run",
+            "uuid-exec",
+            "/my/project",
+            source="exec",
+            originator="codex_exec",
+        )
+
+        codex = CodexProvider()
+        with patch.object(Path, "home", return_value=tmp_path):
+            event = codex.discover_transcript("/my/project", "ccgram:@7")
+        assert event is not None
+        assert event.session_id == "uuid-main"
+
+    def test_codex_desktop_exec_survives_filter(self, tmp_path: Path) -> None:
+        """Codex Desktop legitimately writes ``source = "exec"`` while keeping
+        a non-``codex_exec`` originator. Those sessions must survive the
+        filter."""
+        sessions_dir = tmp_path / ".codex" / "sessions"
+        _write_codex_session(
+            sessions_dir,
+            "2026/03/02",
+            "desktop-exec",
+            "uuid-desktop",
+            "/my/project",
+            source="exec",
+            originator="Codex Desktop",
+        )
+
+        codex = CodexProvider()
+        with patch.object(Path, "home", return_value=tmp_path):
+            event = codex.discover_transcript("/my/project", "ccgram:@7")
+        assert event is not None
+        assert event.session_id == "uuid-desktop"
+
+    def test_missing_originator_field_is_kept(self, tmp_path: Path) -> None:
+        """Older Codex transcripts predate the ``originator`` field. Absence of
+        the field must be treated as fail-safe-open (keep the session)."""
+        sessions_dir = tmp_path / ".codex" / "sessions"
+        _write_codex_session(
+            sessions_dir,
+            "2026/03/02",
+            "no-originator",
+            "uuid-bare",
+            "/my/project",
+            originator=None,
+        )
+
+        codex = CodexProvider()
+        with patch.object(Path, "home", return_value=tmp_path):
+            event = codex.discover_transcript("/my/project", "ccgram:@7")
+        assert event is not None
+        assert event.session_id == "uuid-bare"
+
+    def test_skips_codex_exec_when_only_match(self, tmp_path: Path) -> None:
+        """Reproduce the production bug: when the only cwd-matching session is
+        a ``codex exec`` run, discovery must return ``None`` rather than bind
+        the wrong session."""
+        sessions_dir = tmp_path / ".codex" / "sessions"
+        _write_codex_session(
+            sessions_dir,
+            "2026/03/02",
+            "only-exec",
+            "uuid-exec",
+            "/Users/yubai/Obsidian/byheaven",
+            source="exec",
+            originator="codex_exec",
+        )
+
+        codex = CodexProvider()
+        with patch.object(Path, "home", return_value=tmp_path):
+            event = codex.discover_transcript(
+                "/Users/yubai/Obsidian/byheaven", "ccgram:@14"
+            )
         assert event is None
 
 


### PR DESCRIPTION
## Summary

Fix a class of false binding where ccgram tmux windows running Claude (or any non-codex agent) get mis-classified as `provider_name: codex` and bound to a stale `codex exec` JSONL transcript. Once mis-bound, status notifications still reach the Telegram topic via the events path, but conversation messages are silently dropped because `session_monitor._process_session_file` tails the wrong file.

## Root cause

ccgram's hookless transcript discovery scans `~/.codex/sessions/` for the most recent session whose `cwd` matches the tmux pane's cwd. Non-interactive `codex exec` runs leave JSONL files under whichever directory the user happened to invoke them from — and `_is_primary_codex_session` accepted them as candidates. When a tmux pane's cwd happens to be a directory the user has invoked `codex exec` from, hookless discovery binds the pane to that stale `codex exec` JSONL even though the pane is actually running `claude` (or anything else).

In the field this surfaces as: a Claude pane shows in tmux with cwd `~/Obsidian/byheaven`; ccgram's `state.json` records `provider_name: codex` and `transcript_path` pointing at a `~/.codex/sessions/.../rollout-…codex_exec….jsonl` from days ago; status events reach the topic via `enqueue_status_update` (which only needs `window_key`, not `transcript_path`) but `NewMessage` events never fire because the codex JSONL is stale.

## Fix

`_is_primary_codex_session` now returns `False` when `meta["originator"] == "codex_exec"`. Branch order:

1. `originator == "codex_exec"` → not primary (regardless of `source`)
2. non-dict `source` (string or missing) → primary
3. dict `source` → primary unless it carries `subagent`

The check is fail-safe-open — sessions missing the `originator` field (older codex versions) are kept.

Codex Desktop variants survive: their `originator` is `"Codex Desktop"`, not `"codex_exec"`, so the new branch leaves them alone even when their `source == "exec"`.

## Survey

7115 codex sessions on a long-running developer's machine: 7087 `originator=codex_cli_rs`, 17 `originator=codex_exec`, 6 missing originator (kept), 4 Codex Desktop variants (kept), 1 `codex_vscode` (kept). Only the 17 `codex_exec` are filtered.

## Test plan

- [x] `_write_codex_session` fixture extended with `originator: object = "codex_cli_rs"` kwarg; passing `originator=None` skips the field write so tests can exercise the fail-safe-open branch.
- [x] `test_skips_codex_exec_session` — main interactive session paired with a newer `codex_exec` entry; discovery routes to main.
- [x] `test_codex_desktop_exec_survives_filter` — `source=\"exec\"` + `originator=\"Codex Desktop\"` survives.
- [x] `test_missing_originator_field_is_kept` — sessions with no `originator` field still kept.
- [x] `test_skips_codex_exec_when_only_match` — reproduces the production scenario; cwd with only `codex_exec` match returns `None`.
- [x] `pytest tests/ccgram/providers/test_jsonl_providers.py` — 128 passed.
- [x] `ruff check`, `ruff format --check`, `pyright` — clean.

## Out of scope (planned as separate PRs)

- Claude Code 2.x renames its `argv[0]` to the version string (e.g. `2.1.126`), bypassing the `JS_RUNTIMES = {node, bun, npx, bunx}` allow-list in `detect_provider_from_pane`. The ps-based fallback never runs, so `claude` panes initially fall through to hookless discovery — which is the upstream condition that combines with the `codex_exec` issue fixed here. Worth a separate small PR (relax the JS_RUNTIMES gate while keeping the `pane_current_command` non-empty guard).
- `events.jsonl` has no rotation policy.