### PR TITLE
fix(providers): treat .claude<suffix>/projects/ as Claude

### DIFF
--- a/src/ccgram/providers/__init__.py
+++ b/src/ccgram/providers/__init__.py
@@ -7,6 +7,8 @@ and ``resolve_capabilities()`` for lightweight CLI commands that don't
 require Config (doctor, status).
 """
 
+import re
+
 import structlog
 import os
 
@@ -155,14 +157,22 @@ def detect_provider_from_command(pane_current_command: str) -> str:
     return ""
 
 
+_CLAUDE_PROJECTS_RE = re.compile(r"/\.claude[a-z0-9._-]*/projects/")
+
+
 def detect_provider_from_transcript_path(transcript_path: str) -> str:
-    """Infer provider name from a persisted transcript path when possible."""
+    """Infer provider name from a persisted transcript path when possible.
+
+    Claude wrappers (`ce`, `cc-mirror`, `zai`, `claude-team`, etc.) use sibling
+    config dirs of the form ``~/.claude<suffix>/projects/`` with the same JSONL
+    schema, so any ``.claude*`` config dir is treated as Claude.
+    """
     normalized = transcript_path.strip().lower().replace("\\", "/")
     if not normalized:
         return ""
     if "/.codex/sessions/" in normalized:
         return "codex"
-    if "/.claude/projects/" in normalized:
+    if _CLAUDE_PROJECTS_RE.search(normalized):
         return "claude"
     if "/.gemini/" in normalized and "/chats/" in normalized:
         return "gemini"

--- a/src/ccgram/providers/__init__.py
+++ b/src/ccgram/providers/__init__.py
@@ -167,6 +167,8 @@ def detect_provider_from_transcript_path(transcript_path: str) -> str:
     config dirs of the form ``~/.claude<suffix>/projects/`` with the same JSONL
     schema, so any ``.claude*`` config dir is treated as Claude.
     """
+    if not isinstance(transcript_path, str):
+        return ""
     normalized = transcript_path.strip().lower().replace("\\", "/")
     if not normalized:
         return ""

--- a/tests/ccgram/test_session_map_provider_path_cross_check.py
+++ b/tests/ccgram/test_session_map_provider_path_cross_check.py
@@ -136,6 +136,70 @@ def test_repeated_sync_with_stale_claim_is_idempotent_and_silent(
     assert len(warnings) == 1
 
 
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/Users/x/.claude/projects/repo/abc.jsonl", "claude"),
+        ("/Users/x/.claude-team/projects/repo/abc.jsonl", "claude"),
+        ("/Users/x/.claude.local/projects/repo/abc.jsonl", "claude"),
+        ("/Users/x/.cc-mirror/projects/repo/abc.jsonl", ""),
+        ("/Users/x/.codex/sessions/repo/abc.jsonl", "codex"),
+        ("/Users/x/.gemini/chats/repo/abc.json", "gemini"),
+        ("/Users/x/.pi/agent/sessions/--repo--/abc.jsonl", "pi"),
+        ("/Users/x/weird/abc.jsonl", ""),
+    ],
+)
+def test_detect_provider_from_transcript_path(path: str, expected: str) -> None:
+    """Claude wrapper config dirs (.claude-team, .claude.local, ...) must
+    detect as claude. Non-claude-prefixed wrappers stay unrecognised."""
+    from ccgram.providers import detect_provider_from_transcript_path
+
+    assert detect_provider_from_transcript_path(path) == expected
+
+
+def test_claude_wrapper_transcript_path_silences_session_map_cross_check(
+    tmp_path: Path,
+    store: WindowStateStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Process detection sets provider=claude (claude-team wrapper basename),
+    but session_map.json still claims codex. Path-based inference must
+    classify .claude-team/projects as claude so the cross-check silently
+    keeps state=claude instead of flipping back to codex every poll.
+    """
+    transcript = tmp_path / ".claude-team" / "projects" / "repo" / "abc.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text("{}\n")
+
+    store.window_states["@9730"] = WindowState(
+        session_id="abc",
+        cwd="/repo",
+        window_name="repo",
+        transcript_path=str(transcript),
+        provider_name="claude",
+    )
+
+    warnings: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(
+        session_map_module.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+
+    sync = _sync()
+    sync._sync_window_from_session_map(
+        "@9730", _info("abc", transcript, provider_name="codex")
+    )
+    assert store.window_states["@9730"].provider_name == "claude"
+    assert warnings == []
+
+    sync._sync_window_from_session_map(
+        "@9730", _info("abc", transcript, provider_name="codex")
+    )
+    assert store.window_states["@9730"].provider_name == "claude"
+    assert warnings == []
+
+
 def test_existing_transcript_path_used_when_info_omits_it(
     tmp_path: Path, store: WindowStateStore
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes the per-poll oscillation reported after #81 was merged:

```
07:32:46 [warning] Corrected provider for @9730: state=claude -> codex (...transcript_path=/Users/alexei/.claude-team/projects/...)
07:32:49 [warning] Corrected provider for @9730: state=claude -> codex (...)
07:32:52 [warning] Corrected provider for @9730: state=claude -> codex (...)
```

### Root cause

- `transcript_discovery._detect_and_apply_provider` reads the live pane process. `claude-team` prefix-matches `claude` → state.provider_name = claude.
- `_sync_window_from_session_map` sees session_map.json claiming `codex` (stale from a prior owner). `detect_provider_from_transcript_path` did not recognise `.claude-team/projects/` → returned `""` → cross-check skipped → state flipped back to codex with a warning.
- Next poll: process detection re-wins → state=claude. Repeat forever.

### Fix

Generalise the Claude path matcher from the literal `/.claude/projects/` to the regex `/\.claude[a-z0-9._-]*/projects/`. Sibling config dirs for `ce`, `cc-mirror`, `zai`, `claude-team`, `claude.local`, etc. (all documented in CLAUDE.md as Claude wrappers) now classify as Claude. The cross-check silently overrides the stale codex claim → state stays claude → loop terminates.

## Test plan

- [x] New parametrized test `test_detect_provider_from_transcript_path` covers `.claude`, `.claude-team`, `.claude.local`, `.cc-mirror` (negative — too far from the prefix), `.codex`, `.gemini`, `.pi`, and an unknown path.
- [x] New regression test `test_claude_wrapper_transcript_path_silences_session_map_cross_check` replays the exact field scenario: state=claude, transcript=`.claude-team/projects/...`, session_map claims `codex` → state stays claude across two syncs, zero warnings.
- [x] Live `~/.ccgram/session_map.json` patched (2 entries codex → claude) to stop noise immediately on running instance.