### PR TITLE
Clear deleted Telegram topic bindings

### DIFF
--- a/src/ccgram/telegram_draft.py
+++ b/src/ccgram/telegram_draft.py
@@ -61,6 +61,43 @@ _KEEP_MARKUP: Final[Any] = object()
 
 logger = structlog.get_logger()
 
+
+def _is_thread_gone_error(exc: TelegramError) -> bool:
+    """Return True when Telegram says the target topic/thread is gone."""
+    if not isinstance(exc, BadRequest):
+        return False
+    message = (exc.message or "").lower()
+    return "thread not found" in message or "topic_id_invalid" in message
+
+
+def _clear_dead_thread_binding(chat_id: int, thread_id: int | None) -> None:
+    """Unbind deleted Telegram topics while preserving the group chat hint."""
+    if thread_id is None:
+        return
+    try:
+        # Lazy: DraftStream is lower-level transport code; importing router at
+        # module import time would make transport import the bot state graph.
+        from .thread_router import thread_router
+
+        for user_id, bound_thread_id, window_id in list(
+            thread_router.iter_thread_bindings()
+        ):
+            if bound_thread_id != thread_id:
+                continue
+            if thread_router.resolve_chat_id(user_id, thread_id) != chat_id:
+                continue
+            thread_router.unbind_thread(user_id, thread_id)
+            if chat_id < 0:
+                thread_router.set_group_chat_id(user_id, thread_id, chat_id)
+            logger.info(
+                "Removed stale topic binding after Telegram thread-gone error",
+                user_id=user_id,
+                thread_id=thread_id,
+                window_id=window_id,
+            )
+    except OSError:
+        logger.exception("Failed to persist stale topic binding cleanup")
+
 __all__ = [
     "DRAFT_LEGACY",
     "DRAFT_STREAMING",
@@ -254,12 +291,16 @@ class DraftStream:
             else:
                 await self._start_streaming()
         except (TimedOut, NetworkError) as exc:
+            if _is_thread_gone_error(exc):
+                _clear_dead_thread_binding(self._chat_id, self._thread_id)
             logger.warning("DraftStream.start transient failure: %s", exc)
             return None
         except RetryAfter as exc:
             logger.warning("DraftStream.start rate-limited: %s", exc)
             return None
         except TelegramError as exc:
+            if _is_thread_gone_error(exc):
+                _clear_dead_thread_binding(self._chat_id, self._thread_id)
             logger.warning("DraftStream.start telegram error: %s", exc)
             return None
         return self._message_id

--- a/tests/ccgram/test_telegram_draft.py
+++ b/tests/ccgram/test_telegram_draft.py
@@ -236,6 +236,30 @@ class TestDraftStreamTransientLegacyFailure:
         bot.send_message.assert_not_awaited()
 
 
+class TestDraftStreamDeadTopicCleanup:
+    async def test_thread_gone_unbinds_matching_group_topic(self) -> None:
+        mark_draft_unavailable("test")
+        bot = _make_bot()
+        bot.send_message.side_effect = BadRequest("Message thread not found")
+        router = MagicMock()
+        router.iter_thread_bindings.return_value = [
+            (100, 5, "@1"),
+            (200, 5, "@2"),
+        ]
+        router.resolve_chat_id.side_effect = (
+            lambda user_id, _thread_id: -999 if user_id == 100 else -998
+        )
+
+        stream = DraftStream(bot, chat_id=-999, message_thread_id=5)
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr("ccgram.thread_router.thread_router", router)
+            mid = await stream.start("hi")
+
+        assert mid is None
+        router.unbind_thread.assert_called_once_with(100, 5)
+        router.set_group_chat_id.assert_called_once_with(100, 5, -999)
+
+
 class TestDraftStreamPeerCache:
     async def test_peer_invalid_caches_per_peer(self) -> None:
         bot = _make_bot()


### PR DESCRIPTION
## Summary

Clears stale Telegram topic bindings when Telegram reports that a target forum topic/thread no longer exists during draft stream startup.

## What changed

- Detect `Message thread not found` and `TOPIC_ID_INVALID` startup failures.
- Unbind the stale topic from ccgram state while preserving the group chat hint for future topic recreation.
- Cover both transient and generic Telegram error paths during `DraftStream.start`.
- Add a regression test for cleaning only the matching group/topic binding.

## Validation

- `uv run --extra dev pytest tests/ccgram/test_telegram_draft.py -q`
- `uv run --extra dev ruff check src/ccgram/telegram_draft.py tests/ccgram/test_telegram_draft.py`
- `git diff --check`

## Notes

A full `make test` run in my local environment still fails on unrelated messaging pipeline mock assertions and missing optional `edge_tts`; those files are not touched by this PR.
