### PR TITLE
Avoid binding hookless codex sessions to an already-used session id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "python-telegram-bot[rate-limiter]>=21.0",
+    "python-telegram-bot[socks,rate-limiter]>=21.0",
     "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "libtmux>=0.50.0",

--- a/src/ccgram/handlers/recovery/transcript_discovery.py
+++ b/src/ccgram/handlers/recovery/transcript_discovery.py
@@ -38,6 +38,26 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 
+def _session_id_already_bound(session_id: str, window_id: str) -> bool:
+    """Return True if another currently bound window already uses ``session_id``."""
+    # Lazy: thread_router may not be installed in some test paths; fail open
+    # if it isn't available so discovery can still continue with this window.
+    from ...thread_router import thread_router
+
+    try:
+        iterator = thread_router.iter_thread_bindings()
+    except RuntimeError:
+        return False
+
+    for _user_id, _thread_id, bound_window_id in iterator:
+        if bound_window_id == window_id:
+            continue
+        state = window_store.window_states.get(bound_window_id)
+        if state and state.session_id == session_id:
+            return True
+    return False
+
+
 async def _detect_and_apply_provider(
     window_id: str,
     state: "WindowState",
@@ -157,6 +177,14 @@ async def _find_and_register_transcript(
             max_age=max_age,
         )
         if not event:
+            continue
+
+        if _session_id_already_bound(event.session_id, window_id):
+            logger.debug(
+                "Skipping discover result for window %s: session_id %s already bound",
+                window_id,
+                event.session_id,
+            )
             continue
 
         if (

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -1343,6 +1343,69 @@ class TestMaybeDiscoverTranscript:
             provider_name="codex",
         )
 
+    async def test_skips_session_if_already_bound_to_other_window(self) -> None:
+        from ccgram.handlers.recovery.transcript_discovery import (
+            discover_and_register_transcript,
+        )
+        from ccgram.providers.base import SessionStartEvent
+
+        mock_provider = MagicMock()
+        mock_provider.capabilities.supports_hook = False
+        mock_provider.capabilities.name = "codex"
+        event = SessionStartEvent(
+            session_id="shared-session",
+            cwd="/my/project",
+            transcript_path="/path/to/transcript.jsonl",
+            window_key="ccgram:@7",
+        )
+        mock_provider.discover_transcript.return_value = event
+
+        mock_router = MagicMock()
+        mock_router.iter_thread_bindings.return_value = [
+            (123, 42, "@7"),
+            (321, 7, "@9"),
+        ]
+
+        with (
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.session_manager"
+            ) as mock_sm,  # noqa: F841
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.window_store"
+            ) as mock_ws,  # noqa: F841
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.session_map_sync"
+            ) as mock_sms,
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.get_provider_for_window",
+                return_value=mock_provider,
+            ),
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.config"
+            ) as mock_config,
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.tmux_manager"
+            ) as mock_tmux,
+            patch("ccgram.thread_router.thread_router", mock_router),
+        ):
+            mock_ws.window_states = {
+                "@7": MagicMock(session_id="", cwd="/my/project", provider_name="codex"),
+                "@9": MagicMock(
+                    session_id="shared-session",
+                    cwd="/my/project",
+                    provider_name="codex",
+                ),
+            }
+            mock_config.tmux_session_name = "ccgram"
+            mock_tmux.find_window_by_id = AsyncMock(
+                return_value=MagicMock(pane_current_command="bun")
+            )
+            mock_tmux.get_pane_title = AsyncMock(return_value="")
+            await discover_and_register_transcript("@7")
+
+        mock_sms.register_hookless_session.assert_not_called()
+        mock_sms.write_hookless_session_map.assert_not_called()
+
     async def test_updates_when_new_session_discovered_for_same_window(self) -> None:
         from ccgram.handlers.recovery.transcript_discovery import (
             discover_and_register_transcript,
@@ -1573,6 +1636,91 @@ class TestMaybeDiscoverTranscript:
             cwd="/proj",
             transcript_path="/path/to/transcript.jsonl",
             provider_name="codex",
+        )
+
+    async def test_tries_next_provider_when_session_conflicts_with_bound_window(self) -> None:
+        from ccgram.handlers.recovery.transcript_discovery import (
+            discover_and_register_transcript,
+        )
+        from ccgram.providers.base import SessionStartEvent
+
+        conflicting_event = SessionStartEvent(
+            session_id="uuid-in-use",
+            cwd="/proj",
+            transcript_path="/path/to/in-use.jsonl",
+            window_key="ccgram:@7",
+        )
+        alternative_event = SessionStartEvent(
+            session_id="uuid-new",
+            cwd="/proj",
+            transcript_path="/path/to/alt.jsonl",
+            window_key="ccgram:@7",
+        )
+
+        mock_codex = MagicMock()
+        mock_codex.capabilities.supports_hook = False
+        mock_codex.capabilities.name = "codex"
+        mock_codex.discover_transcript.return_value = conflicting_event
+
+        mock_gemini = MagicMock()
+        mock_gemini.capabilities.supports_hook = False
+        mock_gemini.capabilities.name = "gemini"
+        mock_gemini.discover_transcript.return_value = alternative_event
+
+        mock_registry = MagicMock()
+        mock_registry.provider_names.return_value = ["codex", "gemini"]
+
+        def mock_get(name: str) -> MagicMock:
+            return {"codex": mock_codex, "gemini": mock_gemini}[name]
+
+        mock_registry.get = mock_get
+        mock_router = MagicMock()
+        mock_router.iter_thread_bindings.return_value = [(123, 42, "@9")]
+
+        mock_bound_state = MagicMock(
+            session_id="uuid-in-use",
+            cwd="/proj",
+            provider_name="codex",
+        )
+
+        with (
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.session_manager"
+            ) as mock_sm,  # noqa: F841
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.window_store"
+            ) as mock_ws,  # noqa: F841
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.session_map_sync"
+            ) as mock_sms,
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.recovery.transcript_discovery.config"
+            ) as mock_config,
+            patch("ccgram.providers.registry", mock_registry),
+            patch("ccgram.thread_router.thread_router", mock_router),
+        ):
+            mock_ws.window_states = {
+                "@7": MagicMock(session_id="", cwd="/proj", provider_name=""),
+                "@9": mock_bound_state,
+            }
+            mock_config.tmux_session_name = "ccgram"
+            mock_tmux.find_window_by_id = AsyncMock(
+                return_value=MagicMock(pane_current_command="bun")
+            )
+            mock_tmux.get_pane_title = AsyncMock(return_value="")
+            await discover_and_register_transcript("@7")
+
+        mock_codex.discover_transcript.assert_called_once()
+        mock_gemini.discover_transcript.assert_called_once()
+        mock_sms.register_hookless_session.assert_called_once_with(
+            window_id="@7",
+            session_id="uuid-new",
+            cwd="/proj",
+            transcript_path="/path/to/alt.jsonl",
+            provider_name="gemini",
         )
 
     async def test_skips_hookless_fallback_when_pane_is_shell(self) -> None:

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -1389,7 +1389,9 @@ class TestMaybeDiscoverTranscript:
             patch("ccgram.thread_router.thread_router", mock_router),
         ):
             mock_ws.window_states = {
-                "@7": MagicMock(session_id="", cwd="/my/project", provider_name="codex"),
+                "@7": MagicMock(
+                    session_id="", cwd="/my/project", provider_name="codex"
+                ),
                 "@9": MagicMock(
                     session_id="shared-session",
                     cwd="/my/project",
@@ -1638,7 +1640,9 @@ class TestMaybeDiscoverTranscript:
             provider_name="codex",
         )
 
-    async def test_tries_next_provider_when_session_conflicts_with_bound_window(self) -> None:
+    async def test_tries_next_provider_when_session_conflicts_with_bound_window(
+        self,
+    ) -> None:
         from ccgram.handlers.recovery.transcript_discovery import (
             discover_and_register_transcript,
         )

--- a/tests/ccgram/test_telegram_request.py
+++ b/tests/ccgram/test_telegram_request.py
@@ -1,5 +1,7 @@
 """Tests for resilient Telegram polling requests."""
 
+from pathlib import Path
+import tomllib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -120,3 +122,16 @@ class TestCreateBotPollingRequest:
         assert isinstance(app.bot._request[1], ResilientPollingHTTPXRequest)
         assert app.bot._request[0]._client._transport._pool._max_connections == 1
         assert app.bot._request[1]._client._transport._pool._max_connections == 256
+
+
+class TestProjectDependencies:
+    def test_declares_ptb_socks_support(self) -> None:
+        project_root = Path(__file__).resolve().parents[2]
+        pyproject = tomllib.loads((project_root / "pyproject.toml").read_text())
+        dependencies = pyproject["project"]["dependencies"]
+
+        assert any(
+            dependency.startswith("python-telegram-bot[")
+            and "socks" in dependency.partition("[")[2].partition("]")[0].split(",")
+            for dependency in dependencies
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pyte" },
     { name = "python-dotenv" },
-    { name = "python-telegram-bot", extra = ["rate-limiter"] },
+    { name = "python-telegram-bot", extra = ["rate-limiter", "socks"] },
     { name = "structlog" },
     { name = "telegramify-markdown" },
 ]
@@ -170,7 +170,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "python-telegram-bot", extras = ["rate-limiter"], specifier = ">=21.0" },
+    { name = "python-telegram-bot", extras = ["rate-limiter", "socks"], specifier = ">=21.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "telegramify-markdown", specifier = ">=1.0.0" },
@@ -371,6 +371,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -753,6 +758,9 @@ wheels = [
 rate-limiter = [
     { name = "aiolimiter" },
 ]
+socks = [
+    { name = "httpx", extra = ["socks"] },
+]
 
 [[package]]
 name = "requirements-parser"
@@ -789,6 +797,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
     { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
     { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

When ccgram auto-discovers hookless transcripts, it previously allowed a new window to bind a session_id that was already associated with another active window/topic, causing multiple windows with the same name to share the same Telegram topic flow.

## Changes

- In transcript discovery, skip any discovered session_id that is already bound to a different window.
- Continue discovery with fallback providers when a binding conflict is detected.
- Add regression tests to verify conflict skipping and fallback behavior.

## Validation

- ........................................................................ [ 58%]
...................................................                      [100%]
123 passed in 0.60s
- ......................                                                   [100%]
22 passed in 0.15s