### PR TITLE
feat: multi-provider hook support (Codex, Gemini, Pi)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,19 +119,19 @@ When creating a topic via the directory browser, users can choose the provider (
 
 ### Provider Capability Matrix
 
-| Capability       | Claude                          | Codex              | Gemini                      | Pi                       | Shell                       |
-| ---------------- | ------------------------------- | ------------------ | --------------------------- | ------------------------ | --------------------------- |
-| Hook events      | Yes (all supported event types) | No                 | No                          | No                       | No                          |
-| Resume           | Yes (`--resume`)                | Yes (`resume`)     | Yes (`--resume idx/latest`) | Yes (`--session <path>`) | No                          |
-| Continue         | Yes                             | Yes                | Yes                         | Yes                      | No                          |
-| Transcript       | JSONL                           | JSONL              | JSONL (incremental)         | JSONL (v3)               | None                        |
-| Incremental read | Yes                             | Yes                | Yes                         | Yes                      | No                          |
-| Commands         | Yes                             | Yes                | Yes                         | Yes (builtins + skills)  | No                          |
-| Status detection | Hook events + pyte + spinner    | Activity heuristic | Pane title + interactive UI | Transcript activity      | Shell prompt idle detection |
-| YOLO auto-accept | Yes                             | No                 | No                          | No                       | No                          |
-| Mode scraping    | Yes (mode-line parse)           | No                 | No                          | No                       | No                          |
+| Capability       | Claude                          | Codex                          | Gemini                                                           | Pi                              | Shell                       |
+| ---------------- | ------------------------------- | ------------------------------ | ---------------------------------------------------------------- | ------------------------------- | --------------------------- |
+| Hook events      | Yes (all supported event types) | Yes (`SessionStart`, `Stop`)   | Yes (`SessionStart`, `AfterAgent`, `SessionEnd`, `Notification`) | Yes via hook-runner             | No                          |
+| Resume           | Yes (`--resume`)                | Yes (`resume`)                 | Yes (`--resume idx/latest`)                                      | Yes (`--session <path>`)        | No                          |
+| Continue         | Yes                             | Yes                            | Yes                                                              | Yes                             | No                          |
+| Transcript       | JSONL                           | JSONL                          | JSONL (incremental)                                              | JSONL (v3)                      | None                        |
+| Incremental read | Yes                             | Yes                            | Yes                                                              | Yes                             | No                          |
+| Commands         | Yes                             | Yes                            | Yes                                                              | Yes (builtins + skills)         | No                          |
+| Status detection | Hook events + pyte + spinner    | Stop hook + activity heuristic | AfterAgent hook + pane title                                     | Stop hook + transcript activity | Shell prompt idle detection |
+| YOLO auto-accept | Yes                             | No                             | No                                                               | No                              | No                          |
+| Mode scraping    | Yes (mode-line parse)           | No                             | No                                                               | No                              | No                          |
 
-Capabilities gate UX per-window: recovery keyboard only shows Continue/Resume buttons when supported; `ccgram doctor` checks all hook event types for Claude. Codex, Gemini, Pi, and Shell have no hooks — session tracking for these providers relies on auto-detection from running processes.
+Capabilities gate UX per-window: recovery keyboard only shows Continue/Resume buttons when supported; `ccgram doctor` checks managed hook installs for Claude, Codex, and Gemini. Pi hook support is supplied by cc-thingz hook-runner; transcript/process detection remains fallback for all non-shell agents.
 
 ### Shell Prompt Configuration
 
@@ -239,11 +239,11 @@ Providers absent from the TOML keep their built-in defaults. Malformed entries a
 
 ### Migration Notes
 
-Existing Claude deployments need no changes — `claude` is the default provider. Windows without an explicit `provider_name` fall back to the config default. The hook subsystem (`ccgram hook --install`) is Claude-specific and skipped for other providers.
+Existing Claude deployments need no changes — `claude` is the default provider. Windows without an explicit `provider_name` fall back to the config default. The hook subsystem (`ccgram hook --install`) defaults to Claude; pass `--provider {codex,gemini,pi}` to manage other providers. Codex and Gemini hook installs are ccgram-managed (settings written into `~/.codex/hooks.json` + `~/.codex/config.toml` and `~/.gemini/settings.json` respectively). Pi hooks are owned by the cc-thingz hook-runner extension — ccgram receives Pi events but does not modify Pi configuration. Shell windows have no hooks. When hooks are absent or fail, providers with JSONL transcripts (Codex/Gemini/Pi) fall back to transcript-scan discovery, so missing hooks degrade latency rather than functionality.
 
 ### Pi Provider
 
-[Pi](https://pi.dev) is a Node.js-based coding agent CLI with JSONL v3 transcripts and no hook subsystem, so session discovery follows the Codex/Gemini pattern (hookless `discover_transcript()`). Transcripts live under `~/.pi/agent/sessions/--<encoded-cwd>--/<timestamp>_<uuid>.jsonl`; the canonical session id sits in the header line (`{"type":"session","id":"<uuid>","cwd":"...","version":3}`). Resume always uses `--session <path>` — `--resume` would open an interactive picker ccgram can't drive. Command discovery (`pi_discovery.py`) surfaces Telegram-friendly builtins (`/clear`, `/compact`, `/export`, `/name`, `/reload`, `/session`, `/share`, `/changelog`) plus on-disk sources: skills under `.pi/skills`, `.agents/skills`, `~/.pi/agent/skills`, and `~/.agents/skills`; prompt templates under `.pi/prompts` and `~/.pi/agent/prompts`; extension commands via `pi.registerCommand(...)` scans in `.pi/extensions` and `~/.pi/agent/extensions`.
+[Pi](https://pi.dev) is a Node.js-based coding agent CLI with JSONL v3 transcripts and hook support via cc-thingz hook-runner. The extension sends `SessionStart`, `Stop`, `SessionEnd`, and subagent events to `ccgram hook`; transcript discovery remains fallback and message source of truth. Transcripts live under `~/.pi/agent/sessions/--<encoded-cwd>--/<timestamp>_<uuid>.jsonl`; the canonical session id sits in the header line (`{"type":"session","id":"<uuid>","cwd":"...","version":3}`). Resume always uses `--session <path>` — `--resume` would open an interactive picker ccgram can't drive. Command discovery (`pi_discovery.py`) surfaces Telegram-friendly builtins (`/clear`, `/compact`, `/export`, `/name`, `/reload`, `/session`, `/share`, `/changelog`) plus on-disk sources: skills under `.pi/skills`, `.agents/skills`, `~/.pi/agent/skills`, and `~/.agents/skills`; prompt templates under `.pi/prompts` and `~/.pi/agent/prompts`; extension commands via `pi.registerCommand(...)` scans in `.pi/extensions` and `~/.pi/agent/extensions`.
 
 ## Testing
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -4,13 +4,13 @@ CCGram supports multiple agent CLI backends. Each Telegram topic can use a diffe
 
 ## Overview
 
-| Provider    | CLI Command | Hook Events | Resume | Continue | Transcript | Status Detection                                          |
-| ----------- | ----------- | ----------- | ------ | -------- | ---------- | --------------------------------------------------------- |
-| Claude Code | `claude`    | Yes         | Yes    | Yes      | JSONL      | Hook events + pyte VT100 + spinner                        |
-| Codex CLI   | `codex`     | No          | Yes    | Yes      | JSONL      | pyte VT100 interactive UI + transcript activity heuristic |
-| Gemini CLI  | `gemini`    | No          | Yes    | Yes      | JSONL      | Pane title + interactive UI + `/status` snapshot          |
-| Pi          | `pi`        | No          | Yes    | Yes      | JSONL (v3) | Transcript activity heuristic                             |
-| Shell       | `bash`      | No          | No     | No       | None       | Shell prompt idle detection                               |
+| Provider    | CLI Command | Hook Events | Resume | Continue | Transcript | Status Detection                                                      |
+| ----------- | ----------- | ----------- | ------ | -------- | ---------- | --------------------------------------------------------------------- |
+| Claude Code | `claude`    | Yes         | Yes    | Yes      | JSONL      | Hook events + pyte VT100 + spinner                                    |
+| Codex CLI   | `codex`     | Yes         | Yes    | Yes      | JSONL      | Hook Stop + pyte VT100 interactive UI + transcript activity heuristic |
+| Gemini CLI  | `gemini`    | Yes         | Yes    | Yes      | JSONL      | Hook AfterAgent + pane title + interactive UI + `/status` snapshot    |
+| Pi          | `pi`        | Yes         | Yes    | Yes      | JSONL (v3) | Hook-runner Stop + transcript activity heuristic                      |
+| Shell       | `bash`      | No          | No     | No       | None       | Shell prompt idle detection                                           |
 
 ## Choosing a Provider
 
@@ -75,11 +75,11 @@ The bot also detects Remote Control mode (📡 topic badge + one-tap activation 
 
 ### Hooks
 
-Install hooks with `ccgram hook --install`. This is Claude-specific and not needed for other providers.
+Install hooks with `ccgram hook --install`.
 
 If hooks are missing, ccgram warns at startup with the fix command. Hooks are optional — terminal scraping works as fallback.
 
-### Transcript
+### Claude Transcript
 
 Claude transcripts are JSONL files under `~/.claude/projects/`. They are read incrementally (byte offsets) for efficient polling.
 
@@ -89,7 +89,7 @@ Claude task state is derived from the transcript, not from terminal footer scrap
 
 ## Codex CLI
 
-Codex CLI lacks a session hook, so session tracking relies on hookless transcript discovery plus provider detection from the running process name.
+Codex CLI supports feature-flagged hooks. Install ccgram's lifecycle hooks with `ccgram hook --provider codex --install`; ccgram writes user-level `~/.codex/hooks.json` entries for `SessionStart` and `Stop` and enables `[features].codex_hooks = true` in `~/.codex/config.toml`. Transcript discovery remains as fallback and as the source of message truth.
 
 ### Interactive Prompts
 
@@ -124,13 +124,13 @@ Press enter to confirm or esc to cancel
 
 For Codex, `/status` sends a transcript-based fallback snapshot in Telegram (session/cwd/token/rate-limit summary) because some Codex builds render status in the terminal UI without emitting a transcript assistant message.
 
-### Transcript
+### Codex Transcript
 
 Codex transcripts are JSONL files under `~/.codex/sessions/`. They are read incrementally (byte offsets).
 
 ## Gemini CLI
 
-Gemini CLI lacks a session hook. Session tracking relies on hookless transcript discovery plus provider detection.
+Gemini CLI supports command hooks in `settings.json`. Install ccgram's lifecycle hooks with `ccgram hook --provider gemini --install`; ccgram writes user-level `~/.gemini/settings.json` entries for `SessionStart`, `AfterAgent`, `SessionEnd`, and `Notification`. Transcript discovery remains as fallback and as the source of message truth.
 
 Gemini sets pane titles (`Working: ✦`, `Action Required: ✋`, `Ready: ◇`) that CCGram reads for status, and its `@inquirer/select` permission prompts are detected as interactive UI. Gemini transcript discovery matches project hash/alias only (no cross-project full scan) to avoid wrong-session attachment.
 
@@ -138,7 +138,7 @@ Gemini sets pane titles (`Working: ✦`, `Action Required: ✋`, `Ready: ◇`) t
 
 For ccgram-managed Gemini launches, CCGram injects `GEMINI_CLI_SYSTEM_SETTINGS_PATH=~/.ccgram/gemini-system-settings.json` with `tools.shell.enableInteractiveShell=false` to avoid node-pty `EBADF` crashes in tmux. If you set `CCGRAM_GEMINI_COMMAND`, your override is used as-is.
 
-### Transcript
+### Gemini Transcript
 
 As of Gemini CLI v0.40+, transcripts are append-only JSONL files under `~/.gemini/tmp/<project-hash>/chats/`. Each line is a JSON record (header with `sessionId`/`projectHash`/`startTime`, then message records and `{"$set": {...}}` metadata updates). CCGram reads them incrementally via the shared `JsonlProvider` byte-offset reader and dedupes repeated message ids and pending tool_use ids — a single tool announcement, then one tool_result on the update that carries the result.
 
@@ -150,7 +150,7 @@ Gemini supports `/status` snapshots: CCGram parses recent transcript activity to
 
 ## Pi
 
-[Pi](https://pi.dev) is a Node.js-based CLI with JSONL v3 transcripts and no hook subsystem. Session tracking follows the Codex/Gemini pattern: ccgram scans `~/.pi/agent/sessions/--<encoded-cwd>--/` for the newest transcript whose header `cwd` matches the window working directory.
+[Pi](https://pi.dev) is a Node.js-based CLI with JSONL v3 transcripts. With the `hook-runner` extension from `cc-thingz`, Pi emits Claude-compatible lifecycle hooks to `ccgram hook` for instant `SessionStart`, `Stop`, `SessionEnd`, and subagent signals. Without hook-runner, session tracking falls back to scanning `~/.pi/agent/sessions/--<encoded-cwd>--/` for the newest transcript whose header `cwd` matches the window working directory.
 
 ### Launch
 
@@ -160,7 +160,7 @@ The default command is `pi`. Override via `CCGRAM_PI_COMMAND` to change models, 
 
 Resume always uses `--session <path-or-uuid>`. Pi's `--resume` flag opens an interactive picker ccgram can't drive over `send_keys`, so ccgram always passes the resolved transcript path (or UUID prefix) directly. Pi's own `--continue` is used for the Continue recovery button.
 
-### Transcript
+### Pi Transcript
 
 Pi transcripts are JSONL files (v3 format) under `~/.pi/agent/sessions/--<encoded-cwd>--/<timestamp>_<uuid>.jsonl`. The canonical session id lives in the header line (`{"type":"session","id":"<uuid>","cwd":"...","version":3}`) — the filename prefix is just a timestamp. Transcripts are read incrementally via byte offsets.
 
@@ -176,7 +176,7 @@ Names collide-dedupe with first-source wins (skills > prompts > extensions).
 
 ### Status Detection
 
-Pi has no hooks and no pane-title signaling, so status is inferred from transcript activity — idle when the latest assistant message has no pending tool calls, working when there are unreturned tool uses.
+With hook-runner installed, Pi `Stop` hooks mark the topic ready immediately and trigger pending mailbox delivery. Without hooks, status is inferred from transcript activity — idle when the latest assistant message has no pending tool calls, working when there are unreturned tool uses.
 
 ### Toolbar
 

--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -98,9 +98,21 @@ async def register_provider_commands(application: Application) -> None:
 
 
 def verify_hooks_installed() -> None:
-    """Warn if Claude Code hooks are missing for the default provider."""
+    """Warn if managed hooks are missing for the default provider."""
     provider = get_provider()
     if not provider.capabilities.supports_hook:
+        return
+    provider_name = provider.capabilities.name
+    if provider_name != "claude":
+        if provider.capabilities.hook_install_managed_by_ccgram:
+            # INFO (not WARNING): Codex/Gemini fall back to transcript-scan
+            # discovery when hooks are absent, so missing hooks are an
+            # opt-in latency improvement, not a degraded state.
+            logger.info(
+                "%s hooks can improve status tracking. Run: ccgram hook --provider %s --install",
+                provider_name,
+                provider_name,
+            )
         return
 
     # Lazy: hook module is the Claude-Code subprocess entry point;

--- a/src/ccgram/cli.py
+++ b/src/ccgram/cli.py
@@ -229,18 +229,38 @@ def run_cmd(**kwargs: object) -> None:
 
 @cli.command("hook")
 @click.option(
-    "--install", is_flag=True, help="Install hook into ~/.claude/settings.json."
+    "--install",
+    is_flag=True,
+    help="Install hook into the selected provider's settings file.",
 )
 @click.option(
-    "--uninstall", is_flag=True, help="Remove hook from ~/.claude/settings.json."
+    "--uninstall",
+    is_flag=True,
+    help="Remove hook from the selected provider's settings file.",
 )
-@click.option("--status", is_flag=True, help="Check if hook is installed.")
-def hook_cmd(install: bool, uninstall: bool, status: bool) -> None:
-    """Claude Code session tracking hook."""
+@click.option(
+    "--status",
+    is_flag=True,
+    help="Check whether the selected provider's hook is installed.",
+)
+@click.option(
+    "--provider",
+    "provider_name",
+    type=click.Choice(["claude", "pi", "codex", "gemini"], case_sensitive=False),
+    default="claude",
+    help="Agent provider hook contract to use.",
+)
+def hook_cmd(install: bool, uninstall: bool, status: bool, provider_name: str) -> None:
+    """Agent session tracking hook."""
     # Lazy: defer subcommand import until that command is invoked, keeping `ccgram --help` fast
     from .hook import hook_main
 
-    hook_main(install=install, uninstall=uninstall, status=status)
+    hook_main(
+        install=install,
+        uninstall=uninstall,
+        status=status,
+        provider_name=provider_name.lower(),
+    )
 
 
 # --- status command --------------------------------------------------------

--- a/src/ccgram/doctor_cmd.py
+++ b/src/ccgram/doctor_cmd.py
@@ -86,23 +86,88 @@ def _check_tmux_session() -> tuple[str, str]:
         return _FAIL, "cannot connect to tmux server"
 
 
-def _check_hooks() -> tuple[str, str, dict[str, bool]]:
+def _resolve_hook_check_config(
+    provider_name: str,
+) -> tuple[Path, tuple[str, ...], Callable[[str], bool] | None] | None:
+    """Resolve (settings_file, expected_events, predicate) for a provider.
+
+    Returns None for unknown providers. For claude, predicate is None and
+    events is empty — the caller uses get_installed_events directly.
+    """
+    # Lazy: hook helpers reach back into bot wiring; defer until doctor runs
+    from .hook import (
+        _CODEX_HOOK_EVENTS,
+        _GEMINI_HOOK_EVENTS,
+        _HOOK_EVENT_TYPES,
+        _claude_settings_file,
+        _codex_hooks_file,
+        _gemini_settings_file,
+        _json_hook_command_predicate,
+    )
+
+    if provider_name == "codex":
+        return (
+            _codex_hooks_file(),
+            _CODEX_HOOK_EVENTS,
+            _json_hook_command_predicate("codex"),
+        )
+    if provider_name == "gemini":
+        return (
+            _gemini_settings_file(),
+            _GEMINI_HOOK_EVENTS,
+            _json_hook_command_predicate("gemini"),
+        )
+    if provider_name == "claude":
+        return _claude_settings_file(), _HOOK_EVENT_TYPES, None
+    return None
+
+
+def _scan_json_hook_events(
+    settings: dict, events: tuple[str, ...], predicate: Callable[[str], bool]
+) -> dict[str, bool]:
+    """Detect installed hook events in a JSON-format settings file."""
+    return {
+        event_type: any(
+            isinstance(hook_config, dict) and predicate(hook_config.get("command", ""))
+            for group in settings.get("hooks", {}).get(event_type, [])
+            if isinstance(group, dict)
+            for hook_config in group.get("hooks", [])
+        )
+        for event_type in events
+    }
+
+
+def _check_hooks(provider_name: str = "claude") -> tuple[str, str, dict[str, bool]]:
     """Check hook installation for all event types.
 
     Returns (status, message, event_status_dict).
     """
-    # Lazy: hook helpers reach back into bot wiring; defer until doctor runs
-    from .hook import _claude_settings_file, get_installed_events
+    if provider_name == "pi":
+        return _PASS, "Pi hooks are managed by hook-runner extension", {}
 
-    settings_file = _claude_settings_file()
+    resolved = _resolve_hook_check_config(provider_name)
+    if resolved is None:
+        return _FAIL, f"unknown provider for hook check: {provider_name}", {}
+    settings_file, events, predicate = resolved
+
+    # {event: False} when settings file missing/unreadable so doctor --fix
+    # has something to install — an empty dict would no-op _fix_hooks.
+    all_missing = {event: False for event in events}
+
     if not settings_file.exists():
-        return _FAIL, f"hooks not installed ({settings_file} missing)", {}
+        return _FAIL, f"hooks not installed ({settings_file} missing)", all_missing
     try:
         settings = json.loads(settings_file.read_text())
     except (json.JSONDecodeError, OSError):  # fmt: skip
-        return _FAIL, "hooks not installed (settings.json unreadable)", {}
+        return _FAIL, "hooks not installed (settings.json unreadable)", all_missing
 
-    event_status = get_installed_events(settings)
+    if predicate is None:
+        # Lazy: claude uses its own settings.json scanner
+        from .hook import get_installed_events
+
+        event_status = get_installed_events(settings)
+    else:
+        event_status = _scan_json_hook_events(settings, events, predicate)
     installed = [e for e, v in event_status.items() if v]
     missing = [e for e, v in event_status.items() if not v]
 
@@ -270,7 +335,9 @@ def _run_check(check_fn: Callable[[], tuple[str, str]]) -> tuple[str, str, bool]
     return status, msg, status == _FAIL
 
 
-def _fix_hooks(event_status: dict[str, bool], fix: bool) -> None:
+def _fix_hooks(
+    event_status: dict[str, bool], fix: bool, provider_name: str = "claude"
+) -> None:
     """Attempt to install missing hooks if --fix is set."""
     if not fix:
         return
@@ -280,7 +347,7 @@ def _fix_hooks(event_status: dict[str, bool], fix: bool) -> None:
     # Lazy: hook helpers reach back into bot wiring; defer until doctor runs
     from .hook import _install_hook
 
-    result = _install_hook()
+    result = _install_hook(provider_name)
     if result == 0:
         _print_check(_PASS, "hooks installed (fixed)")
     else:
@@ -330,11 +397,11 @@ def doctor_main(fix: bool = False) -> None:
 
     # Hook checks — only relevant for providers with hook support
     if caps.supports_hook:
-        hook_status, hook_msg, event_status = _check_hooks()
+        hook_status, hook_msg, event_status = _check_hooks(caps.name)
         _print_check(hook_status, hook_msg)
         if hook_status == _FAIL:
             has_failures = True
-        _fix_hooks(event_status, fix)
+        _fix_hooks(event_status, fix, caps.name)
     else:
         _print_check(_PASS, f"hook check skipped ({caps.name} has no hook support)")
 

--- a/src/ccgram/handlers/hook_events.py
+++ b/src/ccgram/handlers/hook_events.py
@@ -102,8 +102,10 @@ async def _handle_notification(event: HookEvent, client: TelegramClient) -> None
         return
 
     tool_name = event.data.get("tool_name", "")
+    provider_name = event.data.get("provider_name", "claude")
     logger.debug(
-        "Hook notification: tool_name=%s, window_key=%s",
+        "Hook notification: provider=%s, tool_name=%s, window_key=%s",
+        provider_name,
         tool_name,
         event.window_key,
     )
@@ -115,6 +117,13 @@ async def _handle_notification(event: HookEvent, client: TelegramClient) -> None
             await enqueue_status_update(
                 client, user_id, window_id, None, thread_id=thread_id
             )
+
+        if provider_name != "claude":
+            message = str(event.data.get("message", "") or "Agent notification")
+            await enqueue_status_update(
+                client, user_id, window_id, f"⚠ {message}", thread_id=thread_id
+            )
+            continue
 
         # Skip if already in interactive mode for this window
         existing = get_interactive_window(user_id, thread_id)
@@ -168,8 +177,10 @@ async def _handle_stop(event: HookEvent, client: TelegramClient) -> None:
         return
 
     stop_reason = event.data.get("stop_reason", "")
+    provider_name = event.data.get("provider_name", "claude")
     logger.debug(
-        "Hook stop: window_key=%s, stop_reason=%s",
+        "Hook stop: provider=%s, window_key=%s, stop_reason=%s",
+        provider_name,
         event.window_key,
         stop_reason,
     )
@@ -199,9 +210,12 @@ async def _handle_stop(event: HookEvent, client: TelegramClient) -> None:
         if notif_mode in ("muted", "errors_only"):
             status_text = None
         else:
-            status_text = claude_task_state.format_completion_text(
-                window_id, num_turns=num_turns
-            )
+            if provider_name == "claude":
+                status_text = claude_task_state.format_completion_text(
+                    window_id, num_turns=num_turns
+                )
+            else:
+                status_text = "✓ Ready"
             if summary and status_text:
                 status_text = status_text.replace("✓ Ready", f"✓ Done — {summary}", 1)
         await enqueue_status_update(
@@ -410,6 +424,7 @@ async def dispatch_hook_event(event: HookEvent, client: TelegramClient) -> None:
             | "WorktreeCreate"
             | "WorktreeRemove"
             | "PreCompact"
+            | "PostCompact"
         ):
             pass  # Not actionable for the bot — SessionStart handled via session_map.json
         case _:

--- a/src/ccgram/handlers/recovery/transcript_discovery.py
+++ b/src/ccgram/handlers/recovery/transcript_discovery.py
@@ -218,7 +218,11 @@ async def discover_and_register_transcript(
 
     if state.provider_name:
         provider = get_provider_for_window(window_id, state.provider_name)
-        if provider.capabilities.supports_hook:
+        # Skip discovery only when hook has already populated transcript_path.
+        # Capability alone (supports_hook=True) is insufficient — Codex/Gemini
+        # support hooks but the user may not have installed them yet, in which
+        # case transcript scan is the fallback path.
+        if provider.capabilities.supports_hook and state.transcript_path:
             return
 
     if not state.cwd:

--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -17,6 +17,7 @@ import fcntl
 import json
 import logging
 import os
+import re
 import shlex
 import subprocess
 import structlog
@@ -26,7 +27,11 @@ from pathlib import Path
 from collections.abc import Callable
 from typing import Any
 
-from ccgram.providers.base import UUID_RE
+from ccgram.hooks.adapters import (
+    detect_provider_from_payload,
+    get_hook_adapter,
+)
+from ccgram.hooks.model import ProviderName
 
 logger = structlog.get_logger()
 
@@ -83,9 +88,42 @@ _ASYNC_EVENTS: frozenset[str] = frozenset(
 )
 
 
-def _current_hook_command() -> str:
+def _installable_events_for(provider_name: str) -> tuple[str, ...]:
+    """Pull installable_events from an adapter, asserting it exists."""
+    adapter = get_hook_adapter(provider_name)
+    if adapter is None:
+        raise AssertionError(f"no hook adapter registered for {provider_name!r}")
+    return adapter.installable_events
+
+
+# Source of truth: each adapter declares its installable_events. We re-export
+# under the legacy names so existing call sites in doctor_cmd keep working
+# without a churny import migration.
+_CODEX_HOOK_EVENTS: tuple[str, ...] = _installable_events_for("codex")
+_GEMINI_HOOK_EVENTS: tuple[str, ...] = _installable_events_for("gemini")
+
+
+def _codex_hooks_file() -> Path:
+    """Return the user-level Codex hooks.json path."""
+    return Path.home() / ".codex" / "hooks.json"
+
+
+def _codex_config_file() -> Path:
+    """Return the user-level Codex config.toml path."""
+    return Path.home() / ".codex" / "config.toml"
+
+
+def _gemini_settings_file() -> Path:
+    """Return the user-level Gemini settings.json path."""
+    return Path.home() / ".gemini" / "settings.json"
+
+
+def _current_hook_command(provider_name: str = "claude") -> str:
     """Build the hook command bound to the current Python interpreter."""
-    return f"{shlex.quote(sys.executable)} -m ccgram.main hook"
+    command = f"{shlex.quote(sys.executable)} -m ccgram.main hook"
+    if provider_name != "claude":
+        command += f" --provider {shlex.quote(provider_name)}"
+    return command
 
 
 def _is_current_hook_command(command: str) -> bool:
@@ -126,11 +164,6 @@ def _has_ccgram_hook(settings: dict, event_type: str) -> bool:
     return _has_matching_hook(settings, event_type, _is_any_ccgram_hook_command)
 
 
-def _is_hook_installed(settings: dict) -> bool:
-    """Check if ccgram hook is installed for SessionStart (backward compat)."""
-    return _has_ccgram_hook(settings, "SessionStart")
-
-
 def get_installed_events(settings: dict) -> dict[str, bool]:
     """Return installation status for each expected hook event type."""
     return {event: _has_ccgram_hook(settings, event) for event in _HOOK_EVENT_TYPES}
@@ -152,11 +185,260 @@ def _replace_hook_commands(
                 h["command"] = replacement
 
 
-def _install_hook() -> int:
-    """Install ccgram hooks for all event types into Claude's settings.json.
+def _load_json_settings(path: Path) -> dict[str, Any] | None:
+    """Load a JSON settings file, returning an empty dict when absent."""
+    if not path.exists():
+        return {}
+    try:
+        parsed = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Error reading {path}: {e}", file=sys.stderr)
+        return None
+    if not isinstance(parsed, dict):
+        print(f"Error reading {path}: expected JSON object", file=sys.stderr)
+        return None
+    return parsed
+
+
+def _json_hook_command_predicate(provider_name: str) -> Callable[[str], bool]:
+    """Build predicate for provider-specific ccgram hook commands.
+
+    Matches `--provider {name}` as a whole token so e.g. `--provider codex-dev`
+    does not also match `--provider codex`. We append a trailing space to the
+    command so a token at the very end of the string also matches the
+    space-delimited needle.
+    """
+
+    needle = f" --provider {provider_name} "
+
+    def _predicate(command: str) -> bool:
+        return _is_any_ccgram_hook_command(command) and needle in f" {command} "
+
+    return _predicate
+
+
+def _hook_entry(provider_name: str, timeout_value: int) -> dict[str, Any]:
+    """Build a command hook entry for non-Claude providers.
+
+    ``timeout_value`` is provider-defined: Codex hooks.json uses seconds,
+    Gemini settings.json uses milliseconds. Callers must pass the unit the
+    target schema expects.
+    """
+    return {
+        "name": "ccgram-session-tracker",
+        "type": "command",
+        "command": _current_hook_command(provider_name),
+        "timeout": timeout_value,
+    }
+
+
+def _install_json_hooks(
+    path: Path, provider_name: str, events: tuple[str, ...], timeout_value: int
+) -> int:
+    """Install ccgram command hooks into a JSON settings file.
+
+    ``timeout_value`` is provider-defined (seconds for Codex, ms for Gemini).
+    """
+    settings = _load_json_settings(path)
+    if settings is None:
+        return 1
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        print(f"Error reading {path}: hooks must be an object", file=sys.stderr)
+        return 1
+
+    installed_count = 0
+    already_count = 0
+    predicate = _json_hook_command_predicate(provider_name)
+    for event_type in events:
+        event_hooks = hooks.setdefault(event_type, [])
+        if not isinstance(event_hooks, list):
+            print(
+                f"Error reading {path}: hooks.{event_type} must be an array",
+                file=sys.stderr,
+            )
+            return 1
+        if _has_matching_hook(settings, event_type, predicate):
+            already_count += 1
+            continue
+        event_hooks.append({"hooks": [_hook_entry(provider_name, timeout_value)]})
+        installed_count += 1
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        # Lazy: utils brings in subprocess + structlog at import time; not worth
+        # paying that cost on `ccgram --help`, only at hook-install.
+        from .utils import atomic_write_json
+
+        atomic_write_json(path, settings)
+    except OSError as e:
+        print(f"Error writing {path}: {e}", file=sys.stderr)
+        return 1
+    print(
+        f"{provider_name} hooks installed in {path}: "
+        f"{installed_count} new, {already_count} already present"
+    )
+    return 0
+
+
+_CODEX_HOOKS_KEY_RE = re.compile(r"^\s*codex_hooks\s*=\s*(\S+)", re.MULTILINE)
+
+
+def _ensure_codex_feature_flag() -> int:
+    """Ensure user Codex config enables the hooks feature flag.
+
+    Detects any existing ``codex_hooks =`` line (spacing-tolerant). If it's
+    already truthy, no-op. If it's explicitly false, warn and refuse to
+    overwrite — the user opted out. Otherwise insert under ``[features]``.
+    """
+    config_file = _codex_config_file()
+    if not config_file.exists():
+        try:
+            config_file.parent.mkdir(parents=True, exist_ok=True)
+            config_file.write_text("[features]\ncodex_hooks = true\n")
+        except OSError as e:
+            print(f"Error creating {config_file}: {e}", file=sys.stderr)
+            return 1
+        return 0
+    try:
+        text = config_file.read_text()
+    except OSError as e:
+        print(f"Error reading {config_file}: {e}", file=sys.stderr)
+        return 1
+    match = _CODEX_HOOKS_KEY_RE.search(text)
+    if match:
+        value = match.group(1).rstrip(",")
+        if value == "true":
+            return 0
+        print(
+            f"{config_file} has codex_hooks = {value}; set it to true and rerun.",
+            file=sys.stderr,
+        )
+        return 1
+    if "[features]" in text:
+        text = text.replace("[features]", "[features]\ncodex_hooks = true", 1)
+    else:
+        text = text.rstrip() + "\n\n[features]\ncodex_hooks = true\n"
+    try:
+        config_file.write_text(text)
+    except OSError as e:
+        print(f"Error writing {config_file}: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+_CODEX_HOOK_TIMEOUT_SECONDS = 5
+_GEMINI_HOOK_TIMEOUT_MS = 5_000
+
+
+def _install_codex_hook() -> int:
+    """Install user-level Codex hooks and enable the feature flag."""
+    if _ensure_codex_feature_flag() != 0:
+        return 1
+    return _install_json_hooks(
+        _codex_hooks_file(), "codex", _CODEX_HOOK_EVENTS, _CODEX_HOOK_TIMEOUT_SECONDS
+    )
+
+
+def _install_gemini_hook() -> int:
+    """Install user-level Gemini hooks."""
+    return _install_json_hooks(
+        _gemini_settings_file(), "gemini", _GEMINI_HOOK_EVENTS, _GEMINI_HOOK_TIMEOUT_MS
+    )
+
+
+def _uninstall_json_hooks(path: Path, provider_name: str) -> int:
+    """Remove provider-specific ccgram hooks from a JSON settings file."""
+    settings = _load_json_settings(path)
+    if settings is None:
+        return 1
+    if not settings:
+        print(f"No {path} found — nothing to uninstall.")
+        return 0
+    hooks = settings.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return 0
+    predicate = _json_hook_command_predicate(provider_name)
+    removed = 0
+    for event_hooks in hooks.values():
+        if not isinstance(event_hooks, list):
+            continue
+        for group in event_hooks:
+            if not isinstance(group, dict):
+                continue
+            inner_hooks = group.get("hooks", [])
+            if not isinstance(inner_hooks, list):
+                continue
+            kept = []
+            for hook_config in inner_hooks:
+                if isinstance(hook_config, dict) and predicate(
+                    hook_config.get("command", "")
+                ):
+                    removed += 1
+                    continue
+                kept.append(hook_config)
+            group["hooks"] = kept
+    if removed == 0:
+        print(f"No {provider_name} hooks found in {path} — nothing to remove.")
+        return 0
+    try:
+        # Lazy: same rationale as _install_json_hooks.
+        from .utils import atomic_write_json
+
+        atomic_write_json(path, settings)
+    except OSError as e:
+        print(f"Error writing {path}: {e}", file=sys.stderr)
+        return 1
+    print(f"{provider_name} hooks removed from {path}: {removed}")
+    return 0
+
+
+def _json_hook_status(path: Path, provider_name: str, events: tuple[str, ...]) -> int:
+    """Print provider-specific JSON hook status."""
+    settings = _load_json_settings(path)
+    if settings is None:
+        return 1
+    if not settings:
+        print(f"Not installed ({path} does not exist)")
+        return 1
+    predicate = _json_hook_command_predicate(provider_name)
+    statuses = {
+        event_type: _has_matching_hook(settings, event_type, predicate)
+        for event_type in events
+    }
+    for event_type, installed in statuses.items():
+        status_str = "installed" if installed else "MISSING"
+        print(f"  {event_type}: {status_str}")
+    if all(statuses.values()):
+        print("All hooks installed")
+        return 0
+    missing = [
+        event_type for event_type, installed in statuses.items() if not installed
+    ]
+    print(f"Missing hooks: {', '.join(missing)}")
+    return 1
+
+
+def _install_hook(provider_name: str = "claude") -> int:  # noqa: PLR0912
+    """Install ccgram hooks for all event types into provider settings.
 
     Returns 0 on success, 1 on error.
     """
+    match provider_name:
+        case "codex":
+            return _install_codex_hook()
+        case "gemini":
+            return _install_gemini_hook()
+        case "pi":
+            print(
+                "Pi hooks are provided by the hook-runner extension; nothing to install."
+            )
+            return 0
+        case "claude":
+            pass
+        case _:
+            print(f"Unsupported hook provider: {provider_name}", file=sys.stderr)
+            return 1
     settings_file = _claude_settings_file()
     settings_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -175,7 +457,7 @@ def _install_hook() -> int:
 
     installed_count = 0
     already_count = 0
-    current_command = _current_hook_command()
+    current_command = _current_hook_command("claude")
 
     for event_type in _HOOK_EVENT_TYPES:
         has_current = _has_matching_hook(settings, event_type, _is_current_hook_command)
@@ -241,11 +523,26 @@ def _install_hook() -> int:
     return 0
 
 
-def _uninstall_hook() -> int:
-    """Remove ccgram hooks from all event types in Claude's settings.json.
+def _uninstall_hook(provider_name: str = "claude") -> int:  # noqa: PLR0911
+    """Remove ccgram hooks from provider settings.
 
     Returns 0 on success, 1 on error.
     """
+    match provider_name:
+        case "codex":
+            return _uninstall_json_hooks(_codex_hooks_file(), "codex")
+        case "gemini":
+            return _uninstall_json_hooks(_gemini_settings_file(), "gemini")
+        case "pi":
+            print(
+                "Pi hooks are managed by the hook-runner extension; nothing to uninstall."
+            )
+            return 0
+        case "claude":
+            pass
+        case _:
+            print(f"Unsupported hook provider: {provider_name}", file=sys.stderr)
+            return 1
     settings_file = _claude_settings_file()
     if not settings_file.exists():
         print("No settings.json found — nothing to uninstall.")
@@ -302,11 +599,30 @@ def _uninstall_hook() -> int:
     return 0
 
 
-def _hook_status() -> int:
+def _hook_status(provider_name: str = "claude") -> int:  # noqa: PLR0911
     """Show per-event hook installation status.
 
     Returns 0 if all installed, 1 if any missing.
     """
+    match provider_name:
+        case "codex":
+            return _json_hook_status(_codex_hooks_file(), "codex", _CODEX_HOOK_EVENTS)
+        case "gemini":
+            return _json_hook_status(
+                _gemini_settings_file(), "gemini", _GEMINI_HOOK_EVENTS
+            )
+        case "pi":
+            print("Pi hook status depends on the hook-runner extension.")
+            print(
+                "Expected built-in hook-runner ccgram events: "
+                "SessionStart, Stop, SessionEnd, SubagentStart"
+            )
+            return 0
+        case "claude":
+            pass
+        case _:
+            print(f"Unsupported hook provider: {provider_name}", file=sys.stderr)
+            return 1
     settings_file = _claude_settings_file()
     if not settings_file.exists():
         print(f"Not installed ({settings_file} does not exist)")
@@ -520,78 +836,6 @@ def _write_event(
         logger.exception("Failed to write event to %s", events_file)
 
 
-def _extract_notification_data(payload: dict[str, Any]) -> dict[str, Any]:
-    """Extract data from a Notification hook payload."""
-    return {
-        "tool_name": payload.get("tool_name", ""),
-        "message": payload.get("message", ""),
-    }
-
-
-def _extract_stop_data(payload: dict[str, Any]) -> dict[str, Any]:
-    """Extract data from a Stop hook payload."""
-    return {
-        "stop_reason": payload.get("stop_reason", ""),
-        "num_turns": payload.get("num_turns", 0),
-    }
-
-
-def _extract_stop_failure_data(payload: dict[str, Any]) -> dict[str, Any]:
-    """Extract data from a StopFailure hook payload."""
-    return {
-        "error": payload.get("error", ""),
-        "error_details": payload.get("error_details", ""),
-    }
-
-
-def _extract_session_end_data(payload: dict[str, Any]) -> dict[str, Any]:
-    """Extract data from a SessionEnd hook payload."""
-    return {
-        "reason": payload.get("reason", ""),
-    }
-
-
-def _extract_subagent_data(payload: dict[str, Any]) -> dict[str, Any]:
-    """Extract data from a SubagentStart/SubagentStop hook payload."""
-    return {
-        "subagent_id": payload.get("subagent_id", ""),
-        "description": payload.get("description", ""),
-        "name": payload.get("name", ""),
-    }
-
-
-def _extract_teammate_idle_data(payload: dict[str, Any]) -> dict[str, Any]:
-    """Extract data from a TeammateIdle hook payload."""
-    return {
-        "teammate_name": payload.get("teammate_name", ""),
-        "team_name": payload.get("team_name", ""),
-    }
-
-
-def _extract_task_completed_data(payload: dict[str, Any]) -> dict[str, Any]:
-    """Extract data from a TaskCompleted hook payload."""
-    return {
-        "task_id": payload.get("task_id", ""),
-        "task_subject": payload.get("task_subject", ""),
-        "task_description": payload.get("task_description", ""),
-        "teammate_name": payload.get("teammate_name", ""),
-        "team_name": payload.get("team_name", ""),
-    }
-
-
-# Map event types to their data extractor functions
-_EVENT_DATA_EXTRACTORS: dict[str, Any] = {
-    "Notification": _extract_notification_data,
-    "Stop": _extract_stop_data,
-    "StopFailure": _extract_stop_failure_data,
-    "SessionEnd": _extract_session_end_data,
-    "SubagentStart": _extract_subagent_data,
-    "SubagentStop": _extract_subagent_data,
-    "TeammateIdle": _extract_teammate_idle_data,
-    "TaskCompleted": _extract_task_completed_data,
-}
-
-
 def _update_session_map(
     session_window_key: str,
     session_id: str,
@@ -599,6 +843,7 @@ def _update_session_map(
     window_name: str,
     transcript_path: str,
     tmux_session_name: str,
+    provider_name: str = "claude",
 ) -> None:
     """Update session_map.json for a SessionStart event."""
     # Lazy: same hook fast-path rationale as ``_write_event``.
@@ -648,7 +893,7 @@ def _update_session_map(
                     "cwd": cwd,
                     "window_name": window_name,
                     "transcript_path": transcript_path,
-                    "provider_name": "claude",
+                    "provider_name": provider_name,
                 }
 
                 # Clean up old-format key ("session:window_name") if it exists
@@ -670,7 +915,87 @@ def _update_session_map(
         logger.exception("Failed to write session_map")
 
 
-def _locate_primary_window(session_id: str, event: str) -> tuple[str, str, str] | None:
+def _encode_pi_cwd_dirname(cwd: str) -> str:
+    """Encode cwd using Pi's session directory convention."""
+    stripped = cwd.lstrip("/\\").rstrip("/\\")
+    encoded = stripped.replace("/", "-").replace("\\", "-").replace(":", "-")
+    return f"--{encoded}--"
+
+
+def _resolve_pi_transcript_path(session_id: str, cwd: str) -> str:
+    """Find a Pi transcript path when hook-runner omitted it."""
+    if not cwd:
+        return ""
+    session_dir = (
+        Path.home() / ".pi" / "agent" / "sessions" / _encode_pi_cwd_dirname(cwd)
+    )
+    if not session_dir.is_dir():
+        return ""
+    candidates: list[tuple[float, Path]] = []
+    try:
+        for entry in session_dir.iterdir():
+            if entry.suffix != ".jsonl" or not entry.is_file():
+                continue
+            try:
+                candidates.append((entry.stat().st_mtime, entry))
+            except OSError:
+                continue
+    except OSError:
+        return ""
+    candidates.sort(reverse=True)
+    for _mtime, path in candidates:
+        if session_id and session_id in path.name:
+            return str(path)
+    return str(candidates[0][1]) if candidates else ""
+
+
+def _resolve_transcript_path(
+    provider_name: str, session_id: str, cwd: str, transcript_path: str
+) -> str:
+    """Return transcript path from payload or provider-specific fallback."""
+    if transcript_path:
+        return transcript_path
+    if provider_name == "pi":
+        return _resolve_pi_transcript_path(session_id, cwd)
+    return ""
+
+
+def _provider_from_pane_tty(pane_tty: str) -> ProviderName | None:
+    """Best-effort provider detection from foreground tty process commands.
+
+    This is a last-resort fallback; the primary paths are the explicit
+    ``provider_name`` field and the ``/.provider/`` transcript path prefix
+    checked in ``detect_provider_from_payload``.  JS-wrapped Pi (e.g.
+    ``node ~/.pi/agent/cli.js``) is not matched here — it is caught by the
+    ``/.pi/`` transcript path check instead.
+    """
+    if not pane_tty:
+        return None
+    tty_name = pane_tty.removeprefix("/dev/")
+    try:
+        result = subprocess.run(
+            ["ps", "-t", tty_name, "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired, OSError:
+        return None
+    text = result.stdout.lower()
+    if "gemini" in text:
+        return "gemini"
+    if "codex" in text:
+        return "codex"
+    if "claude" in text:
+        return "claude"
+    if any(tok == "pi" or tok.endswith("/pi") for tok in text.split()):
+        return "pi"
+    return None
+
+
+def _locate_primary_window(
+    session_id: str, event: str, provider_name: str = "claude"
+) -> tuple[str, str, str] | None:
     """Resolve TMUX_PANE → primary window, or None to drop the hook.
 
     Returns ``(session_window_key, window_id, window_name)`` for the foreground
@@ -693,7 +1018,7 @@ def _locate_primary_window(session_id: str, event: str) -> tuple[str, str, str] 
         session_id,
         event,
     )
-    if _is_nested_session(pane_tty):
+    if provider_name == "claude" and _is_nested_session(pane_tty):
         logger.info(
             "Skipping hook from nested claude (window_key=%s, session_id=%s, event=%s)",
             session_window_key,
@@ -704,75 +1029,94 @@ def _locate_primary_window(session_id: str, event: str) -> tuple[str, str, str] 
     return session_window_key, window_id, window_name
 
 
-def _process_hook_stdin() -> None:
-    """Process a Claude Code hook event from stdin."""
+def _process_hook_stdin(provider_name: str | None = None) -> None:
+    """Process an agent hook event from stdin."""
     logger.debug("Processing hook event from stdin")
     try:
-        payload = json.load(sys.stdin)
+        raw_payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError) as e:
         logger.warning("Failed to parse stdin JSON: %s", e)
         return
+    if not isinstance(raw_payload, dict):
+        logger.warning("Hook stdin JSON must be an object")
+        return
+    payload: dict[str, object] = raw_payload
 
-    session_id = payload.get("session_id", "")
-    cwd = payload.get("cwd", "")
-    transcript_path = payload.get("transcript_path", "")
-    event = payload.get("hook_event_name", "")
+    payload_provider = detect_provider_from_payload(payload)
+    if provider_name and payload_provider and payload_provider != provider_name:
+        logger.warning(
+            "Hook --provider=%s but payload looks like %s; using %s",
+            provider_name,
+            payload_provider,
+            provider_name,
+        )
+    detected_provider = provider_name or payload_provider
+    if detected_provider is None:
+        pane_id = os.environ.get("TMUX_PANE", "")
+        resolved = _resolve_window_id(pane_id) if pane_id else None
+        if resolved:
+            detected_provider = _provider_from_pane_tty(resolved[3])
+    if detected_provider is None:
+        detected_provider = "claude"
 
-    if not session_id or not event:
-        logger.debug("Empty session_id or event, ignoring")
+    adapter = get_hook_adapter(detected_provider)
+    if adapter is None:
+        logger.debug("Ignoring hook for unsupported provider: %s", detected_provider)
+        return
+    normalized = adapter.normalize(payload)
+    if normalized is None:
+        logger.debug(
+            "Ignoring invalid hook payload for provider: %s", detected_provider
+        )
         return
 
-    # Validate session_id format
-    if not UUID_RE.match(session_id):
-        logger.warning("Invalid session_id format: %s", session_id)
-        return
-
-    # Validate cwd is an absolute path (if provided)
-    if cwd and not os.path.isabs(cwd):
-        logger.warning("cwd is not absolute: %s", cwd)
-        return
-
-    # Only process events we handle
-    if event not in _HOOK_EVENT_TYPES:
+    event = normalized.canonical_event_name
+    if event not in _HOOK_EVENT_TYPES and event not in {"PreCompact", "PostCompact"}:
         logger.debug("Ignoring unhandled event: %s", event)
         return
 
-    located = _locate_primary_window(session_id, event)
+    located = _locate_primary_window(normalized.session_id, event, detected_provider)
     if located is None:
         return
-    session_window_key, window_id, window_name = located
+    session_window_key, _window_id, window_name = located
 
-    # SessionStart: update session_map.json AND write event
     if event == "SessionStart":
         tmux_session_name = session_window_key.rsplit(":", 1)[0]
+        transcript_path = _resolve_transcript_path(
+            detected_provider,
+            normalized.session_id,
+            str(normalized.cwd) if normalized.cwd else "",
+            str(normalized.transcript_path) if normalized.transcript_path else "",
+        )
+        cwd = str(normalized.cwd) if normalized.cwd else ""
         _update_session_map(
             session_window_key,
-            session_id,
+            normalized.session_id,
             cwd,
             window_name,
             transcript_path,
             tmux_session_name,
+            detected_provider,
         )
-        _write_event(
-            event,
-            session_id,
-            session_window_key,
+        data = dict(normalized.data)
+        data.update(
             {
                 "cwd": cwd,
                 "transcript_path": transcript_path,
                 "window_name": window_name,
-            },
+            }
         )
+        _write_event(event, normalized.session_id, session_window_key, data)
         return
 
-    # Other events: write event only
-    extractor = _EVENT_DATA_EXTRACTORS.get(event)
-    data = extractor(payload) if extractor else {}
-    _write_event(event, session_id, session_window_key, data)
+    _write_event(event, normalized.session_id, session_window_key, normalized.data)
 
 
 def hook_main(
-    install: bool = False, uninstall: bool = False, status: bool = False
+    install: bool = False,
+    uninstall: bool = False,
+    status: bool = False,
+    provider_name: str = "claude",
 ) -> None:
     """Process a Claude Code hook event from stdin, or manage hook installation."""
     logging.basicConfig(
@@ -783,12 +1127,17 @@ def hook_main(
 
     if install:
         logger.info("Hook install requested")
-        sys.exit(_install_hook())
+        sys.exit(_install_hook(provider_name))
 
     if uninstall:
-        sys.exit(_uninstall_hook())
+        sys.exit(_uninstall_hook(provider_name))
 
     if status:
-        sys.exit(_hook_status())
+        sys.exit(_hook_status(provider_name))
 
-    _process_hook_stdin()
+    # Pass None for the implicit Claude default so detect_provider_from_payload
+    # gets first say (an explicit `--provider claude` invocation deliberately
+    # keeps the explicit flag to surface the mismatch warning when payload
+    # heuristics disagree). The CLI default also resolves to "claude", so the
+    # None path covers the common case of an unannotated hook command.
+    _process_hook_stdin(provider_name if provider_name != "claude" else None)

--- a/src/ccgram/hooks/__init__.py
+++ b/src/ccgram/hooks/__init__.py
@@ -1,0 +1,19 @@
+"""Provider-aware hook support for agent lifecycle events.
+
+Defines normalized hook contracts and provider adapters used by the
+``ccgram.hook`` CLI wrapper. Runtime code must stay import-light because hook
+commands execute inside agent panes without bot configuration.
+"""
+
+from .adapters import (
+    detect_provider_from_payload,
+    get_hook_adapter,
+)
+from .model import NormalizedHookEvent, ProviderName
+
+__all__ = [
+    "NormalizedHookEvent",
+    "ProviderName",
+    "detect_provider_from_payload",
+    "get_hook_adapter",
+]

--- a/src/ccgram/hooks/adapters.py
+++ b/src/ccgram/hooks/adapters.py
@@ -1,0 +1,373 @@
+"""Provider adapters for command hook stdin payloads.
+
+The adapters validate common fields, map native event names to ccgram's canonical
+lifecycle events, and retain only metadata safe enough for ``events.jsonl``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import cast
+
+from ccgram.providers.base import UUID_RE
+
+from .model import HookAdapter, JsonValue, NormalizedHookEvent, ProviderName
+
+_SAFE_PROVIDERS: tuple[ProviderName, ...] = ("claude", "pi", "codex", "gemini")
+
+# Event names emitted only by Gemini — used by detect_provider_from_payload
+# to distinguish Gemini payloads when transcript path is absent. SessionStart,
+# SessionEnd, and Notification are shared across providers so they don't help.
+_GEMINI_ONLY_EVENT_TYPES: tuple[str, ...] = (
+    "AfterAgent",
+    "BeforeAgent",
+    "BeforeTool",
+    "AfterTool",
+    "PreCompress",
+)
+
+
+def _str_field(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _int_field(payload: dict[str, object], key: str, default: int = 0) -> int:
+    value = payload.get(key)
+    return value if isinstance(value, int) else default
+
+
+def _bool_field(payload: dict[str, object], key: str) -> bool:
+    value = payload.get(key)
+    return value if isinstance(value, bool) else False
+
+
+def _path_or_none(value: str) -> Path | None:
+    if not value:
+        return None
+    return Path(value) if os.path.isabs(value) else None
+
+
+def _safe_details_tool_name(payload: dict[str, object]) -> str:
+    details = payload.get("details")
+    if not isinstance(details, dict):
+        return ""
+    tool_name = details.get("tool_name") or details.get("toolName")
+    return tool_name if isinstance(tool_name, str) else ""
+
+
+def _event(
+    *,
+    provider_name: ProviderName,
+    native_event_name: str,
+    canonical_event_name: str,
+    session_id: str,
+    cwd: str,
+    transcript_path: str,
+    data: dict[str, JsonValue] | None = None,
+) -> NormalizedHookEvent | None:
+    if not session_id or not native_event_name:
+        return None
+    cwd_path = _path_or_none(cwd)
+    if cwd and cwd_path is None:
+        return None
+    if canonical_event_name == "SessionStart" and cwd_path is None:
+        return None
+    safe_data: dict[str, JsonValue] = {
+        "provider_name": provider_name,
+        "native_event_name": native_event_name,
+    }
+    if data:
+        safe_data.update(data)
+    return NormalizedHookEvent(
+        provider_name=provider_name,
+        native_event_name=native_event_name,
+        canonical_event_name=canonical_event_name,
+        session_id=session_id,
+        cwd=cwd_path,
+        transcript_path=_path_or_none(transcript_path),
+        data=safe_data,
+    )
+
+
+class ClaudeHookAdapter:
+    """Normalize Claude Code hook payloads."""
+
+    provider_name: ProviderName = "claude"
+    event_types: tuple[str, ...] = (
+        "SessionStart",
+        "Notification",
+        "Stop",
+        "StopFailure",
+        "SessionEnd",
+        "SubagentStart",
+        "SubagentStop",
+        "TeammateIdle",
+        "TaskCompleted",
+    )
+    # Claude installs all of its event types — the install path uses
+    # ~/.claude/settings.json schema rather than the JSON-hook installer,
+    # but installable_events lets call sites read every adapter uniformly.
+    installable_events: tuple[str, ...] = event_types
+    install_managed_by_ccgram = True
+
+    def normalize(self, payload: dict[str, object]) -> NormalizedHookEvent | None:
+        event_name = _str_field(payload, "hook_event_name")
+        session_id = _str_field(payload, "session_id")
+        if event_name not in self.event_types or not UUID_RE.match(session_id):
+            return None
+        data = _extract_claude_data(event_name, payload)
+        return _event(
+            provider_name=self.provider_name,
+            native_event_name=event_name,
+            canonical_event_name=event_name,
+            session_id=session_id,
+            cwd=_str_field(payload, "cwd"),
+            transcript_path=_str_field(payload, "transcript_path"),
+            data=data,
+        )
+
+
+class PiHookAdapter:
+    """Normalize Pi hook-runner payloads."""
+
+    provider_name: ProviderName = "pi"
+    event_types: tuple[str, ...] = (
+        "SessionStart",
+        "Stop",
+        "SessionEnd",
+        "SubagentStart",
+        "SubagentStop",
+        "Notification",
+        "PreCompact",
+        "PostCompact",
+    )
+    # Pi hooks are installed by cc-thingz hook-runner, not ccgram.
+    installable_events: tuple[str, ...] = ()
+    install_managed_by_ccgram = False
+
+    def normalize(self, payload: dict[str, object]) -> NormalizedHookEvent | None:
+        event_name = _str_field(payload, "hook_event_name")
+        if event_name not in self.event_types:
+            return None
+        session_id = _str_field(payload, "session_id")
+        if not UUID_RE.match(session_id):
+            return None
+        canonical = event_name
+        data: dict[str, JsonValue] = {}
+        if event_name == "SessionEnd":
+            data["reason"] = _str_field(payload, "reason") or _str_field(
+                payload, "end_reason"
+            )
+        elif event_name == "Notification":
+            data["message"] = _str_field(payload, "message")
+            data["notification_type"] = _str_field(payload, "notification_type")
+            data["tool_name"] = _str_field(payload, "tool_name")
+        elif event_name in {"SubagentStart", "SubagentStop"}:
+            data["subagent_id"] = _str_field(payload, "subagent_id")
+            data["name"] = _str_field(payload, "name") or "Pi agent"
+            data["description"] = _str_field(payload, "description")
+        return _event(
+            provider_name=self.provider_name,
+            native_event_name=event_name,
+            canonical_event_name=canonical,
+            session_id=session_id,
+            cwd=_str_field(payload, "cwd"),
+            transcript_path=_str_field(payload, "transcript_path"),
+            data=data,
+        )
+
+
+class CodexHookAdapter:
+    """Normalize Codex hook payloads."""
+
+    provider_name: ProviderName = "codex"
+    event_types: tuple[str, ...] = (
+        "SessionStart",
+        "Stop",
+        "PreToolUse",
+        "PostToolUse",
+        "PermissionRequest",
+        "UserPromptSubmit",
+        "PreCompact",
+        "PostCompact",
+    )
+    # Only the lifecycle signals ccgram acts on — the rest are accepted by
+    # normalize() in case Codex starts emitting them with useful data.
+    installable_events: tuple[str, ...] = ("SessionStart", "Stop")
+    install_managed_by_ccgram = True
+
+    def normalize(self, payload: dict[str, object]) -> NormalizedHookEvent | None:
+        event_name = _str_field(payload, "hook_event_name")
+        if event_name not in self.event_types:
+            return None
+        session_id = _str_field(payload, "session_id")
+        if not UUID_RE.match(session_id):
+            return None
+        canonical = event_name
+        data: dict[str, JsonValue] = {}
+        if event_name == "Stop":
+            data["stop_hook_active"] = _bool_field(payload, "stop_hook_active")
+            data["stop_reason"] = _str_field(payload, "stopReason")
+        elif event_name in {"PreToolUse", "PostToolUse", "PermissionRequest"}:
+            data["tool_name"] = _str_field(payload, "tool_name")
+        elif event_name == "SessionStart":
+            data["source"] = _str_field(payload, "source")
+        elif event_name in {"PreCompact", "PostCompact"}:
+            data["trigger"] = _str_field(payload, "trigger")
+        return _event(
+            provider_name=self.provider_name,
+            native_event_name=event_name,
+            canonical_event_name=canonical,
+            session_id=session_id,
+            cwd=_str_field(payload, "cwd"),
+            transcript_path=_str_field(payload, "transcript_path"),
+            data=data,
+        )
+
+
+class GeminiHookAdapter:
+    """Normalize Gemini CLI hook payloads."""
+
+    provider_name: ProviderName = "gemini"
+    event_types: tuple[str, ...] = (
+        "SessionStart",
+        "SessionEnd",
+        "Notification",
+        "AfterAgent",
+        "BeforeAgent",
+        "BeforeTool",
+        "AfterTool",
+        "PreCompress",
+    )
+    # AfterAgent maps to canonical Stop; the rest line up directly.
+    installable_events: tuple[str, ...] = (
+        "SessionStart",
+        "AfterAgent",
+        "SessionEnd",
+        "Notification",
+    )
+    install_managed_by_ccgram = True
+
+    def normalize(self, payload: dict[str, object]) -> NormalizedHookEvent | None:
+        # Gemini session IDs are not UUIDs in current builds (free-form CLI
+        # tokens). Skipping UUID validation here is intentional; the empty-
+        # session_id and absolute-cwd checks in _event still apply.
+        event_name = _str_field(payload, "hook_event_name")
+        if event_name not in self.event_types:
+            return None
+        canonical = "Stop" if event_name == "AfterAgent" else event_name
+        data: dict[str, JsonValue] = {}
+        if event_name == "SessionEnd":
+            data["reason"] = _str_field(payload, "reason")
+        elif event_name == "Notification":
+            data["message"] = _str_field(payload, "message")
+            data["notification_type"] = _str_field(payload, "notification_type")
+            data["tool_name"] = _safe_details_tool_name(payload)
+        elif event_name == "AfterAgent":
+            data["stop_hook_active"] = _bool_field(payload, "stop_hook_active")
+        elif event_name in {"BeforeTool", "AfterTool"}:
+            data["tool_name"] = _str_field(payload, "tool_name")
+        elif event_name == "SessionStart":
+            data["source"] = _str_field(payload, "source")
+        elif event_name == "PreCompress":
+            data["trigger"] = _str_field(payload, "trigger")
+        return _event(
+            provider_name=self.provider_name,
+            native_event_name=event_name,
+            canonical_event_name=canonical,
+            session_id=_str_field(payload, "session_id"),
+            cwd=_str_field(payload, "cwd"),
+            transcript_path=_str_field(payload, "transcript_path"),
+            data=data,
+        )
+
+
+def _extract_claude_data(
+    event_name: str, payload: dict[str, object]
+) -> dict[str, JsonValue]:
+    if event_name == "Notification":
+        return {
+            "tool_name": _str_field(payload, "tool_name"),
+            "message": _str_field(payload, "message"),
+        }
+    if event_name == "Stop":
+        return {
+            "stop_reason": _str_field(payload, "stop_reason"),
+            "num_turns": _int_field(payload, "num_turns"),
+        }
+    if event_name == "StopFailure":
+        return {
+            "error": _str_field(payload, "error"),
+            "error_details": _str_field(payload, "error_details"),
+        }
+    if event_name == "SessionEnd":
+        return {"reason": _str_field(payload, "reason")}
+    if event_name in {"SubagentStart", "SubagentStop"}:
+        return {
+            "subagent_id": _str_field(payload, "subagent_id"),
+            "description": _str_field(payload, "description"),
+            "name": _str_field(payload, "name"),
+        }
+    if event_name == "TeammateIdle":
+        return {
+            "teammate_name": _str_field(payload, "teammate_name"),
+            "team_name": _str_field(payload, "team_name"),
+        }
+    if event_name == "TaskCompleted":
+        return {
+            "task_id": _str_field(payload, "task_id"),
+            "task_subject": _str_field(payload, "task_subject"),
+            "task_description": _str_field(payload, "task_description"),
+            "teammate_name": _str_field(payload, "teammate_name"),
+            "team_name": _str_field(payload, "team_name"),
+        }
+    return {}
+
+
+_ADAPTERS: dict[ProviderName, HookAdapter] = {
+    "claude": ClaudeHookAdapter(),
+    "pi": PiHookAdapter(),
+    "codex": CodexHookAdapter(),
+    "gemini": GeminiHookAdapter(),
+}
+
+
+def get_hook_adapter(provider_name: str) -> HookAdapter | None:
+    """Return the hook adapter for a provider name."""
+    if provider_name not in _SAFE_PROVIDERS:
+        return None
+    return _ADAPTERS[cast(ProviderName, provider_name)]
+
+
+def all_hook_adapters() -> tuple[HookAdapter, ...]:
+    """Return all known hook adapters."""
+    return tuple(_ADAPTERS.values())
+
+
+def detect_provider_from_payload(payload: dict[str, object]) -> ProviderName | None:
+    """Best-effort provider detection when installed hook lacks --provider."""
+    explicit = _str_field(payload, "provider_name")
+    transcript_path = _str_field(payload, "transcript_path")
+    event_name = _str_field(payload, "hook_event_name")
+    session_id = _str_field(payload, "session_id")
+
+    provider: ProviderName | None = None
+    if explicit in _SAFE_PROVIDERS:
+        provider = cast(ProviderName, explicit)
+    elif "/.codex/" in transcript_path:
+        provider = "codex"
+    elif "/.gemini/" in transcript_path:
+        provider = "gemini"
+    elif "/.pi/" in transcript_path:
+        provider = "pi"
+    elif event_name in _GEMINI_ONLY_EVENT_TYPES:
+        provider = "gemini"
+    elif _str_field(payload, "permission_mode") or _str_field(payload, "model"):
+        provider = "codex"
+    elif _str_field(payload, "end_reason") or (
+        session_id and not UUID_RE.match(session_id)
+    ):
+        provider = "pi"
+    return provider

--- a/src/ccgram/hooks/model.py
+++ b/src/ccgram/hooks/model.py
@@ -1,0 +1,48 @@
+"""Normalized hook event types shared by provider adapters.
+
+Adapters convert provider-specific stdin payloads into a small safe event model.
+The model intentionally excludes raw prompts, tool inputs, tool outputs, and LLM
+messages because hook payloads can contain secrets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol, TypeAlias
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+ProviderName: TypeAlias = Literal["claude", "pi", "codex", "gemini"]
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedHookEvent:
+    """Provider-neutral hook event safe for ccgram state files."""
+
+    provider_name: ProviderName
+    native_event_name: str
+    canonical_event_name: str
+    session_id: str
+    cwd: Path | None
+    transcript_path: Path | None
+    data: dict[str, JsonValue]
+
+
+class HookAdapter(Protocol):
+    """Provider-specific hook payload normalizer.
+
+    ``event_types`` covers what the adapter knows how to normalize (a superset).
+    ``installable_events`` covers what ccgram actually installs in user config —
+    a subset chosen for the lifecycle signals ccgram acts on. The two differ on
+    purpose; conflating them would install hooks for events the bot ignores.
+    """
+
+    provider_name: ProviderName
+    event_types: tuple[str, ...]
+    installable_events: tuple[str, ...]
+    install_managed_by_ccgram: bool
+
+    def normalize(self, payload: dict[str, object]) -> NormalizedHookEvent | None:
+        """Return a safe normalized event, or None for invalid/unhandled input."""
+        ...

--- a/src/ccgram/providers/_jsonl.py
+++ b/src/ccgram/providers/_jsonl.py
@@ -175,12 +175,6 @@ class JsonlProvider:
             return f"--resume {resume_id}"
         return ""
 
-    def parse_hook_payload(
-        self,
-        payload: dict[str, Any],  # noqa: ARG002 — protocol signature
-    ) -> SessionStartEvent | None:
-        return None
-
     def read_transcript_file(
         self, file_path: str, last_offset: int
     ) -> tuple[list[dict[str, Any]], int]:

--- a/src/ccgram/providers/base.py
+++ b/src/ccgram/providers/base.py
@@ -112,6 +112,7 @@ class ProviderCapabilities:
     supports_hook: bool = False
     supports_hook_events: bool = False
     hook_event_types: tuple[str, ...] = ()
+    hook_install_managed_by_ccgram: bool = False
     supports_resume: bool = False
     supports_continue: bool = False
     supports_structured_transcript: bool = False
@@ -161,13 +162,6 @@ class AgentProvider(Protocol):
 
         Returns a string like ``--resume abc123`` or ``--continue``.
         Empty string for a fresh session.
-        """
-        ...
-
-    def parse_hook_payload(self, payload: dict[str, Any]) -> SessionStartEvent | None:
-        """Parse a hook's stdin JSON into a SessionStartEvent.
-
-        Returns None if the payload is invalid or not from this provider.
         """
         ...
 

--- a/src/ccgram/providers/claude.py
+++ b/src/ccgram/providers/claude.py
@@ -7,7 +7,6 @@ that translates between the provider protocol and existing module APIs.
 
 from __future__ import annotations
 
-import os
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
@@ -93,6 +92,7 @@ class ClaudeProvider:
         launch_command="claude",
         supports_hook=True,
         supports_hook_events=True,
+        hook_install_managed_by_ccgram=True,
         hook_event_types=(
             "Notification",
             "Stop",
@@ -130,33 +130,6 @@ class ClaudeProvider:
         if use_continue:
             return "--continue"
         return ""
-
-    def parse_hook_payload(self, payload: dict[str, Any]) -> SessionStartEvent | None:
-        """Parse a Claude Code SessionStart hook payload.
-
-        Validates session_id (UUID format), cwd (absolute path), and
-        rejects payloads missing required fields.
-        """
-        session_id = payload.get("session_id", "")
-        cwd = payload.get("cwd", "")
-        transcript_path = payload.get("transcript_path", "")
-        window_key = payload.get("window_key", "")
-
-        if not session_id or not cwd:
-            return None
-
-        if not UUID_RE.match(session_id):
-            return None
-
-        if not os.path.isabs(cwd):
-            return None
-
-        return SessionStartEvent(
-            session_id=session_id,
-            cwd=cwd,
-            transcript_path=transcript_path,
-            window_key=window_key,
-        )
 
     def read_transcript_file(
         self, file_path: str, last_offset: int

--- a/src/ccgram/providers/codex.py
+++ b/src/ccgram/providers/codex.py
@@ -586,7 +586,10 @@ class CodexProvider(JsonlProvider):
     _CAPS = ProviderCapabilities(
         name="codex",
         launch_command="codex",
-        supports_hook=False,
+        supports_hook=True,
+        supports_hook_events=True,
+        hook_install_managed_by_ccgram=True,
+        hook_event_types=("SessionStart", "Stop"),
         supports_resume=True,
         supports_continue=True,
         supports_structured_transcript=True,

--- a/src/ccgram/providers/gemini.py
+++ b/src/ccgram/providers/gemini.py
@@ -463,7 +463,10 @@ class GeminiProvider(JsonlProvider):
     _CAPS = ProviderCapabilities(
         name="gemini",
         launch_command="gemini",
-        supports_hook=False,
+        supports_hook=True,
+        supports_hook_events=True,
+        hook_install_managed_by_ccgram=True,
+        hook_event_types=("SessionStart", "AfterAgent", "SessionEnd", "Notification"),
         supports_resume=True,
         supports_continue=True,
         supports_structured_transcript=True,

--- a/src/ccgram/providers/pi.py
+++ b/src/ccgram/providers/pi.py
@@ -1,8 +1,9 @@
 """Pi coding agent provider — https://pi.dev behind AgentProvider.
 
-Pi is a Node.js-based CLI with JSONL session transcripts (v3 format) and no
-hook subsystem; session discovery therefore follows the Codex/Gemini pattern:
-scan ``~/.pi/agent/sessions/`` for the newest transcript whose header ``cwd``
+Pi is a Node.js-based CLI with JSONL session transcripts (v3 format). With the
+cc-thingz hook-runner extension, lifecycle hooks provide instant status signals;
+transcript discovery remains the fallback and message source of truth. Discovery
+scans ``~/.pi/agent/sessions/`` for the newest transcript whose header ``cwd``
 matches the window working directory.
 
 Session path:  ``~/.pi/agent/sessions/--<encoded-cwd>--/<timestamp>_<uuid>.jsonl``
@@ -116,8 +117,16 @@ class PiProvider(JsonlProvider):
     _CAPS = ProviderCapabilities(
         name="pi",
         launch_command="pi",
-        supports_hook=False,
-        supports_hook_events=False,
+        supports_hook=True,
+        supports_hook_events=True,
+        hook_event_types=(
+            "SessionStart",
+            "Stop",
+            "SessionEnd",
+            "SubagentStart",
+            "SubagentStop",
+            "Notification",
+        ),
         supports_resume=True,
         supports_continue=True,
         supports_structured_transcript=True,

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_queue.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_queue.py
@@ -246,7 +246,11 @@ class TestDispatch:
     ):
         ct = _content_task("tool", content_type="tool_use")
         mock_tool_event.return_value = None
-        extra = await _dispatch(bot, 1, ct, queue, lock)
+        with patch(
+            "ccgram.handlers.messaging_pipeline.message_queue.is_tool_calls_hidden",
+            return_value=False,
+        ):
+            extra = await _dispatch(bot, 1, ct, queue, lock)
         assert extra == 0
         mock_tool_event.assert_awaited_once_with(bot, 1, ct)
         mock_process.assert_not_awaited()
@@ -269,7 +273,11 @@ class TestDispatch:
         ct = _content_task("tool", content_type="tool_use")
         followup = _content_task("overflow")
         mock_tool_event.return_value = followup
-        await _dispatch(bot, 1, ct, queue, lock)
+        with patch(
+            "ccgram.handlers.messaging_pipeline.message_queue.is_tool_calls_hidden",
+            return_value=False,
+        ):
+            await _dispatch(bot, 1, ct, queue, lock)
         mock_process.assert_awaited_once_with(bot, 1, followup)
 
     @patch(

--- a/tests/ccgram/handlers/messaging_pipeline/test_tool_batching.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_tool_batching.py
@@ -587,7 +587,11 @@ class TestHandleContentTask:
             parts=("Read x",),
         )
         mock_batch.return_value = None
-        extra = await _handle_content_task(bot, 1, task, queue, lock)
+        with patch(
+            "ccgram.handlers.messaging_pipeline.message_queue.is_tool_calls_hidden",
+            return_value=False,
+        ):
+            extra = await _handle_content_task(bot, 1, task, queue, lock)
         assert extra == 0
         mock_batch.assert_awaited_once()
 
@@ -608,7 +612,11 @@ class TestHandleContentTask:
             window_id="@0",
             parts=("Read x",),
         )
-        extra = await _handle_content_task(bot, 1, task, queue, lock)
+        with patch(
+            "ccgram.handlers.messaging_pipeline.message_queue.is_tool_calls_hidden",
+            return_value=False,
+        ):
+            extra = await _handle_content_task(bot, 1, task, queue, lock)
         assert extra == 0
         mock_process.assert_awaited_once()
 

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -873,7 +873,7 @@ class TestProviderSwitchPromptSetup:
                     session_id="",
                     cwd="/proj",
                     provider_name="shell",
-                    transcript_path="",
+                    transcript_path="/path/to/claude.jsonl",
                 )
             }
             mock_tmux.find_window_by_id = AsyncMock(

--- a/tests/ccgram/providers/test_contracts.py
+++ b/tests/ccgram/providers/test_contracts.py
@@ -9,7 +9,6 @@ from ccgram.providers.base import (
     AgentProvider,
     DiscoveredCommand,
     ProviderCapabilities,
-    SessionStartEvent,
     StatusUpdate,
 )
 from ccgram.providers._jsonl import JsonlProvider
@@ -44,18 +43,6 @@ class StubProvider(JsonlProvider):
         if use_continue and self._CAPS.supports_continue:
             return "--continue"
         return ""
-
-    def parse_hook_payload(self, payload: dict[str, Any]) -> SessionStartEvent | None:
-        sid = payload.get("session_id", "")
-        cwd = payload.get("cwd", "")
-        if not sid or not cwd:
-            return None
-        return SessionStartEvent(
-            session_id=sid,
-            cwd=cwd,
-            transcript_path=payload.get("transcript_path", ""),
-            window_key=payload.get("window_key", ""),
-        )
 
 
 PROVIDER_FIXTURES: list[type] = [
@@ -107,38 +94,6 @@ class TestMakeLaunchArgs:
             assert result != ""  # Each provider has its own continue syntax
         else:
             assert result == ""
-
-
-class TestParseHookPayload:
-    def test_valid_payload_returns_event(self, provider: AgentProvider) -> None:
-        payload = {
-            "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-            "cwd": "/tmp/test",
-            "transcript_path": "/tmp/test.jsonl",
-            "window_key": "ccgram:@0",
-        }
-        event = provider.parse_hook_payload(payload)
-        if provider.capabilities.supports_hook:
-            assert event is not None
-            assert isinstance(event, SessionStartEvent)
-            assert event.session_id == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-            assert event.cwd == "/tmp/test"
-        else:
-            assert event is None
-
-    @pytest.mark.parametrize(
-        "payload",
-        [
-            {},
-            {"session_id": ""},
-            {"session_id": "x"},
-        ],
-        ids=["empty", "empty_sid", "invalid_sid_no_cwd"],
-    )
-    def test_invalid_payload_returns_none(
-        self, provider: AgentProvider, payload: dict[str, Any]
-    ) -> None:
-        assert provider.parse_hook_payload(payload) is None
 
 
 class TestParseTranscriptLine:

--- a/tests/ccgram/providers/test_jsonl_providers.py
+++ b/tests/ccgram/providers/test_jsonl_providers.py
@@ -48,28 +48,34 @@ class TestResolvePending:
         assert _resolve_pending(42, pending) == (None, None)
 
 
-HOOKLESS_PROVIDERS = [CodexProvider, GeminiProvider]
+HOOK_AWARE_JSONL_PROVIDERS = [CodexProvider, GeminiProvider]
 
 
-@pytest.fixture(params=HOOKLESS_PROVIDERS, ids=lambda cls: cls.__name__)
-def hookless(request: pytest.FixtureRequest):
+@pytest.fixture(params=HOOK_AWARE_JSONL_PROVIDERS, ids=lambda cls: cls.__name__)
+def hook_aware_jsonl_provider(request: pytest.FixtureRequest):
     return request.param()
 
 
-class TestHooklessCapabilities:
-    def test_hookless_flags(self, hookless) -> None:
-        caps = hookless.capabilities
-        assert caps.supports_hook is False
+@pytest.fixture(params=HOOK_AWARE_JSONL_PROVIDERS, ids=lambda cls: cls.__name__)
+def jsonl_provider(request: pytest.FixtureRequest):
+    return request.param()
+
+
+class TestHookAwareCapabilities:
+    def test_hook_flags(self, hook_aware_jsonl_provider) -> None:
+        caps = hook_aware_jsonl_provider.capabilities
+        assert caps.supports_hook is True
+        assert caps.supports_hook_events is True
         assert caps.supports_resume is True
         assert caps.supports_continue is True
 
-    def test_invalid_resume_id_raises(self, hookless) -> None:
+    def test_invalid_resume_id_raises(self, hook_aware_jsonl_provider) -> None:
         with pytest.raises(ValueError, match="Invalid resume_id"):
-            hookless.make_launch_args(resume_id="abc; rm -rf /")
+            hook_aware_jsonl_provider.make_launch_args(resume_id="abc; rm -rf /")
 
-    def test_valid_resume_ids(self, hookless) -> None:
-        assert hookless.make_launch_args(resume_id="abc-123")
-        assert hookless.make_launch_args(resume_id="session_42")
+    def test_valid_resume_ids(self, hook_aware_jsonl_provider) -> None:
+        assert hook_aware_jsonl_provider.make_launch_args(resume_id="abc-123")
+        assert hook_aware_jsonl_provider.make_launch_args(resume_id="session_42")
 
 
 class TestCodexLaunchArgs:
@@ -1143,10 +1149,10 @@ class TestGeminiPaneTitleStatus:
 
 
 class TestHooklessCommands:
-    def test_returns_exact_builtins(self, hookless) -> None:
-        result = hookless.discover_commands("/tmp/nonexistent")
+    def test_returns_exact_builtins(self, jsonl_provider) -> None:
+        result = jsonl_provider.discover_commands("/tmp/nonexistent")
         names = {c.name for c in result}
-        assert names == set(hookless.capabilities.builtin_commands)
+        assert names == set(jsonl_provider.capabilities.builtin_commands)
 
 
 class TestGeminiCommandDiscovery:

--- a/tests/ccgram/providers/test_pi.py
+++ b/tests/ccgram/providers/test_pi.py
@@ -563,7 +563,8 @@ class TestCapabilities:
         caps = PiProvider().capabilities
         assert caps.name == "pi"
         assert caps.launch_command == "pi"
-        assert caps.supports_hook is False
+        assert caps.supports_hook is True
+        assert caps.supports_hook_events is True
         assert caps.supports_resume is True
         assert caps.supports_continue is True
         assert caps.transcript_format == "jsonl"

--- a/tests/ccgram/providers/test_shell.py
+++ b/tests/ccgram/providers/test_shell.py
@@ -79,15 +79,6 @@ class TestShellOverrides:
     def test_discover_commands_returns_empty(self, provider: ShellProvider) -> None:
         assert provider.discover_commands("/any/dir") == []
 
-    def test_parse_hook_payload_returns_none(self, provider: ShellProvider) -> None:
-        payload = {
-            "session_id": "test-sid",
-            "cwd": "/tmp",
-            "transcript_path": "/tmp/t.jsonl",
-            "window_key": "ccgram:@0",
-        }
-        assert provider.parse_hook_payload(payload) is None
-
     def test_parse_terminal_status_returns_none_for_spinner(
         self, provider: ShellProvider
     ) -> None:

--- a/tests/ccgram/test_bootstrap.py
+++ b/tests/ccgram/test_bootstrap.py
@@ -243,6 +243,7 @@ class TestVerifyHooksInstalled:
     def test_warns_when_settings_file_missing(self, tmp_path):
         provider = MagicMock()
         provider.capabilities.supports_hook = True
+        provider.capabilities.name = "claude"
 
         missing = tmp_path / "missing.json"
 
@@ -254,3 +255,35 @@ class TestVerifyHooksInstalled:
             bootstrap.verify_hooks_installed()
 
         logger.warning.assert_called_once()
+
+    def test_logs_install_hint_for_non_claude_managed_provider(self):
+        provider = MagicMock()
+        provider.capabilities.supports_hook = True
+        provider.capabilities.name = "codex"
+        provider.capabilities.hook_install_managed_by_ccgram = True
+
+        with (
+            patch("ccgram.bootstrap.get_provider", return_value=provider),
+            patch("ccgram.bootstrap.logger") as logger,
+        ):
+            bootstrap.verify_hooks_installed()
+
+        logger.info.assert_called_once()
+        # Message includes the provider name and the install command.
+        args = logger.info.call_args[0]
+        assert "codex" in args
+
+    def test_no_hint_for_non_managed_provider(self):
+        provider = MagicMock()
+        provider.capabilities.supports_hook = True
+        provider.capabilities.name = "pi"
+        provider.capabilities.hook_install_managed_by_ccgram = False
+
+        with (
+            patch("ccgram.bootstrap.get_provider", return_value=provider),
+            patch("ccgram.bootstrap.logger") as logger,
+        ):
+            bootstrap.verify_hooks_installed()
+
+        logger.info.assert_not_called()
+        logger.warning.assert_not_called()

--- a/tests/ccgram/test_claude_characterization.py
+++ b/tests/ccgram/test_claude_characterization.py
@@ -8,7 +8,7 @@ tests in test_provider_contracts.py.
 import pytest
 
 from ccgram.cc_commands import CC_BUILTINS
-from ccgram.hook import UUID_RE
+from ccgram.providers.base import UUID_RE
 from ccgram.terminal_parser import (
     STATUS_SPINNERS,
     UI_PATTERNS,
@@ -48,22 +48,6 @@ class TestClaudeProviderMethods:
         provider = ClaudeProvider()
         with pytest.raises(ValueError, match="Invalid resume_id"):
             provider.make_launch_args(resume_id="not-a-uuid")
-
-    def test_relative_cwd_rejected(self) -> None:
-        provider = ClaudeProvider()
-        payload = {
-            "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-            "cwd": "relative/path",
-        }
-        assert provider.parse_hook_payload(payload) is None
-
-    def test_invalid_uuid_in_hook_rejected(self) -> None:
-        provider = ClaudeProvider()
-        payload = {
-            "session_id": "NOT-A-VALID-UUID",
-            "cwd": "/tmp/test",
-        }
-        assert provider.parse_hook_payload(payload) is None
 
     def test_parse_transcript_entries_adapter(self, make_jsonl_entry) -> None:
         entries = [

--- a/tests/ccgram/test_doctor_cmd.py
+++ b/tests/ccgram/test_doctor_cmd.py
@@ -143,7 +143,9 @@ class TestCheckHooks:
 
         status, msg, event_status = _check_hooks()
         assert status == "fail"
-        assert event_status == {}
+        # Populated with {event: False} so doctor --fix can install them.
+        assert event_status
+        assert all(v is False for v in event_status.values())
 
 
 class TestDoctorMain:
@@ -164,7 +166,11 @@ class TestDoctorMain:
         )
         monkeypatch.setattr(
             "ccgram.doctor_cmd._check_hooks",
-            lambda: ("pass", "all 5 hook events installed", _all_hooks_status()),
+            lambda _provider="claude": (
+                "pass",
+                "all 5 hook events installed",
+                _all_hooks_status(),
+            ),
         )
         monkeypatch.setattr(
             "ccgram.doctor_cmd._find_orphaned_windows",
@@ -195,7 +201,11 @@ class TestDoctorMain:
         )
         monkeypatch.setattr(
             "ccgram.doctor_cmd._check_hooks",
-            lambda: ("pass", "all 5 hook events installed", _all_hooks_status()),
+            lambda _provider="claude": (
+                "pass",
+                "all 5 hook events installed",
+                _all_hooks_status(),
+            ),
         )
         monkeypatch.setattr("ccgram.doctor_cmd._find_orphaned_windows", lambda: [])
 
@@ -205,7 +215,7 @@ class TestDoctorMain:
         captured = capsys.readouterr()
         assert "Provider: claude" in captured.out
 
-    def test_skips_hook_check_for_hookless_provider(
+    def test_reports_missing_hooks_for_codex_provider(
         self, tmp_path, monkeypatch, capsys
     ) -> None:
         monkeypatch.setenv("CCGRAM_DIR", str(tmp_path))
@@ -229,7 +239,7 @@ class TestDoctorMain:
 
         captured = capsys.readouterr()
         assert "Provider: codex" in captured.out
-        assert "hook check skipped" in captured.out
+        assert "hooks not installed" in captured.out
 
 
 class TestCheckProviderCommand:

--- a/tests/ccgram/test_hook.py
+++ b/tests/ccgram/test_hook.py
@@ -8,17 +8,22 @@ from unittest.mock import patch
 import pytest
 
 from ccgram.hook import (
-    UUID_RE,
     _claude_settings_file,
     _closest_claude_ancestor,
     _foreground_pgid_on_tty,
     _hook_status,
     _install_hook,
-    _is_hook_installed,
     _is_nested_session,
+    _provider_from_pane_tty,
     _uninstall_hook,
+    get_installed_events,
     hook_main,
 )
+from ccgram.providers.base import UUID_RE
+
+
+def _is_hook_installed(settings: dict) -> bool:
+    return get_installed_events(settings).get("SessionStart", False)
 
 
 def _expected_module_command() -> str:
@@ -915,3 +920,39 @@ class TestNestedHookEndToEnd:
         with patch("ccgram.hook.subprocess.run", return_value=tmux_result):
             hook_main()
         assert (tmp_path / "session_map.json").exists()
+
+
+class TestProviderFromPaneTty:
+    def _run(self, stdout: str) -> object:
+        result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=stdout, stderr=""
+        )
+        with patch("ccgram.hook.subprocess.run", return_value=result):
+            return _provider_from_pane_tty("/dev/ttys012")
+
+    def test_detects_gemini(self) -> None:
+        assert self._run("/usr/local/bin/gemini --model flash\n") == "gemini"
+
+    def test_detects_codex(self) -> None:
+        assert self._run("/usr/local/bin/codex\n") == "codex"
+
+    def test_detects_claude(self) -> None:
+        assert self._run("/usr/local/bin/claude\n") == "claude"
+
+    def test_detects_pi_exact_basename(self) -> None:
+        assert self._run("/usr/local/bin/pi\n") == "pi"
+
+    def test_pi_does_not_match_pip(self) -> None:
+        assert self._run("/usr/bin/pip install requests\n") is None
+
+    def test_pi_does_not_match_pipenv(self) -> None:
+        assert self._run("/usr/local/bin/pipenv shell\n") is None
+
+    def test_pi_does_not_match_pip3(self) -> None:
+        assert self._run("/usr/bin/pip3 install foo\n") is None
+
+    def test_empty_tty_returns_none(self) -> None:
+        assert _provider_from_pane_tty("") is None
+
+    def test_unknown_process_returns_none(self) -> None:
+        assert self._run("/usr/bin/python3 script.py\n") is None

--- a/tests/ccgram/test_hook_provider_events.py
+++ b/tests/ccgram/test_hook_provider_events.py
@@ -1,0 +1,203 @@
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from ccgram.hook import _encode_pi_cwd_dirname, _install_hook, hook_main
+
+
+def _tmux_result() -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="ccgram\t@0\tproject\n", stderr=""
+    )
+
+
+def _run_hook(monkeypatch, payload: dict[str, object], provider_name: str) -> None:
+    monkeypatch.setenv("TMUX_PANE", "%0")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    with patch("ccgram.hook.subprocess.run", return_value=_tmux_result()):
+        hook_main(provider_name=provider_name)
+
+
+def test_pi_session_start_writes_provider_and_resolves_transcript(
+    tmp_path: Path, monkeypatch
+) -> None:
+    cwd = str(tmp_path / "proj")
+    session_id = "019e214d-7011-754d-9efb-60106dfa967c"
+    transcript_dir = (
+        tmp_path / ".pi" / "agent" / "sessions" / _encode_pi_cwd_dirname(cwd)
+    )
+    transcript_dir.mkdir(parents=True)
+    transcript = transcript_dir / f"2026-05-13T12-26-23-633Z_{session_id}.jsonl"
+    transcript.write_text('{"type":"session"}\n')
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CCGRAM_DIR", str(tmp_path / "state"))
+
+    _run_hook(
+        monkeypatch,
+        {
+            "session_id": session_id,
+            "cwd": cwd,
+            "hook_event_name": "SessionStart",
+            "source": "startup",
+        },
+        "pi",
+    )
+
+    session_map = json.loads((tmp_path / "state" / "session_map.json").read_text())
+    entry = session_map["ccgram:@0"]
+    assert entry["provider_name"] == "pi"
+    assert entry["transcript_path"] == str(transcript)
+
+
+_CODEX_SESSION_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+_GEMINI_SESSION_ID = "b2c3d4e5-f678-90ab-cdef-1234567890ab"
+
+
+def test_codex_stop_redacts_raw_prompt_and_tool_payload(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("CCGRAM_DIR", str(tmp_path))
+    _run_hook(
+        monkeypatch,
+        {
+            "session_id": _CODEX_SESSION_ID,
+            "cwd": "/tmp/project",
+            "transcript_path": "/tmp/.codex/session.jsonl",
+            "hook_event_name": "Stop",
+            "model": "gpt-5",
+            "permission_mode": "default",
+            "turn_id": "turn",
+            "stop_hook_active": False,
+            "last_assistant_message": "secret output",
+        },
+        "codex",
+    )
+
+    event = json.loads((tmp_path / "events.jsonl").read_text())
+    assert event["event"] == "Stop"
+    assert event["data"]["provider_name"] == "codex"
+    assert "last_assistant_message" not in event["data"]
+
+
+def test_codex_adapter_rejects_non_uuid_session_id() -> None:
+    from ccgram.hooks.adapters import get_hook_adapter
+
+    adapter = get_hook_adapter("codex")
+    assert adapter is not None
+    result = adapter.normalize(
+        {
+            "session_id": "not-a-uuid",
+            "cwd": "/tmp/project",
+            "hook_event_name": "Stop",
+        }
+    )
+    assert result is None
+
+
+def test_pi_adapter_rejects_non_uuid_session_id() -> None:
+    from ccgram.hooks.adapters import get_hook_adapter
+
+    adapter = get_hook_adapter("pi")
+    assert adapter is not None
+    result = adapter.normalize(
+        {
+            "session_id": "garbage",
+            "cwd": "/tmp/project",
+            "hook_event_name": "Stop",
+        }
+    )
+    assert result is None
+
+
+def test_gemini_after_agent_maps_to_stop(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("CCGRAM_DIR", str(tmp_path))
+    _run_hook(
+        monkeypatch,
+        {
+            "session_id": _GEMINI_SESSION_ID,
+            "cwd": "/tmp/project",
+            "transcript_path": "/tmp/.gemini/session.jsonl",
+            "hook_event_name": "AfterAgent",
+            "timestamp": "2026-05-13T00:00:00Z",
+            "prompt": "do thing",
+            "prompt_response": "done",
+        },
+        "gemini",
+    )
+
+    event = json.loads((tmp_path / "events.jsonl").read_text())
+    assert event["event"] == "Stop"
+    assert event["data"]["provider_name"] == "gemini"
+    assert event["data"]["native_event_name"] == "AfterAgent"
+    assert "prompt" not in event["data"]
+    assert "prompt_response" not in event["data"]
+
+
+def test_detect_provider_from_payload_defaults_to_none() -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    assert detect_provider_from_payload({}) is None
+
+
+def test_detect_provider_from_payload_uses_transcript_path_codex() -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    assert (
+        detect_provider_from_payload({"transcript_path": "/home/u/.codex/sess.jsonl"})
+        == "codex"
+    )
+
+
+def test_detect_provider_from_payload_uses_transcript_path_gemini() -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    assert (
+        detect_provider_from_payload({"transcript_path": "/home/u/.gemini/sess.jsonl"})
+        == "gemini"
+    )
+
+
+def test_detect_provider_from_payload_uses_transcript_path_pi() -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    assert (
+        detect_provider_from_payload({"transcript_path": "/home/u/.pi/agent/s.jsonl"})
+        == "pi"
+    )
+
+
+def test_detect_provider_from_payload_uses_explicit_provider_field() -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    assert detect_provider_from_payload({"provider_name": "codex"}) == "codex"
+
+
+def test_detect_provider_from_payload_uses_gemini_only_event_name() -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    # AfterAgent is unique to Gemini
+    assert detect_provider_from_payload({"hook_event_name": "AfterAgent"}) == "gemini"
+
+
+def test_gemini_install_adds_provider_specific_hooks(
+    tmp_path: Path, monkeypatch
+) -> None:
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr("ccgram.hook._gemini_settings_file", lambda: settings_file)
+
+    assert _install_hook("gemini") == 0
+    assert _install_hook("gemini") == 0
+
+    settings = json.loads(settings_file.read_text())
+    hooks = settings["hooks"]
+    for event_type in ("SessionStart", "AfterAgent", "SessionEnd", "Notification"):
+        matches = [
+            hook
+            for group in hooks[event_type]
+            for hook in group["hooks"]
+            if "--provider gemini" in hook["command"]
+        ]
+        assert len(matches) == 1

--- a/tests/ccgram/test_status_cmd.py
+++ b/tests/ccgram/test_status_cmd.py
@@ -115,9 +115,7 @@ class TestStatusMain:
         assert "hook" in captured.out
         assert "resume" in captured.out
 
-    def test_hookless_provider_capabilities(
-        self, tmp_path, monkeypatch, capsys
-    ) -> None:
+    def test_codex_provider_capabilities(self, tmp_path, monkeypatch, capsys) -> None:
         monkeypatch.setenv("CCGRAM_DIR", str(tmp_path))
         monkeypatch.setenv("CCGRAM_PROVIDER", "codex")
         monkeypatch.setenv("TMUX_SESSION_NAME", "test")
@@ -128,4 +126,4 @@ class TestStatusMain:
 
         captured = capsys.readouterr()
         assert "Provider: codex" in captured.out
-        assert "hook" not in captured.out.split("Provider:")[1].split("\n")[0]
+        assert "hook" in captured.out.split("Provider:")[1].split("\n")[0]


### PR DESCRIPTION
## Summary

Generalizes the hook subsystem so Codex, Gemini, and Pi become first-class hook citizens alongside Claude. Hooks are still optional — when absent, JSONL-based providers fall back to transcript-scan discovery, so this is a latency / signal-quality improvement, not a hard new dependency.

- **New `src/ccgram/hooks/` subpackage** with normalized `NormalizedHookEvent` model and per-provider `HookAdapter` Protocol. Adapters validate session_id (UUID for Claude/Codex/Pi, free-form for Gemini), reject empty cwd on `SessionStart`, sanitize sensitive payload fields, and detect provider from payload as a fallback when the installed hook lacks `--provider`.
- **`ccgram hook --provider {claude,pi,codex,gemini}`** drives provider-aware install / uninstall / status. Codex writes to `~/.codex/hooks.json` + `~/.codex/config.toml`; Gemini writes to `~/.gemini/settings.json`; Pi is delegated to the cc-thingz hook-runner extension (ccgram observes events but never modifies Pi config); Claude path unchanged. JSON-format installs use atomic write (temp + fsync + rename) and early-return on no-op uninstall so user configs aren't silently reformatted.
- **`ProviderCapabilities`** gains `hook_install_managed_by_ccgram` — distinct from `supports_hook` (Pi observes, Codex/Gemini ccgram installs).
- **`transcript_discovery`** now gates the hook short-circuit on `state.transcript_path` populated (= hook fired and wired state), not bare capability. Codex/Gemini without hooks installed yet still get their transcript scanned.
- **`doctor [--fix]`** is provider-aware; missing settings files return populated `{event: False}` so `--fix` has events to install.
- **`bootstrap.verify_hooks_installed`** logs an INFO hint for non-Claude managed providers (fallback works, so it's an improvement opportunity, not a degradation).

## Why

Before this PR, only Claude got the hook fast-path (instant status / interactive-UI / subagent events). Codex, Gemini, and Pi inferred state from JSONL polling + pane scraping, ~1-2s slower per signal. The capability flag misuse (`supports_hook` gated transcript-scan fallback) also meant flipping providers to support hooks would have silently broken un-installed users — this PR fixes both at once.

## Test plan

- [x] `make check` — 4749 unit + 266 integration green, ruff clean, pyright 0 errors
- [x] New `tests/ccgram/test_hook_provider_events.py`: UUID-rejection per provider, `detect_provider_from_payload` heuristics, Pi transcript resolution, Codex Stop redaction, Gemini AfterAgent→Stop mapping, install idempotency
- [x] Bootstrap test coverage for non-Claude managed (INFO hint) and non-managed (no log) paths
- [x] `doctor --fix` path covered for missing settings files
- [ ] Manual smoke: `ccgram hook --provider codex --install` then verify `~/.codex/hooks.json` contains `--provider codex` entries
- [ ] Manual smoke: `ccgram hook --provider gemini --install` then verify `~/.gemini/settings.json` carries timeout=5000ms entries
- [ ] Manual smoke: `ccgram doctor` reports correct hook status per active provider; `--fix` installs when absent

## Notes

- One pre-existing xdist flake (`test_uses_pyte_result_when_available`) is documented in CLAUDE.md and unaffected by this change.
- Codex `[features].codex_hooks = true` is verified against OpenAI Codex docs as the correct flag (an earlier reviewer suggestion of `features.hooks = true` was based on outdated info and was not applied).