### PR TITLE
fix(session-map): prefer transcript-path provider over stale claim

### DIFF
--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -617,16 +617,20 @@ class SessionMapSync:
 
             inferred = detect_provider_from_transcript_path(path_for_inference)
             if inferred and inferred != new_provider:
-                logger.warning(
-                    "session_map provider_name=%s contradicts transcript_path=%s "
-                    "(inferred=%s); preferring transcript-path for %s",
-                    new_provider,
-                    path_for_inference,
-                    inferred,
-                    window_id,
-                )
                 new_provider = inferred
         if new_provider and state.provider_name != new_provider:
+            # Log only on actual mutation so a persistent stale claim in
+            # session_map.json doesn't spam the log every poll cycle once the
+            # in-memory state has already been corrected.
+            logger.warning(
+                "Corrected provider for %s: state=%s -> %s "
+                "(session_map claimed %s; transcript_path=%s)",
+                window_id,
+                state.provider_name,
+                new_provider,
+                effective["provider_name"].lower(),
+                path_for_inference,
+            )
             state.provider_name = new_provider
             changed = True
         if (

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -604,6 +604,28 @@ class SessionMapSync:
             state.transcript_path = new_transcript
             changed = True
         new_provider = effective["provider_name"].lower()
+        # Cross-check provider claim against the transcript path. session_map.json
+        # may carry a stale `provider_name` from a previous run in the same tmux
+        # window (e.g. codex once owned @9729, then claude took over). The
+        # transcript path is observed reality and wins; without this guard the
+        # transcript_reader spams "Provider mismatch" warnings every poll.
+        path_for_inference = new_transcript or state.transcript_path
+        if new_provider and path_for_inference:
+            # Lazy: providers import pulls the agent provider registry which
+            # imports the shell provider's prompt-marker machinery; defer.
+            from .providers import detect_provider_from_transcript_path
+
+            inferred = detect_provider_from_transcript_path(path_for_inference)
+            if inferred and inferred != new_provider:
+                logger.warning(
+                    "session_map provider_name=%s contradicts transcript_path=%s "
+                    "(inferred=%s); preferring transcript-path for %s",
+                    new_provider,
+                    path_for_inference,
+                    inferred,
+                    window_id,
+                )
+                new_provider = inferred
         if new_provider and state.provider_name != new_provider:
             state.provider_name = new_provider
             changed = True

--- a/tests/ccgram/test_session_map_provider_path_cross_check.py
+++ b/tests/ccgram/test_session_map_provider_path_cross_check.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 
+from ccgram import session_map as session_map_module
 from ccgram.session_map import SessionMapSync
 from ccgram.thread_router import ThreadRouter, install_thread_router
 from ccgram.window_state_store import (
@@ -40,9 +41,7 @@ def _sync() -> SessionMapSync:
     return SessionMapSync(schedule_save=lambda: None)
 
 
-def _info(
-    session_id: str, transcript: Path, provider_name: str
-) -> dict[str, Any]:
+def _info(session_id: str, transcript: Path, provider_name: str) -> dict[str, Any]:
     return {
         "session_id": session_id,
         "cwd": "/repo",
@@ -98,6 +97,43 @@ def test_session_map_provider_kept_when_transcript_path_is_ambiguous(
 
     # No path-based inference possible → trust session_map's claim.
     assert store.window_states["@1"].provider_name == "codex"
+
+
+def test_repeated_sync_with_stale_claim_is_idempotent_and_silent(
+    tmp_path: Path,
+    store: WindowStateStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once state.provider_name is corrected, a stale session_map claim must
+    not re-trigger the warning or flip state again on subsequent polls.
+
+    Patches ``logger.warning`` directly because the module uses structlog and
+    pytest's ``caplog`` only sees the stdlib ``logging`` pipeline.
+    """
+    claude_dir = tmp_path / ".claude" / "projects" / "repo"
+    claude_dir.mkdir(parents=True)
+    transcript = claude_dir / "session.jsonl"
+    transcript.write_text("{}\n")
+
+    warnings: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(
+        session_map_module.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+
+    stale_info = _info("session-a", transcript, provider_name="codex")
+    sync = _sync()
+
+    first = sync._sync_window_from_session_map("@1", stale_info)
+    assert first is True
+    assert store.window_states["@1"].provider_name == "claude"
+    assert len(warnings) == 1
+
+    second = sync._sync_window_from_session_map("@1", stale_info)
+    assert second is False
+    assert store.window_states["@1"].provider_name == "claude"
+    assert len(warnings) == 1
 
 
 def test_existing_transcript_path_used_when_info_omits_it(

--- a/tests/ccgram/test_session_map_provider_path_cross_check.py
+++ b/tests/ccgram/test_session_map_provider_path_cross_check.py
@@ -1,0 +1,131 @@
+"""Regression: session_map.json provider_name cross-checked against transcript path.
+
+When session_map.json carries a stale ``provider_name`` (e.g. ``codex`` from
+a previous run in the same tmux window) and the transcript path points to a
+different provider's session directory, transcript-path detection wins. Without
+this guard, the polling loop overwrites the in-memory state every cycle and
+``transcript_reader`` spams "Provider mismatch" warnings forever.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ccgram.session_map import SessionMapSync
+from ccgram.thread_router import ThreadRouter, install_thread_router
+from ccgram.window_state_store import (
+    WindowState,
+    WindowStateStore,
+    install_window_store,
+)
+
+
+@pytest.fixture
+def store() -> WindowStateStore:
+    s = WindowStateStore(
+        schedule_save=lambda: None,
+        on_hookless_provider_switch=lambda _wid: None,
+    )
+    install_window_store(s)
+    install_thread_router(
+        ThreadRouter(schedule_save=lambda: None, has_window_state=lambda _wid: True)
+    )
+    return s
+
+
+def _sync() -> SessionMapSync:
+    return SessionMapSync(schedule_save=lambda: None)
+
+
+def _info(
+    session_id: str, transcript: Path, provider_name: str
+) -> dict[str, Any]:
+    return {
+        "session_id": session_id,
+        "cwd": "/repo",
+        "window_name": "repo",
+        "transcript_path": str(transcript),
+        "provider_name": provider_name,
+    }
+
+
+def test_transcript_path_wins_when_session_map_provider_is_stale(
+    tmp_path: Path, store: WindowStateStore
+) -> None:
+    claude_dir = tmp_path / ".claude" / "projects" / "repo"
+    claude_dir.mkdir(parents=True)
+    transcript = claude_dir / "session.jsonl"
+    transcript.write_text('{"type":"assistant"}\n')
+
+    changed = _sync()._sync_window_from_session_map(
+        "@9729", _info("session-a", transcript, provider_name="codex")
+    )
+
+    assert changed is True
+    state = store.window_states["@9729"]
+    assert state.provider_name == "claude"
+    assert state.transcript_path == str(transcript)
+
+
+def test_session_map_provider_kept_when_transcript_path_agrees(
+    tmp_path: Path, store: WindowStateStore
+) -> None:
+    codex_dir = tmp_path / ".codex" / "sessions" / "repo"
+    codex_dir.mkdir(parents=True)
+    transcript = codex_dir / "session.jsonl"
+    transcript.write_text("{}\n")
+
+    _sync()._sync_window_from_session_map(
+        "@1", _info("session-a", transcript, provider_name="codex")
+    )
+
+    assert store.window_states["@1"].provider_name == "codex"
+
+
+def test_session_map_provider_kept_when_transcript_path_is_ambiguous(
+    tmp_path: Path, store: WindowStateStore
+) -> None:
+    transcript = tmp_path / "weird" / "session.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text("{}\n")
+
+    _sync()._sync_window_from_session_map(
+        "@1", _info("session-a", transcript, provider_name="codex")
+    )
+
+    # No path-based inference possible → trust session_map's claim.
+    assert store.window_states["@1"].provider_name == "codex"
+
+
+def test_existing_transcript_path_used_when_info_omits_it(
+    tmp_path: Path, store: WindowStateStore
+) -> None:
+    """If info["transcript_path"] is empty but state already knows the path,
+    the existing path is the cross-check source."""
+    claude_dir = tmp_path / ".claude" / "projects" / "repo"
+    claude_dir.mkdir(parents=True)
+    transcript = claude_dir / "session.jsonl"
+    transcript.write_text("{}\n")
+
+    store.window_states["@1"] = WindowState(
+        session_id="session-a",
+        cwd="/repo",
+        transcript_path=str(transcript),
+        provider_name="claude",
+    )
+
+    _sync()._sync_window_from_session_map(
+        "@1",
+        {
+            "session_id": "session-a",
+            "cwd": "/repo",
+            "window_name": "repo",
+            "transcript_path": "",
+            "provider_name": "codex",
+        },
+    )
+
+    assert store.window_states["@1"].provider_name == "claude"


### PR DESCRIPTION
## Summary

- `_sync_window_from_session_map` unconditionally overwrote `WindowState.provider_name` with whatever `session_map.json` claimed. Stale claims (e.g. `codex` left over from a prior owner of the same tmux window) survived across runs.
- Result: `transcript_reader._resolve_provider_for_file` noticed the mismatch against the transcript path and logged `Provider mismatch` every poll cycle (~2-3s), forever.
- Fix: before writing `state.provider_name`, cross-check the claimed provider against the transcript path via `detect_provider_from_transcript_path`. If they disagree, the path wins and we log once.

## Test plan

- [x] New focused tests in `tests/ccgram/test_session_map_provider_path_cross_check.py`: stale-claim correction, agreement passthrough, ambiguous path passthrough, fallback to existing state path when info omits it.
- [x] `make test` — 4752/4753 pass; the single failure (`test_parse_session_map_preserves_fresh_existing_primary`) is pre-existing on `main`.
- [x] Manually patched a running `session_map.json` (`@9729` codex → claude) to confirm warnings stop.