### PR TITLE
Support external tmux sessions

### DIFF
--- a/src/ccgram/handlers/polling/polling_coordinator.py
+++ b/src/ccgram/handlers/polling/polling_coordinator.py
@@ -16,6 +16,7 @@ from telegram.error import TelegramError
 from ...thread_router import thread_router
 from ...tmux_manager import tmux_manager
 from ...utils import log_throttled
+from ...window_resolver import is_foreign_window
 from . import window_tick
 
 if TYPE_CHECKING:
@@ -29,6 +30,19 @@ _BACKOFF_MIN = 2.0
 _BACKOFF_MAX = 30.0
 
 _LoopError = (TelegramError, OSError, RuntimeError, ValueError)
+
+
+async def _include_bound_foreign_windows(all_windows: list) -> list:
+    """Add bound foreign windows even when provider-filtered discovery misses them."""
+    seen = {w.window_id for w in all_windows}
+    for _user_id, _thread_id, window_id in thread_router.iter_thread_bindings():
+        if not is_foreign_window(window_id) or window_id in seen:
+            continue
+        window = await tmux_manager.find_window_by_id(window_id)
+        if window:
+            all_windows.append(window)
+            seen.add(window_id)
+    return all_windows
 
 
 # ── Main loop ─────────────────────────────────────────────────────────────
@@ -62,6 +76,7 @@ async def status_poll_loop(bot: "Bot") -> None:
             all_windows = await tmux_manager.list_windows()
             external_windows = await tmux_manager.discover_external_sessions()
             all_windows.extend(external_windows)
+            all_windows = await _include_bound_foreign_windows(all_windows)
             window_lookup = {w.window_id: w for w in all_windows}
 
             await run_periodic_tasks(client, all_windows, timers)

--- a/src/ccgram/handlers/recovery/transcript_discovery.py
+++ b/src/ccgram/handlers/recovery/transcript_discovery.py
@@ -128,8 +128,10 @@ def _resolve_providers_to_try(
             return []
         return [(provider.capabilities.name, provider)]
 
-    if w and is_shell_prompt(w.pane_current_command) and not is_foreign_window(
-        window_id
+    if (
+        w
+        and is_shell_prompt(w.pane_current_command)
+        and not is_foreign_window(window_id)
     ):
         return None  # signals caller to set up shell
 

--- a/src/ccgram/handlers/recovery/transcript_discovery.py
+++ b/src/ccgram/handlers/recovery/transcript_discovery.py
@@ -61,6 +61,15 @@ async def _detect_and_apply_provider(
         )
 
     if detected == "shell" and is_foreign_window(window_id):
+        if state.provider_name == "shell":
+            session_manager.set_window_provider(window_id, "", cwd=w.cwd or None)
+            state.provider_name = ""
+            state.transcript_path = ""
+            logger.info(
+                "Cleared stale shell provider for foreign window %s; "
+                "probing hookless providers",
+                window_id,
+            )
         detected = ""
 
     if detected and detected != state.provider_name:
@@ -253,5 +262,7 @@ async def discover_and_register_transcript(
     if not providers_to_try:
         return
 
-    pane_alive = w is not None and not is_shell_prompt(w.pane_current_command)
+    pane_alive = w is not None and (
+        not is_shell_prompt(w.pane_current_command) or is_foreign_window(window_id)
+    )
     await _find_and_register_transcript(window_id, state, providers_to_try, pane_alive)

--- a/src/ccgram/handlers/recovery/transcript_discovery.py
+++ b/src/ccgram/handlers/recovery/transcript_discovery.py
@@ -60,6 +60,9 @@ async def _detect_and_apply_provider(
             pane_title=pane_title,
         )
 
+    if detected == "shell" and is_foreign_window(window_id):
+        detected = ""
+
     if detected and detected != state.provider_name:
         old_provider = state.provider_name
         session_manager.set_window_provider(window_id, detected, cwd=w.cwd or None)
@@ -125,7 +128,9 @@ def _resolve_providers_to_try(
             return []
         return [(provider.capabilities.name, provider)]
 
-    if w and is_shell_prompt(w.pane_current_command):
+    if w and is_shell_prompt(w.pane_current_command) and not is_foreign_window(
+        window_id
+    ):
         return None  # signals caller to set up shell
 
     return [

--- a/src/ccgram/handlers/sync_command.py
+++ b/src/ccgram/handlers/sync_command.py
@@ -31,7 +31,7 @@ from ..session import AuditIssue, AuditResult, session_manager
 from ..session_map import session_map_sync
 from ..telegram_client import PTBTelegramClient, TelegramClient
 from ..thread_router import thread_router
-from ..tmux_manager import tmux_manager
+from ..tmux_manager import TmuxWindow, tmux_manager
 from ..user_preferences import user_preferences
 from .callback_data import CB_SYNC_DISMISS, CB_SYNC_FIX
 from .callback_registry import register
@@ -44,8 +44,8 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger()
 
-_GHOST_RE = re.compile(r"user:(\d+) thread:(\d+) window:(@\d+)")
-_WINDOW_RE = re.compile(r"(@\d+)")
+_GHOST_RE = re.compile(r"user:(\d+) thread:(\d+) window:(\S+)")
+_WINDOW_RE = re.compile(r"(\S+)")
 
 _CATEGORY_LABELS: dict[str, str] = {
     "ghost_binding": "ghost binding (dead window)",
@@ -61,10 +61,17 @@ _CATEGORY_LABELS: dict[str, str] = {
 
 async def _run_audit() -> AuditResult:
     """Fetch live tmux state and run audit."""
-    all_windows = await tmux_manager.list_windows()
+    all_windows = await _list_all_windows()
     live_ids = {w.window_id for w in all_windows}
     live_pairs = [(w.window_id, w.window_name) for w in all_windows]
     return session_manager.audit_state(live_ids, live_pairs)
+
+
+async def _list_all_windows() -> list[TmuxWindow]:
+    """Return native ccgram windows plus configured external tmux windows."""
+    windows = await tmux_manager.list_windows()
+    windows.extend(await tmux_manager.discover_external_sessions())
+    return windows
 
 
 def _issue_summary_lines(audit: AuditResult) -> list[str]:
@@ -90,7 +97,7 @@ async def _sync_live_topic_names(
 ) -> None:
     """Best-effort reconciliation of bound live topic titles."""
     if live_ids is None:
-        all_windows = await tmux_manager.list_windows()
+        all_windows = await _list_all_windows()
         live_ids = {w.window_id for w in all_windows}
 
     for user_id, thread_id, window_id in thread_router.iter_thread_bindings():
@@ -431,8 +438,8 @@ async def sync_command(update: Update, _context: ContextTypes.DEFAULT_TYPE) -> N
 
 async def handle_sync_fix(query: CallbackQuery) -> None:
     """Run all fix operations, re-audit, and edit message in place."""
-    # Single list_windows call — reused for both audit and fix
-    all_windows = await tmux_manager.list_windows()
+    # Single live-window snapshot — reused for both audit and fix
+    all_windows = await _list_all_windows()
     live_ids = {w.window_id for w in all_windows}
     live_pairs = [(w.window_id, w.window_name) for w in all_windows]
 

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -332,6 +332,7 @@ async def handle_new_window(event: NewWindowEvent, client: TelegramClient) -> No
 async def adopt_unbound_windows(client: TelegramClient) -> None:
     """Auto-adopt known-but-unbound windows (post-restart recovery)."""
     all_windows = await tmux_manager.list_windows()
+    all_windows.extend(await tmux_manager.discover_external_sessions())
     live_ids = {w.window_id for w in all_windows}
     live_pairs = [(w.window_id, w.window_name) for w in all_windows]
     audit = session_manager.audit_state(live_ids, live_pairs)

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -110,7 +110,7 @@ async def _auto_detect_provider(window_id: str) -> None:
             w.pane_current_command,
             pane_title=pane_title,
         )
-    if detected:
+    if detected and detected != "shell":
         session_manager.set_window_provider(window_id, detected)
         logger.info(
             "Auto-detected provider %r for window %s (command=%s)",

--- a/src/ccgram/providers/__init__.py
+++ b/src/ccgram/providers/__init__.py
@@ -221,24 +221,24 @@ async def detect_provider_from_pane(
        fall back to ``ps -t`` foreground process inspection with PGID cache.
     """
     detected = detect_provider_from_command(pane_current_command)
-    if detected:
+    if detected and detected != "shell":
         return detected
 
     if pane_tty and pane_current_command:
         cmd = pane_current_command.strip().lower()
         if not cmd:
-            return ""
+            return detected
         basename = os.path.basename(cmd.split()[0])
-        if basename in JS_RUNTIMES:
+        if detected == "shell" or basename in JS_RUNTIMES:
             # Lazy: process_detection forks `ps` subprocesses; only worth
             # loading when the pane command is a JS runtime wrapper.
             from .process_detection import detect_provider_cached
 
-            detected = await detect_provider_cached(window_id or "", pane_tty)
-            if detected:
-                return detected
+            tty_detected = await detect_provider_cached(window_id or "", pane_tty)
+            if tty_detected and tty_detected != "shell":
+                return tty_detected
 
-    return ""
+    return detected
 
 
 def resolve_launch_command(

--- a/src/ccgram/providers/process_detection.py
+++ b/src/ccgram/providers/process_detection.py
@@ -35,6 +35,8 @@ logger = structlog.get_logger()
 _WRAPPER_TOKENS = frozenset(
     {"sudo", "env", "node", "bun", "npx", "bunx", "uv", "python", "python3"}
 )
+_SHELL_COMMAND_PREFIXES = frozenset({"exec", "command"})
+_SHELL_CONTROL_TOKENS = frozenset({"&", "&&", "|", "||", ";", ";;"})
 
 # Basename → provider name.  Checked via exact match and prefix (``claude-*``).
 _PROVIDER_BASENAMES: tuple[tuple[frozenset[str], str], ...] = (
@@ -60,7 +62,8 @@ JS_RUNTIMES = frozenset({"node", "bun", "npx", "bunx"})
 
 def _match_token(token: str) -> str:
     """Match a single argv token against provider basenames and path markers."""
-    basename = os.path.basename(token).lower().lstrip("-")
+    normalized_token = token.strip("\"'")
+    basename = os.path.basename(normalized_token).lower().lstrip("-")
 
     # Direct basename match
     for names, provider in _PROVIDER_BASENAMES:
@@ -70,12 +73,68 @@ def _match_token(token: str) -> str:
         return "shell"
 
     # Path-based match for ambiguous basenames (e.g. cli.js)
-    token_lower = token.lower()
+    token_lower = normalized_token.lower()
     for markers, provider in _PROVIDER_PATH_MARKERS:
         if any(m in token_lower for m in markers):
             return provider
 
     return ""
+
+
+def _clean_token(token: str) -> str:
+    """Return the normalized basename used for wrapper/control-token checks."""
+    return os.path.basename(token.strip("\"'")).lower().lstrip("-")
+
+
+def _is_shell_command_flag(token: str) -> bool:
+    """Return True for shell option groups that include ``-c``."""
+    cleaned = token.strip("\"'")
+    return cleaned.startswith("-") and "c" in cleaned[1:]
+
+
+def _classify_shell_command_tokens(tokens: list[str]) -> str:
+    """Classify tokens inside a shell ``-c`` command string.
+
+    Shell launchers often prepend assignments/redirections before the agent
+    command.  Scanning is allowed here because ``-c`` explicitly says the
+    remaining text is command syntax, unlike arbitrary process arguments.
+    """
+    for index, token in enumerate(tokens):
+        if _is_shell_setup_token(token):
+            continue
+        provider = _match_token(token)
+        if provider == "shell":
+            for shell_arg_index, shell_arg in enumerate(tokens[index + 1 :]):
+                if _is_shell_command_flag(shell_arg):
+                    command_start = index + 1 + shell_arg_index + 1
+                    return _classify_shell_command_tokens(tokens[command_start:])
+            return ""
+        return provider
+    return ""
+
+
+def _is_shell_setup_token(token: str) -> bool:
+    """Return True for shell setup syntax before the real command."""
+    cleaned = _clean_token(token)
+    if cleaned in _SHELL_COMMAND_PREFIXES or cleaned in _WRAPPER_TOKENS:
+        return True
+    if "=" in cleaned:
+        return True
+    stripped = token.strip("\"'")
+    if stripped in _SHELL_CONTROL_TOKENS:
+        return True
+    return _is_fd_redirection_token(stripped)
+
+
+def _is_fd_redirection_token(token: str) -> bool:
+    """Return True for shell file-descriptor redirection tokens."""
+    trimmed = token.rstrip(";")
+    if not trimmed:
+        return False
+    first = trimmed[0]
+    if first in "<>":
+        return True
+    return first.isdigit() and any(op in trimmed for op in ("<", ">"))
 
 
 def classify_provider_from_args(args: str) -> str:
@@ -89,11 +148,19 @@ def classify_provider_from_args(args: str) -> str:
     if not args:
         return ""
 
-    for token in args.split():
-        cleaned = os.path.basename(token).lower().lstrip("-")
+    tokens = args.split()
+    for index, token in enumerate(tokens):
+        cleaned = _clean_token(token)
         if cleaned in _WRAPPER_TOKENS:
             continue
-        return _match_token(token)
+        provider = _match_token(token)
+        if provider == "shell":
+            for shell_arg_index, shell_arg in enumerate(tokens[index + 1 :]):
+                if _is_shell_command_flag(shell_arg):
+                    command_start = index + 1 + shell_arg_index + 1
+                    return _classify_shell_command_tokens(tokens[command_start:])
+            return "shell"
+        return provider
 
     return ""
 

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -37,7 +37,7 @@ from .user_preferences import (
     install_user_preferences,
     user_preferences,
 )
-from .window_resolver import EMDASH_SESSION_PREFIX, is_foreign_window, is_window_id
+from .window_resolver import is_foreign_window, is_window_id
 from .window_view import WindowView
 from .window_state_store import (
     APPROVAL_MODES,
@@ -238,6 +238,7 @@ class SessionManager:
         from .window_resolver import LiveWindow, resolve_stale_ids as _resolve
 
         windows = await tmux_manager.list_windows()
+        windows.extend(await tmux_manager.discover_external_sessions())
         live = [
             LiveWindow(window_id=w.window_id, window_name=w.window_name)
             for w in windows
@@ -369,8 +370,8 @@ class SessionManager:
     def _get_session_map_window_ids(self) -> set[str]:
         """Read session_map.json and return window IDs tracked by ccgram.
 
-        Includes native windows (stripped to @id) and emdash windows
-        (full qualified key like "emdash-claude-main-xxx:@0").
+        Includes native windows (stripped to @id) and foreign windows
+        (full qualified key like "omx-project-main-xxx:@0").
         """
         if not config.session_map_file.exists():
             return set()
@@ -385,7 +386,7 @@ class SessionManager:
                 wid = key[len(prefix) :]
                 if self._is_window_id(wid):
                     result.add(wid)
-            elif key.startswith(EMDASH_SESSION_PREFIX):
+            elif is_foreign_window(key):
                 result.add(key)
         return result
 

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -504,9 +504,8 @@ class SessionManager:
         # 7. Orphaned tmux windows (live and adoptable, but not bound to any topic)
         known_wids = session_map_wids | set(self.window_states.keys())
         for wid in live_window_ids:
-            if (
-                wid not in bound_window_ids
-                and (wid in known_wids or is_foreign_window(wid))
+            if wid not in bound_window_ids and (
+                wid in known_wids or is_foreign_window(wid)
             ):
                 name = dict(live_windows).get(wid, wid)
                 issues.append(

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -501,10 +501,13 @@ class SessionManager:
                     )
                 )
 
-        # 7. Orphaned tmux windows (live, known to ccgram, but not bound to any topic)
+        # 7. Orphaned tmux windows (live and adoptable, but not bound to any topic)
         known_wids = session_map_wids | set(self.window_states.keys())
         for wid in live_window_ids:
-            if wid not in bound_window_ids and wid in known_wids:
+            if (
+                wid not in bound_window_ids
+                and (wid in known_wids or is_foreign_window(wid))
+            ):
                 name = dict(live_windows).get(wid, wid)
                 issues.append(
                     AuditIssue(

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -140,7 +140,8 @@ def parse_session_map(raw: dict[str, Any], prefix: str) -> dict[str, dict[str, s
     """Parse session_map.json entries matching a tmux session prefix.
 
     Also matches legacy "ccbot:" prefix keys when the current prefix is "ccgram:".
-    Returns {window_name: {"session_id": ..., "cwd": ...}} for matching entries.
+    Also accepts foreign qualified window IDs (for example ``omx-...:@90``).
+    Returns {window_id: {"session_id": ..., "cwd": ...}} for matching entries.
 
     Safe to call from a clean interpreter (no SessionManager wired): the
     nested-session preference logic in ``_prefer_existing_primary`` short-
@@ -155,6 +156,8 @@ def parse_session_map(raw: dict[str, Any], prefix: str) -> dict[str, dict[str, s
             window_name = key[len(prefix) :]
         elif legacy_prefix and key.startswith(legacy_prefix):
             window_name = key[len(legacy_prefix) :]
+        elif is_foreign_window(key):
+            window_name = key
         else:
             continue
         if not isinstance(info, dict):
@@ -240,12 +243,11 @@ class SessionMapSync:
         for key, info in session_map.items():
             if not isinstance(info, dict):
                 continue
-            if key.startswith(EMDASH_SESSION_PREFIX):
-                valid_wids.add(key)
-                if self._sync_emdash_entry(key, info):
-                    changed = True
-                continue
             if not key.startswith(prefix):
+                if is_foreign_window(key):
+                    valid_wids.add(key)
+                    if self._sync_foreign_entry(key, info):
+                        changed = True
                 continue
             window_id = key[len(prefix) :]
             if not is_window_id(window_id):
@@ -260,8 +262,8 @@ class SessionMapSync:
 
         return valid_wids, old_format_sids, old_format_keys, changed
 
-    def _sync_emdash_entry(self, key: str, info: dict[str, Any]) -> bool:
-        """Sync one emdash session_map entry; infer provider if missing.
+    def _sync_foreign_entry(self, key: str, info: dict[str, Any]) -> bool:
+        """Sync one foreign session_map entry; infer emdash provider if missing.
 
         Returns True if any state changed.
         """
@@ -386,13 +388,7 @@ class SessionMapSync:
             return
 
         prefix = f"{config.tmux_session_name}:"
-        dead_entries: list[tuple[str, str]] = []  # (map_key, window_id)
-        for key in raw:
-            if not key.startswith(prefix):
-                continue
-            window_id = key[len(prefix) :]
-            if is_window_id(window_id) and window_id not in live_window_ids:
-                dead_entries.append((key, window_id))
+        dead_entries = self._dead_session_map_entries(raw, prefix, live_window_ids)
 
         if not dead_entries:
             return
@@ -411,11 +407,35 @@ class SessionMapSync:
         if changed_state:
             self._schedule_save()
 
+    def _dead_session_map_entries(
+        self,
+        raw: dict[str, Any],
+        prefix: str,
+        live_window_ids: set[str],
+    ) -> list[tuple[str, str]]:
+        """Return ``(map_key, window_id)`` entries that are known dead."""
+        # Lazy: same cycle + wiring contract as _prefer_existing_primary.
+        from .window_state_store import window_store
+
+        dead_entries: list[tuple[str, str]] = []
+        for key in raw:
+            if key.startswith(prefix):
+                window_id = key[len(prefix) :]
+                if is_window_id(window_id) and window_id not in live_window_ids:
+                    dead_entries.append((key, window_id))
+            elif (
+                is_foreign_window(key)
+                and key not in live_window_ids
+                and window_store.has_window(key)
+            ):
+                dead_entries.append((key, key))
+        return dead_entries
+
     def get_session_map_window_ids(self) -> set[str]:
         """Read session_map.json and return window IDs tracked by ccgram.
 
-        Includes native windows (stripped to @id) and emdash windows
-        (full qualified key like "emdash-claude-main-xxx:@0").
+        Includes native windows (stripped to @id) and foreign windows
+        (full qualified key like "omx-project-xxx:@0").
         """
         if not config.session_map_file.exists():
             return set()
@@ -430,7 +450,7 @@ class SessionMapSync:
                 wid = key[len(prefix) :]
                 if is_window_id(wid):
                     result.add(wid)
-            elif key.startswith(EMDASH_SESSION_PREFIX):
+            elif is_foreign_window(key):
                 result.add(key)
         return result
 

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -128,6 +128,7 @@ class SessionMonitor:
 
         self._idle_tracker = IdleTracker()
         self._transcript_reader = TranscriptReader(self.state, self._idle_tracker)
+        self._initial_replay_sessions: set[str] = set()
 
     # Delegation properties for backward-compatible test access
     @property
@@ -198,12 +199,15 @@ class SessionMonitor:
 
         for session_id, file_path in direct_sessions:
             try:
+                replay_initial = session_id in self._initial_replay_sessions
                 await self._process_session_file(
                     session_id,
                     file_path,
                     new_messages,
                     window_id=sid_to_wid.get(session_id, ""),
+                    replay_initial=replay_initial,
                 )
+                self._initial_replay_sessions.discard(session_id)
             except Exception:
                 logger.exception("Error processing session %s", session_id)
 
@@ -214,12 +218,17 @@ class SessionMonitor:
                 if session_info.session_id not in fallback_session_ids:
                     continue
                 try:
+                    replay_initial = (
+                        session_info.session_id in self._initial_replay_sessions
+                    )
                     await self._process_session_file(
                         session_info.session_id,
                         session_info.file_path,
                         new_messages,
                         window_id=sid_to_wid.get(session_info.session_id, ""),
+                        replay_initial=replay_initial,
                     )
+                    self._initial_replay_sessions.discard(session_info.session_id)
                 except Exception:
                     logger.exception(
                         "Error processing session %s", session_info.session_id
@@ -229,11 +238,20 @@ class SessionMonitor:
         return new_messages
 
     async def _process_session_file(
-        self, session_id: str, file_path: Path, new_messages: list, window_id: str = ""
+        self,
+        session_id: str,
+        file_path: Path,
+        new_messages: list,
+        window_id: str = "",
+        replay_initial: bool = False,
     ) -> None:
         """Process a single session file (delegates to TranscriptReader)."""
         await self._transcript_reader._process_session_file(
-            session_id, file_path, new_messages, window_id=window_id
+            session_id,
+            file_path,
+            new_messages,
+            window_id=window_id,
+            replay_initial=replay_initial,
         )
 
     def _scan_projects_sync(self, active_cwds: set) -> list:
@@ -310,8 +328,17 @@ class SessionMonitor:
 
         for session_id in result.sessions_to_remove:
             self._transcript_reader.clear_session(session_id)
+            self._initial_replay_sessions.discard(session_id)
         if result.sessions_to_remove:
             self.state.save_if_dirty()
+
+        for details in (*result.new_windows.values(), *result.changed_windows.values()):
+            provider_name = details.get("provider_name", "")
+            if not details.get("transcript_path") or not provider_name:
+                continue
+            provider = get_provider_for_window("", provider_name=provider_name)
+            if not provider.capabilities.supports_hook:
+                self._initial_replay_sessions.add(details["session_id"])
 
         adoption_windows = dict(result.new_windows)
         # Lazy: thread_router is wired into session_manager which imports

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -35,6 +35,8 @@ from .tmux_manager import tmux_manager
 from .monitor_events import NewMessage, NewWindowEvent, SessionInfo
 from .transcript_reader import TranscriptReader
 from .utils import task_done_callback
+from .window_resolver import is_foreign_window
+from .window_state_store import window_store
 
 import aiofiles
 import json
@@ -59,6 +61,32 @@ _MSG_PREVIEW_LENGTH = 80
 logger = structlog.get_logger()
 
 _SessionMapError = (json.JSONDecodeError, OSError)
+
+
+async def _include_tracked_foreign_windows(all_windows: list) -> list:
+    """Add bound/tracked foreign windows without provider filtering."""
+    seen = {w.window_id for w in all_windows}
+
+    # Lazy: thread_router is part of the SessionManager-wired state graph.
+    from .thread_router import thread_router
+
+    candidates = {
+        wid
+        for _, _, wid in thread_router.iter_thread_bindings()
+        if is_foreign_window(wid)
+    }
+    candidates.update(
+        wid for wid in window_store.iter_window_ids() if is_foreign_window(wid)
+    )
+
+    for window_id in candidates:
+        if window_id in seen:
+            continue
+        window = await tmux_manager.find_window_by_id(window_id)
+        if window:
+            all_windows.append(window)
+            seen.add(window_id)
+    return all_windows
 
 
 class SessionMonitor:
@@ -343,6 +371,7 @@ class SessionMonitor:
                 all_windows = await tmux_manager.list_windows()
                 external_windows = await tmux_manager.discover_external_sessions()
                 all_windows = all_windows + external_windows
+                all_windows = await _include_tracked_foreign_windows(all_windows)
                 live_window_ids = {w.window_id for w in all_windows}
                 session_map_sync.prune_session_map(live_window_ids)
                 known_window_ids = set(current_map.keys())

--- a/src/ccgram/tmux_manager.py
+++ b/src/ccgram/tmux_manager.py
@@ -825,13 +825,20 @@ class TmuxManager:
                 fnmatch.fnmatch(session_name, pat) for pat in patterns
             ):
                 continue
-            results.extend(await self._scan_session_windows(session_name))
+            results.extend(
+                await self._scan_session_windows(
+                    session_name,
+                    include_unrecognized=bool(patterns),
+                )
+            )
 
         self._external_cache = results
         self._external_cache_expires = now + _EXTERNAL_DISCOVERY_TTL
         return list(results)
 
-    async def _scan_session_windows(self, session_name: str) -> list[TmuxWindow]:
+    async def _scan_session_windows(
+        self, session_name: str, *, include_unrecognized: bool = False
+    ) -> list[TmuxWindow]:
         """List windows in *session_name* that run a recognised AI provider."""
         proc: asyncio.subprocess.Process | None = None
         try:
@@ -880,7 +887,7 @@ class TmuxManager:
                 pane_tty=tty,
                 window_id=f"{session_name}:{win_id}",
             )
-            if not detected or detected == "shell":
+            if (not detected or detected == "shell") and not include_unrecognized:
                 continue
             qualified_id = f"{session_name}:{win_id}"
             display_name = win_name or session_name.removeprefix(_EMDASH_PREFIX)

--- a/src/ccgram/tmux_manager.py
+++ b/src/ccgram/tmux_manager.py
@@ -88,6 +88,7 @@ _TmuxError = (
 )
 
 _EXTERNAL_DISCOVERY_TTL = 10.0  # seconds — cache external session discovery
+_GENERIC_EXTERNAL_WINDOW_NAMES = frozenset({"bash", "zsh", "sh", "fish", "dash", "ksh"})
 
 
 @dataclass
@@ -862,7 +863,7 @@ class TmuxManager:
         # (providers) at module level.
         # Lazy: providers reach back into tmux_manager during process detection
         from .providers import (
-            detect_provider_from_command,
+            detect_provider_from_pane,
         )
 
         results: list[TmuxWindow] = []
@@ -874,14 +875,21 @@ class TmuxManager:
                 continue
             win_id, win_name, cwd, cmd = parts[:4]
             tty = parts[4] if len(parts) > 4 else ""  # noqa: PLR2004
-            detected = detect_provider_from_command(cmd)
+            detected = await detect_provider_from_pane(
+                cmd,
+                pane_tty=tty,
+                window_id=f"{session_name}:{win_id}",
+            )
             if not detected or detected == "shell":
                 continue
             qualified_id = f"{session_name}:{win_id}"
+            display_name = win_name or session_name.removeprefix(_EMDASH_PREFIX)
+            if win_name in _GENERIC_EXTERNAL_WINDOW_NAMES:
+                display_name = session_name.removeprefix(_EMDASH_PREFIX)
             results.append(
                 TmuxWindow(
                     window_id=qualified_id,
-                    window_name=win_name or session_name.removeprefix(_EMDASH_PREFIX),
+                    window_name=display_name,
                     cwd=cwd,
                     pane_current_command=cmd,
                     pane_tty=tty,

--- a/src/ccgram/tmux_manager.py
+++ b/src/ccgram/tmux_manager.py
@@ -88,7 +88,9 @@ _TmuxError = (
 )
 
 _EXTERNAL_DISCOVERY_TTL = 10.0  # seconds — cache external session discovery
-_GENERIC_EXTERNAL_WINDOW_NAMES = frozenset({"bash", "zsh", "sh", "fish", "dash", "ksh"})
+_GENERIC_EXTERNAL_WINDOW_NAMES = frozenset(
+    {"bash", "zsh", "sh", "fish", "dash", "ksh", "node", "bun", "deno"}
+)
 
 
 @dataclass

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -99,6 +99,7 @@ class TranscriptReader:
         new_messages: list[NewMessage],
         window_id: str = "",
         current_map: dict[str, dict[str, Any]] | None = None,
+        replay_initial: bool = False,
     ) -> None:
         """Process a single session file for new messages."""
         tracked = self._state.get_session(session_id)
@@ -113,7 +114,7 @@ class TranscriptReader:
                 current_mtime = 0.0
 
             if provider.capabilities.supports_incremental_read:
-                initial_offset = file_size
+                initial_offset = 0 if replay_initial else file_size
             else:
                 _, initial_offset = await asyncio.to_thread(
                     provider.read_transcript_file, str(file_path), 0
@@ -125,11 +126,12 @@ class TranscriptReader:
                 last_byte_offset=initial_offset,
             )
             self._state.update_session(tracked)
-            self._file_mtimes[session_id] = current_mtime
+            self._file_mtimes[session_id] = 0.0 if replay_initial else current_mtime
             if provider.capabilities.supports_task_tracking and window_id:
                 await provider.seed_task_state(window_id, session_id, str(file_path))
             logger.debug("Started tracking session: %s", session_id)
-            return
+            if not replay_initial:
+                return
 
         try:
             st = file_path.stat()

--- a/tests/ccgram/handlers/polling/test_polling_coordinator.py
+++ b/tests/ccgram/handlers/polling/test_polling_coordinator.py
@@ -82,6 +82,7 @@ def _patch_loop_deps(
             mocks["tmux_manager"].discover_external_sessions = AsyncMock(
                 return_value=external
             )
+            mocks["tmux_manager"].find_window_by_id = AsyncMock(return_value=None)
             mocks["thread_router"].iter_thread_bindings.return_value = bindings
             mocks["config"].status_poll_interval = 1.0
 
@@ -157,6 +158,31 @@ class TestStatusPollLoopHandlesExternalSessions:
         bindings = [(1, 100, "emdash-claude-main-abc:@0")]
 
         ctx = await _run_loop_once(bot, bindings=bindings, external=[ext])
+
+        tick = ctx.mocks["tick_window"]
+        assert tick.call_count == 1
+        assert tick.call_args[0][4] is ext
+
+    async def test_bound_foreign_window_rechecked_when_discovery_misses_it(self):
+        bot = AsyncMock(spec=Bot)
+        ext = _make_window("omx-project:@90", "omx-project")
+        bindings = [(1, 100, "omx-project:@90")]
+
+        combined, ctx = _patch_loop_deps(bindings=bindings, external=[])
+
+        async def _stop_after_one(_delay: float) -> None:
+            raise asyncio.CancelledError
+
+        with (
+            combined(),
+            patch(
+                "ccgram.handlers.polling.polling_coordinator.asyncio.sleep",
+                side_effect=_stop_after_one,
+            ),
+            contextlib.suppress(asyncio.CancelledError),
+        ):
+            ctx.mocks["tmux_manager"].find_window_by_id = AsyncMock(return_value=ext)
+            await status_poll_loop(bot)
 
         tick = ctx.mocks["tick_window"]
         assert tick.call_count == 1
@@ -280,6 +306,7 @@ class TestImportsAreMinimal:
             "..thread_router",
             "..tmux_manager",
             "..utils",
+            "..window_resolver",
             "..config",
             ".window_tick",
             ".periodic_tasks",

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -935,6 +935,61 @@ class TestProviderSwitchPromptSetup:
         mock_ensure.assert_awaited_once()
         assert mock_ensure.call_args[0] == ("@7", "provider_switch")
 
+    async def test_foreign_shell_wrapper_does_not_switch_to_shell(self) -> None:
+        from ccgram.handlers.recovery.transcript_discovery import (
+            discover_and_register_transcript,
+        )
+
+        bot = AsyncMock(spec=Bot)
+        state = MagicMock(
+            session_id="",
+            cwd="/proj",
+            provider_name="",
+            transcript_path="",
+        )
+        with (
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.session_manager"
+            ) as mock_sm,
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.window_store"
+            ) as mock_ws,
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.detect_provider_from_pane",
+                new_callable=AsyncMock,
+                return_value="shell",
+            ),
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery._find_and_register_transcript",
+                new_callable=AsyncMock,
+            ) as mock_find,
+            patch(
+                "ccgram.handlers.shell.shell_prompt_orchestrator.ensure_setup",
+                new_callable=AsyncMock,
+            ) as mock_ensure,
+        ):
+            mock_ws.window_states = {"omx-project:@90": state}
+            mock_tmux.find_window_by_id = AsyncMock(
+                return_value=MagicMock(
+                    pane_current_command="bash",
+                    pane_tty="/dev/ttys004",
+                    cwd="/proj",
+                )
+            )
+
+            await discover_and_register_transcript(
+                "omx-project:@90", client=bot, user_id=1, thread_id=42
+            )
+
+        mock_sm.set_window_provider.assert_not_called()
+        mock_ensure.assert_not_awaited()
+        mock_find.assert_awaited_once()
+        assert mock_find.call_args.args[0] == "omx-project:@90"
+        assert mock_find.call_args.args[3] is False
+
     async def test_fallback_shell_assignment_sets_up_prompt_without_bot(self) -> None:
         from ccgram.handlers.recovery.transcript_discovery import (
             discover_and_register_transcript,

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -988,7 +988,76 @@ class TestProviderSwitchPromptSetup:
         mock_ensure.assert_not_awaited()
         mock_find.assert_awaited_once()
         assert mock_find.call_args.args[0] == "omx-project:@90"
-        assert mock_find.call_args.args[3] is False
+        assert mock_find.call_args.args[3] is True
+
+    async def test_foreign_stale_shell_provider_reprobes_transcripts(self) -> None:
+        from ccgram.handlers.recovery.transcript_discovery import (
+            discover_and_register_transcript,
+        )
+
+        bot = AsyncMock(spec=Bot)
+        state = MagicMock(
+            session_id="",
+            cwd="/proj",
+            provider_name="shell",
+            transcript_path="",
+        )
+
+        def _clear_provider(
+            window_id: str, provider_name: str, *, cwd: str | None = None
+        ) -> None:
+            assert window_id == "omx-project:@90"
+            assert provider_name == ""
+            state.provider_name = provider_name
+            if cwd:
+                state.cwd = cwd
+
+        with (
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.session_manager"
+            ) as mock_sm,
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.window_store"
+            ) as mock_ws,
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.detect_provider_from_pane",
+                new_callable=AsyncMock,
+                return_value="shell",
+            ),
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery._find_and_register_transcript",
+                new_callable=AsyncMock,
+            ) as mock_find,
+            patch(
+                "ccgram.handlers.shell.shell_prompt_orchestrator.ensure_setup",
+                new_callable=AsyncMock,
+            ) as mock_ensure,
+        ):
+            mock_ws.window_states = {"omx-project:@90": state}
+            mock_sm.set_window_provider.side_effect = _clear_provider
+            mock_tmux.find_window_by_id = AsyncMock(
+                return_value=MagicMock(
+                    pane_current_command="bash",
+                    pane_tty="/dev/ttys004",
+                    cwd="/proj",
+                )
+            )
+
+            await discover_and_register_transcript(
+                "omx-project:@90", client=bot, user_id=1, thread_id=42
+            )
+
+        mock_sm.set_window_provider.assert_called_once_with(
+            "omx-project:@90", "", cwd="/proj"
+        )
+        mock_ensure.assert_not_awaited()
+        mock_find.assert_awaited_once()
+        assert mock_find.call_args.args[0] == "omx-project:@90"
+        assert mock_find.call_args.args[3] is True
+        assert state.provider_name == ""
 
     async def test_fallback_shell_assignment_sets_up_prompt_without_bot(self) -> None:
         from ccgram.handlers.recovery.transcript_discovery import (

--- a/tests/ccgram/handlers/test_emdash_integration.py
+++ b/tests/ccgram/handlers/test_emdash_integration.py
@@ -199,6 +199,33 @@ class TestLoadSessionMapEmdash:
 
         assert "emdash-claude-main-abc:@0" in mgr.window_states
 
+    async def test_picks_up_non_emdash_foreign_entries(
+        self, mgr: SessionManager, tmp_path: Path, monkeypatch
+    ) -> None:
+        session_map_file = tmp_path / "session_map.json"
+        session_map_file.write_text(
+            json.dumps(
+                {
+                    "omx-project-main-abc:@90": {
+                        "session_id": "sid-omx",
+                        "cwd": "/tmp/omx",
+                        "window_name": "omx-project-main-abc",
+                        "provider_name": "codex",
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr("ccgram.session.config.session_map_file", session_map_file)
+        monkeypatch.setattr("ccgram.session.config.tmux_session_name", "ccgram")
+
+        await session_map_sync.load_session_map()
+
+        wid = "omx-project-main-abc:@90"
+        assert wid in mgr.window_states
+        assert mgr.window_states[wid].session_id == "sid-omx"
+        assert mgr.window_states[wid].external is True
+        assert mgr.window_states[wid].provider_name == "codex"
+
 
 class TestGetSessionMapWindowIds:
     def test_includes_emdash_entries(
@@ -210,7 +237,7 @@ class TestGetSessionMapWindowIds:
                 {
                     "ccgram:@1": {"session_id": "s1", "cwd": "/a"},
                     "emdash-claude-main-abc:@0": {"session_id": "s2", "cwd": "/b"},
-                    "other:@9": {"session_id": "s3", "cwd": "/c"},
+                    "omx-project-main-abc:@90": {"session_id": "s3", "cwd": "/c"},
                 }
             )
         )
@@ -220,7 +247,7 @@ class TestGetSessionMapWindowIds:
         result = mgr._get_session_map_window_ids()
         assert "@1" in result
         assert "emdash-claude-main-abc:@0" in result
-        assert "@9" not in result  # different session prefix
+        assert "omx-project-main-abc:@90" in result
 
 
 class TestPruneStaleWindowStatesEmdash:

--- a/tests/ccgram/handlers/test_sync_command.py
+++ b/tests/ccgram/handlers/test_sync_command.py
@@ -9,6 +9,7 @@ from ccgram.handlers.sync_command import (
     _format_report,
     _probe_dead_topics,
     _recreate_dead_topics,
+    _run_audit,
     handle_sync_dismiss,
     handle_sync_fix,
     sync_command,
@@ -32,6 +33,7 @@ def _patch_deps():
         mock_tr.iter_thread_bindings.return_value = []
         mock_sm.window_states = {}
         mock_tm.list_windows = AsyncMock(return_value=[])
+        mock_tm.discover_external_sessions = AsyncMock(return_value=[])
         mock_cfg.is_user_allowed.return_value = True
         yield mock_sm, mock_sms, mock_wq, mock_tr, mock_tm, mock_cfg
 
@@ -188,6 +190,22 @@ class TestSyncCommand:
             mock_sm.audit_state.assert_called_once()
             assert "2 topics bound" in mock_reply.call_args[0][1]
 
+    async def test_audit_includes_external_windows(self, _patch_deps) -> None:
+        mock_sm, _, _, _, mock_tm, _ = _patch_deps
+        mock_tm.list_windows.return_value = [
+            MagicMock(window_id="@1", window_name="native")
+        ]
+        mock_tm.discover_external_sessions.return_value = [
+            MagicMock(window_id="omx-project:@90", window_name="omx-project")
+        ]
+
+        await _run_audit()
+
+        mock_sm.audit_state.assert_called_once_with(
+            {"@1", "omx-project:@90"},
+            [("@1", "native"), ("omx-project:@90", "omx-project")],
+        )
+
     async def test_reconciles_live_topic_names_before_reporting(
         self, _patch_deps
     ) -> None:
@@ -251,6 +269,32 @@ class TestSyncFix:
             assert mock_sm.audit_state.call_count == 2
             mock_edit.assert_called_once()
             assert "\u2705 Fixed 1 issue" in mock_edit.call_args[0][1]
+
+    async def test_fix_uses_external_windows_as_live(self, _patch_deps) -> None:
+        mock_sm, mock_sms, _, _, mock_tm, _ = _patch_deps
+        mock_tm.list_windows.return_value = [
+            MagicMock(window_id="@1", window_name="native")
+        ]
+        mock_tm.discover_external_sessions.return_value = [
+            MagicMock(window_id="omx-project:@90", window_name="omx-project")
+        ]
+        mock_sm.audit_state.side_effect = [
+            AuditResult(issues=[], total_bindings=2, live_binding_count=2),
+            AuditResult(issues=[], total_bindings=2, live_binding_count=2),
+        ]
+
+        query = MagicMock()
+
+        with patch("ccgram.handlers.sync_command.safe_edit"):
+            await handle_sync_fix(query)
+
+        live_ids = {"@1", "omx-project:@90"}
+        live_pairs = [("@1", "native"), ("omx-project:@90", "omx-project")]
+        mock_sm.sync_display_names.assert_called_once_with(live_pairs)
+        mock_sm.prune_stale_state.assert_called_once_with(live_ids)
+        mock_sms.prune_session_map.assert_called_once_with(live_ids)
+        mock_sm.prune_stale_window_states.assert_called_once_with(live_ids)
+        mock_sm.audit_state.assert_any_call(live_ids, live_pairs)
 
     async def test_fix_computes_actual_fixed_count(self, _patch_deps) -> None:
         mock_sm, _, _, _, _, _ = _patch_deps
@@ -430,6 +474,41 @@ class TestSyncFix:
             assert event.window_id == "@5"
             assert event.window_name == "stray-proj"
 
+    async def test_fix_adopts_orphaned_external_windows(self, _patch_deps) -> None:
+        mock_sm, _, mock_wq, _, _, _ = _patch_deps
+        window_id = "omx-project:@90"
+        mock_sm.audit_state.side_effect = [
+            AuditResult(
+                issues=[
+                    AuditIssue(
+                        "orphaned_window",
+                        f"{window_id} (omx-project)",
+                        fixable=True,
+                    ),
+                ],
+                total_bindings=1,
+                live_binding_count=1,
+            ),
+            AuditResult(issues=[], total_bindings=1, live_binding_count=1),
+        ]
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="omx-project"
+        )
+
+        query = MagicMock()
+
+        with (
+            patch("ccgram.handlers.sync_command.safe_edit"),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+                new_callable=AsyncMock,
+            ) as mock_handle,
+        ):
+            await handle_sync_fix(query)
+            event = mock_handle.call_args[0][0]
+            assert event.window_id == window_id
+            assert event.window_name == "omx-project"
+
     def test_orphaned_window_label(self) -> None:
         audit = AuditResult(
             issues=[
@@ -555,6 +634,35 @@ class TestDeadTopicRecreation:
             event = mock_handle.call_args[0][0]
             assert event.window_id == "@2"
             assert event.window_name == "qmd-go"
+
+    async def test_recreate_handles_foreign_window_ids(self, _patch_deps) -> None:
+        mock_sm, _, mock_wq, mock_tr, _, _ = _patch_deps
+        window_id = "omx-project-main-abc:@90"
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp/proj", window_name="omx-project-main-abc"
+        )
+        mock_tr.get_window_for_thread.return_value = window_id
+
+        issues = [
+            AuditIssue(
+                "dead_topic",
+                f"user:100 thread:42 window:{window_id} (omx-project-main-abc)",
+                fixable=True,
+            ),
+        ]
+
+        mock_bot = AsyncMock()
+
+        with patch(
+            "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+            new_callable=AsyncMock,
+        ) as mock_handle:
+            count = await _recreate_dead_topics(mock_bot, issues)
+            assert count == 1
+            mock_tr.unbind_thread.assert_called_once_with(100, 42)
+            event = mock_handle.call_args[0][0]
+            assert event.window_id == window_id
+            assert event.window_name == "omx-project-main-abc"
 
     async def test_recreate_skips_non_dead_topic_issues(self, _patch_deps) -> None:
         issues = [

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -146,9 +146,7 @@ class TestAutoDetectProvider:
         window.pane_tty = "/dev/ttys004"
 
         with (
-            patch(
-                "ccgram.handlers.topics.topic_orchestration.window_query"
-            ) as mock_wq,
+            patch("ccgram.handlers.topics.topic_orchestration.window_query") as mock_wq,
             patch(
                 "ccgram.handlers.topics.topic_orchestration.tmux_manager"
             ) as mock_tmux,
@@ -174,9 +172,7 @@ class TestAutoDetectProvider:
         window.pane_tty = "/dev/ttys004"
 
         with (
-            patch(
-                "ccgram.handlers.topics.topic_orchestration.window_query"
-            ) as mock_wq,
+            patch("ccgram.handlers.topics.topic_orchestration.window_query") as mock_wq,
             patch(
                 "ccgram.handlers.topics.topic_orchestration.tmux_manager"
             ) as mock_tmux,

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -629,6 +629,7 @@ class TestAdoptUnboundWindows:
             ),
         ):
             mock_tmux.list_windows = AsyncMock(return_value=[mock_window])
+            mock_tmux.discover_external_sessions = AsyncMock(return_value=[])
             mock_sm.audit_state.return_value = mock_audit
 
             with patch(
@@ -637,6 +638,43 @@ class TestAdoptUnboundWindows:
             ) as mock_adopt:
                 await adopt_unbound_windows(bot)
                 mock_adopt.assert_called_once()
+
+    async def test_adopts_external_orphaned_windows(self):
+        bot = AsyncMock()
+        external_window = MagicMock()
+        external_window.window_id = "omx-project:@90"
+        external_window.window_name = "omx-project"
+
+        mock_audit = MagicMock()
+        mock_issue = MagicMock()
+        mock_issue.category = "orphaned_window"
+        mock_audit.issues = [mock_issue]
+
+        with (
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.session_manager"
+            ) as mock_sm,
+            patch(
+                "ccgram.handlers.sync_command._adopt_orphaned_windows",
+                new_callable=AsyncMock,
+            ) as mock_adopt,
+        ):
+            mock_tmux.list_windows = AsyncMock(return_value=[])
+            mock_tmux.discover_external_sessions = AsyncMock(
+                return_value=[external_window]
+            )
+            mock_sm.audit_state.return_value = mock_audit
+
+            await adopt_unbound_windows(bot)
+
+        mock_sm.audit_state.assert_called_once_with(
+            {"omx-project:@90"},
+            [("omx-project:@90", "omx-project")],
+        )
+        mock_adopt.assert_called_once_with(bot, [mock_issue])
 
     async def test_no_orphans_skips(self):
         bot = AsyncMock()
@@ -652,5 +690,6 @@ class TestAdoptUnboundWindows:
             ) as mock_sm,
         ):
             mock_tmux.list_windows = AsyncMock(return_value=[])
+            mock_tmux.discover_external_sessions = AsyncMock(return_value=[])
             mock_sm.audit_state.return_value = mock_audit
             await adopt_unbound_windows(bot)

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -8,6 +8,7 @@ from telegram.error import BadRequest, RetryAfter, TelegramError, TimedOut
 
 from ccgram.handlers.topics.topic_orchestration import (
     collect_target_chats,
+    _auto_detect_provider,
     _is_window_already_bound,
     _topic_create_retry_until,
     adopt_unbound_windows,
@@ -134,6 +135,66 @@ class TestCollectTargetChats:
             mock_config.group_id = None
             result = collect_target_chats("@5")
             assert result == set()
+
+
+class TestAutoDetectProvider:
+    async def test_does_not_persist_shell_detection_for_wrapped_external_window(
+        self,
+    ) -> None:
+        window = MagicMock()
+        window.pane_current_command = "bash"
+        window.pane_tty = "/dev/ttys004"
+
+        with (
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.window_query"
+            ) as mock_wq,
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.detect_provider_from_pane",
+                new_callable=AsyncMock,
+                return_value="shell",
+            ),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.session_manager"
+            ) as mock_sm,
+        ):
+            mock_wq.view_window.return_value = None
+            mock_tmux.find_window_by_id = AsyncMock(return_value=window)
+
+            await _auto_detect_provider("omx-project:@90")
+
+        mock_sm.set_window_provider.assert_not_called()
+
+    async def test_persists_agent_provider_detection(self) -> None:
+        window = MagicMock()
+        window.pane_current_command = "codex"
+        window.pane_tty = "/dev/ttys004"
+
+        with (
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.window_query"
+            ) as mock_wq,
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.detect_provider_from_pane",
+                new_callable=AsyncMock,
+                return_value="codex",
+            ),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.session_manager"
+            ) as mock_sm,
+        ):
+            mock_wq.view_window.return_value = None
+            mock_tmux.find_window_by_id = AsyncMock(return_value=window)
+
+            await _auto_detect_provider("omx-project:@90")
+
+        mock_sm.set_window_provider.assert_called_once_with("omx-project:@90", "codex")
 
 
 class TestHandleNewWindow:

--- a/tests/ccgram/providers/test_process_detection.py
+++ b/tests/ccgram/providers/test_process_detection.py
@@ -36,6 +36,19 @@ class TestClassifyProviderFromArgs:
             ("bash ./scripts/restart.sh run", "shell"),
             ("zsh", "shell"),
             ("fish", "shell"),
+            (
+                "/bin/sh -c exec 'codex' "
+                "'--dangerously-bypass-approvals-and-sandbox'",
+                "codex",
+            ),
+            ("bash -lc 'codex --full-auto'", "codex"),
+            ("sh -c FOO=bar exec codex --full-auto", "codex"),
+            (
+                "/bin/sh -c 'OMX=1 exec 3<&0; /bin/zsh -c exec codex --full-auto'",
+                "codex",
+            ),
+            ("sh -c 'vim /path/to/claude'", ""),
+            ("sh -c 'echo; /path/to/claude'", ""),
             ("sudo codex", "codex"),
             ("env node /path/to/claude", "claude"),
             ("sudo env bun /Users/x/.bun/bin/codex", "codex"),

--- a/tests/ccgram/providers/test_process_detection.py
+++ b/tests/ccgram/providers/test_process_detection.py
@@ -37,8 +37,7 @@ class TestClassifyProviderFromArgs:
             ("zsh", "shell"),
             ("fish", "shell"),
             (
-                "/bin/sh -c exec 'codex' "
-                "'--dangerously-bypass-approvals-and-sandbox'",
+                "/bin/sh -c exec 'codex' '--dangerously-bypass-approvals-and-sandbox'",
                 "codex",
             ),
             ("bash -lc 'codex --full-auto'", "codex"),

--- a/tests/ccgram/test_external_discovery.py
+++ b/tests/ccgram/test_external_discovery.py
@@ -75,6 +75,27 @@ class TestDiscoverExternalSessions:
         assert result[0].window_id == "omc-abc:@0"
 
     @pytest.mark.asyncio
+    async def test_pattern_matched_sessions_include_shell_wrapped_windows(
+        self, manager
+    ):
+        sessions_proc = _make_proc("omx-project\nrandom-session\n")
+        omx_windows = _make_proc("@0\tbash\t/tmp/project\tbash\t/dev/ttys004\n")
+        ps_proc = _make_proc("")
+
+        with (
+            patch("ccgram.tmux_manager.asyncio.create_subprocess_exec") as mock_exec,
+            patch("ccgram.tmux_manager.config") as mock_config,
+        ):
+            mock_config.tmux_external_patterns = "omx-*"
+            mock_exec.side_effect = [sessions_proc, omx_windows, ps_proc]
+            result = await manager.discover_external_sessions()
+
+        assert len(result) == 1
+        assert result[0].window_id == "omx-project:@0"
+        assert result[0].window_name == "omx-project"
+        assert result[0].pane_current_command == "bash"
+
+    @pytest.mark.asyncio
     async def test_multiple_patterns(self, manager):
         sessions_proc = _make_proc("omc-abc\nomx-xyz\nother\n")
         omc_windows = _make_proc("@0\tagent\t/tmp\tclaude\n")
@@ -236,6 +257,22 @@ class TestScanSessionWindows:
 
         assert len(result) == 1
         assert result[0].window_id == "my-session:@0"
+
+    @pytest.mark.asyncio
+    async def test_can_include_unrecognized_windows_for_explicit_sessions(
+        self, manager
+    ):
+        proc = _make_proc("@0\tbash\t/home/user/project\tbash\n@1\tvim\t/home\tvim\n")
+
+        with patch(
+            "ccgram.tmux_manager.asyncio.create_subprocess_exec", return_value=proc
+        ):
+            result = await manager._scan_session_windows(
+                "omx-project", include_unrecognized=True
+            )
+
+        assert [w.window_id for w in result] == ["omx-project:@0", "omx-project:@1"]
+        assert result[0].window_name == "omx-project"
 
     @pytest.mark.asyncio
     async def test_detects_shell_wrapped_agent_from_tty(self, manager):

--- a/tests/ccgram/test_external_discovery.py
+++ b/tests/ccgram/test_external_discovery.py
@@ -238,6 +238,26 @@ class TestScanSessionWindows:
         assert result[0].window_id == "my-session:@0"
 
     @pytest.mark.asyncio
+    async def test_detects_shell_wrapped_agent_from_tty(self, manager):
+        windows_proc = _make_proc("@0\tbash\t/home/user/project\tbash\t/dev/ttys004\n")
+        ps_proc = _make_proc(
+            "72033 72033 Ss+ /bin/sh -c exec 'codex' '--dangerously-bypass-approvals-and-sandbox'\n"
+            "72100 72033 S+ node /Users/x/bin/codex\n"
+        )
+
+        with patch(
+            "ccgram.tmux_manager.asyncio.create_subprocess_exec",
+            side_effect=[windows_proc, ps_proc],
+        ):
+            result = await manager._scan_session_windows("omx-project-abc")
+
+        assert len(result) == 1
+        assert result[0].window_id == "omx-project-abc:@0"
+        assert result[0].window_name == "omx-project-abc"
+        assert result[0].pane_current_command == "bash"
+        assert result[0].pane_tty == "/dev/ttys004"
+
+    @pytest.mark.asyncio
     async def test_multiple_ai_windows(self, manager):
         proc = _make_proc(
             "@0\tproject-a\t/home/a\tclaude\n"

--- a/tests/ccgram/test_external_discovery.py
+++ b/tests/ccgram/test_external_discovery.py
@@ -96,6 +96,24 @@ class TestDiscoverExternalSessions:
         assert result[0].pane_current_command == "bash"
 
     @pytest.mark.asyncio
+    async def test_runtime_auto_renamed_windows_use_session_name(self, manager):
+        sessions_proc = _make_proc("omx-project\n")
+        omx_windows = _make_proc("@0\tnode\t/tmp/project\tbash\t/dev/ttys004\n")
+        ps_proc = _make_proc("")
+
+        with (
+            patch("ccgram.tmux_manager.asyncio.create_subprocess_exec") as mock_exec,
+            patch("ccgram.tmux_manager.config") as mock_config,
+        ):
+            mock_config.tmux_external_patterns = "omx-*"
+            mock_exec.side_effect = [sessions_proc, omx_windows, ps_proc]
+            result = await manager.discover_external_sessions()
+
+        assert len(result) == 1
+        assert result[0].window_id == "omx-project:@0"
+        assert result[0].window_name == "omx-project"
+
+    @pytest.mark.asyncio
     async def test_multiple_patterns(self, manager):
         sessions_proc = _make_proc("omc-abc\nomx-xyz\nother\n")
         omc_windows = _make_proc("@0\tagent\t/tmp\tclaude\n")

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -1013,8 +1013,11 @@ class TestResolveStaleIdsPreservesDeadBindings:
         alive = SimpleNamespace(window_id="@1", window_name="alive-proj")
         from ccgram.tmux_manager import tmux_manager
 
-        with patch.object(
-            tmux_manager, "list_windows", AsyncMock(return_value=[alive])
+        with (
+            patch.object(tmux_manager, "list_windows", AsyncMock(return_value=[alive])),
+            patch.object(
+                tmux_manager, "discover_external_sessions", AsyncMock(return_value=[])
+            ),
         ):
             await mgr.resolve_stale_ids()
 
@@ -1027,19 +1030,65 @@ class TestResolveStaleIdsPreservesDeadBindings:
         alive = SimpleNamespace(window_id="@1", window_name="proj")
         from ccgram.tmux_manager import tmux_manager
 
-        with patch.object(
-            tmux_manager, "list_windows", AsyncMock(return_value=[alive])
+        with (
+            patch.object(tmux_manager, "list_windows", AsyncMock(return_value=[alive])),
+            patch.object(
+                tmux_manager, "discover_external_sessions", AsyncMock(return_value=[])
+            ),
         ):
             await mgr.resolve_stale_ids()
 
         assert thread_router.get_window_for_thread(100, 1) == "@1"
+
+    async def test_foreign_session_map_entry_not_pruned_on_startup(
+        self, mgr: SessionManager, tmp_path, monkeypatch
+    ) -> None:
+        foreign_wid = "omx-project-main-abc:@90"
+        session_map_file = tmp_path / "session_map.json"
+        session_map_file.write_text(
+            json.dumps(
+                {
+                    foreign_wid: {
+                        "session_id": "sid-omx",
+                        "cwd": "/tmp/project",
+                        "window_name": "omx-project-main-abc",
+                        "provider_name": "codex",
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr("ccgram.session.config.session_map_file", session_map_file)
+
+        external = SimpleNamespace(
+            window_id=foreign_wid,
+            window_name="omx-project-main-abc",
+        )
+        from ccgram.tmux_manager import tmux_manager
+
+        with (
+            patch.object(tmux_manager, "list_windows", AsyncMock(return_value=[])),
+            patch.object(
+                tmux_manager,
+                "discover_external_sessions",
+                AsyncMock(return_value=[external]),
+            ),
+        ):
+            await mgr.resolve_stale_ids()
+
+        result = json.loads(session_map_file.read_text())
+        assert foreign_wid in result
 
     async def test_dead_window_state_preserved(self, mgr: SessionManager) -> None:
         thread_router.bind_thread(100, 1, "@1", window_name="proj")
         mgr.window_states["@1"] = WindowState(cwd="/my/project", provider_name="codex")
         from ccgram.tmux_manager import tmux_manager
 
-        with patch.object(tmux_manager, "list_windows", AsyncMock(return_value=[])):
+        with (
+            patch.object(tmux_manager, "list_windows", AsyncMock(return_value=[])),
+            patch.object(
+                tmux_manager, "discover_external_sessions", AsyncMock(return_value=[])
+            ),
+        ):
             await mgr.resolve_stale_ids()
 
         assert "@1" in mgr.window_states

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -59,6 +59,29 @@ class TestResolveChatId:
         assert thread_router.resolve_chat_id(100) == 100
 
 
+class TestAuditExternalWindows:
+    def test_unbound_foreign_window_is_orphan_even_without_prior_state(
+        self, mgr: SessionManager
+    ) -> None:
+        result = mgr.audit_state(
+            {"omx-project:@90"},
+            [("omx-project:@90", "omx-project")],
+        )
+
+        assert any(
+            issue.category == "orphaned_window"
+            and issue.detail == "omx-project:@90 (omx-project)"
+            for issue in result.issues
+        )
+
+    def test_unbound_unknown_native_window_is_not_orphan(
+        self, mgr: SessionManager
+    ) -> None:
+        result = mgr.audit_state({"@90"}, [("@90", "scratch")])
+
+        assert not any(issue.category == "orphaned_window" for issue in result.issues)
+
+
 class TestWindowState:
     def test_get_creates_new(self, mgr: SessionManager) -> None:
         state = window_store.get_window_state("@0")

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -111,6 +111,31 @@ class TestNewWindowDetection:
 
         cb.assert_not_called()
 
+    async def test_new_hookless_transcript_is_marked_for_initial_replay(
+        self, monitor: SessionMonitor
+    ) -> None:
+        monitor._last_session_map = {}
+        new_map = {
+            "@9": {
+                "session_id": "codex-new",
+                "cwd": "/proj",
+                "window_name": "proj",
+                "transcript_path": "/tmp/codex.jsonl",
+                "provider_name": "codex",
+            }
+        }
+
+        with patch.object(
+            monitor,
+            "_load_current_session_map",
+            spec=True,
+            new_callable=AsyncMock,
+            return_value=new_map,
+        ):
+            await monitor._detect_and_cleanup_changes()
+
+        assert "codex-new" in monitor._initial_replay_sessions
+
     async def test_callback_error_does_not_crash(self, monitor: SessionMonitor) -> None:
         cb = AsyncMock(side_effect=RuntimeError("boom"))
         monitor.set_new_window_callback(cb)
@@ -212,10 +237,20 @@ class TestPerWindowProviderResolution:
         captured_window_ids = []
         original = monitor._process_session_file
 
-        async def spy(session_id, file_path, new_messages, window_id=""):
+        async def spy(
+            session_id,
+            file_path,
+            new_messages,
+            window_id="",
+            replay_initial=False,
+        ):
             captured_window_ids.append(window_id)
             return await original(
-                session_id, file_path, new_messages, window_id=window_id
+                session_id,
+                file_path,
+                new_messages,
+                window_id=window_id,
+                replay_initial=replay_initial,
             )
 
         monitor._process_session_file = spy
@@ -383,6 +418,46 @@ class TestCheckForUpdates:
         tracked = monitor.state.get_session("sess-direct")
         assert tracked is not None
         assert tracked.last_byte_offset == session_file.stat().st_size
+
+    async def test_new_hookless_session_replays_initial_transcript(
+        self, tmp_path
+    ) -> None:
+        """A live-discovered hookless session must not drop its first response."""
+        session_file = tmp_path / "codex.jsonl"
+        session_file.write_text(
+            "\n".join(
+                [
+                    '{"type":"session_meta","payload":{"id":"sess-codex","cwd":"/proj"}}',
+                    '{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first question"}]}}',
+                    "",
+                ]
+            )
+        )
+
+        monitor = SessionMonitor(
+            projects_path=tmp_path / "projects",
+            state_file=tmp_path / "ms.json",
+        )
+        monitor._initial_replay_sessions.add("sess-codex")
+        current_map = {
+            "@0": {
+                "session_id": "sess-codex",
+                "cwd": "/proj",
+                "window_name": "proj",
+                "transcript_path": str(session_file),
+                "provider_name": "codex",
+            },
+        }
+
+        with patch(
+            "ccgram.transcript_reader.get_provider_for_window",
+            return_value=CodexProvider(),
+        ):
+            msgs = await monitor.check_for_updates(current_map)
+
+        assert len(msgs) == 1
+        assert msgs[0].text == "first question"
+        assert "sess-codex" not in monitor._initial_replay_sessions
 
     async def test_unchanged_mtime_skips_read(self, tmp_path) -> None:
         projects_path = tmp_path / "projects"

--- a/tests/ccgram/test_state_migration.py
+++ b/tests/ccgram/test_state_migration.py
@@ -31,3 +31,16 @@ class TestSessionMapParsing:
         result = parse_session_map(raw, "ccgram:")
         assert result["@0"]["session_id"] == "abc-123"
         assert result["@0"]["cwd"] == "/tmp/project"
+
+    def test_foreign_session_map_parsing(self) -> None:
+        window_id = "omx-project-main-abc:@90"
+        raw = {
+            window_id: {
+                "session_id": "sid-omx",
+                "cwd": "/tmp/project",
+                "provider_name": "codex",
+            }
+        }
+        result = parse_session_map(raw, "ccgram:")
+        assert result[window_id]["session_id"] == "sid-omx"
+        assert result[window_id]["provider_name"] == "codex"


### PR DESCRIPTION
## Summary

Adds support for controlling external tmux sessions such as OMX/OMC sessions from ccgram when they match `TMUX_EXTERNAL_PATTERNS`.

## What changed

- Discover configured external tmux sessions and include them in startup recovery, monitor pruning, `/sync`, and `/sync Fix` live-window sets.
- Generalize foreign window IDs beyond emdash so qualified IDs like `omx-project:@90` stay routable and recoverable.
- Detect agent providers inside shell-wrapped panes via TTY process inspection, including OMX shell wrappers that launch Codex under `bash`/`zsh`.
- Use the external session name instead of generic shell window names like `bash` for auto-created Telegram topic names.
- Extend tests for external discovery, session-map parsing, startup preservation, sync repair, and provider detection.

## Validation

- `uv run --extra dev pytest tests/ccgram/providers/test_process_detection.py tests/ccgram/handlers/topics/test_topic_orchestration.py::TestAdoptUnboundWindows tests/ccgram/handlers/test_sync_command.py tests/ccgram/test_external_discovery.py tests/ccgram/handlers/test_emdash_integration.py tests/ccgram/test_state_migration.py tests/ccgram/test_session.py::TestResolveStaleIdsPreservesDeadBindings -q`
- `uv run --extra dev ruff check src/ccgram/handlers/sync_command.py src/ccgram/handlers/topics/topic_orchestration.py src/ccgram/providers/__init__.py src/ccgram/providers/process_detection.py src/ccgram/session.py src/ccgram/session_map.py src/ccgram/tmux_manager.py tests/ccgram/handlers/test_emdash_integration.py tests/ccgram/handlers/test_sync_command.py tests/ccgram/handlers/topics/test_topic_orchestration.py tests/ccgram/providers/test_process_detection.py tests/ccgram/test_external_discovery.py tests/ccgram/test_session.py tests/ccgram/test_state_migration.py`
- `git diff --check`

## Notes

A full `make test` run in my local environment still fails on unrelated messaging pipeline mock assertions and missing optional `edge_tts`; those files are not touched by this PR.
