### PR TITLE
fix(gemini): extract question from boxed prompts (#75)

### DIFF
--- a/src/ccgram/providers/gemini.py
+++ b/src/ccgram/providers/gemini.py
@@ -166,13 +166,16 @@ _BOX_OPEN_RE = re.compile(r"^\s*[╭┌╔]")
 _BOX_CLOSE_RE = re.compile(r"^\s*[╰└╚]")
 _BOX_SIDE_RE = re.compile(r"^\s*[│┃║|]\s?|\s*[│┃║|]\s*$")
 _BOX_GLYPHS = frozenset("─━═│┃║|╭╮╰╯┌┐└┘╔╗╚╝ ")
-_GEMINI_INTERACTIVE_MARKERS = (
+# Any one of these unambiguously marks an interactive prompt.
+_GEMINI_STRONG_MARKERS = (
     re.compile(r"^\s*[●❯]\s*\d+\."),  # selected option marker
-    re.compile(r"^\s*\d+\.\s"),  # numbered option
     re.compile(r"(?i)\benter to (submit|select|confirm|continue)\b"),
     re.compile(r"(?i)\(press esc to (close|cancel)\)"),
     re.compile(r"(?i)\(esc\b"),
 )
+# A bare numbered line is weak — a single one may be prose. Require ≥2.
+_GEMINI_NUMBERED_OPTION_RE = re.compile(r"^\s*\d+\.\s")
+_MIN_NUMBERED_OPTIONS = 2
 _PERMISSION_HINT_RE = re.compile(
     r"(?i)\b(allow|permission|denied|proceed|approve)\b|\(esc\b"
 )
@@ -198,7 +201,14 @@ def _clean_box_lines(lines: list[str]) -> list[str]:
 
 
 def _extract_active_box(pane_text: str) -> str | None:
-    """Return the cleaned content of the last (active) box, or None."""
+    """Return the cleaned content of the active box, or None.
+
+    Conservative against torn captures: returns content only for a single
+    well-formed box at the bottom. A dangling open border below the last
+    close (active box mid-render) or another box boundary between the
+    matched open and close yields None — the next poll re-reads a complete
+    frame rather than surfacing a stale earlier box.
+    """
     lines = pane_text.split("\n")
     close_idx = next(
         (i for i in range(len(lines) - 1, -1, -1) if _BOX_CLOSE_RE.match(lines[i])),
@@ -206,10 +216,15 @@ def _extract_active_box(pane_text: str) -> str | None:
     )
     if close_idx is None:
         return None
-    open_idx = next(
-        (i for i in range(close_idx - 1, -1, -1) if _BOX_OPEN_RE.match(lines[i])),
-        None,
-    )
+    if any(_BOX_OPEN_RE.match(lines[i]) for i in range(close_idx + 1, len(lines))):
+        return None
+    open_idx: int | None = None
+    for i in range(close_idx - 1, -1, -1):
+        if _BOX_CLOSE_RE.match(lines[i]):
+            return None
+        if _BOX_OPEN_RE.match(lines[i]):
+            open_idx = i
+            break
     if open_idx is None:
         return None
     inner = _clean_box_lines(lines[open_idx + 1 : close_idx])
@@ -217,11 +232,21 @@ def _extract_active_box(pane_text: str) -> str | None:
 
 
 def _box_is_interactive(box_text: str) -> bool:
-    """True when the box content carries an interactive affordance."""
-    return any(
-        any(marker.search(line) for marker in _GEMINI_INTERACTIVE_MARKERS)
-        for line in box_text.split("\n")
-    )
+    """True when the box content carries an interactive affordance.
+
+    Any strong marker (selected ``●``/``❯`` option, footer hint) is
+    sufficient. A bare numbered list needs ≥2 entries so a single ``1.``
+    line in informational prose is not misread as a prompt.
+    """
+    numbered = 0
+    for line in box_text.split("\n"):
+        if any(marker.search(line) for marker in _GEMINI_STRONG_MARKERS):
+            return True
+        if _GEMINI_NUMBERED_OPTION_RE.search(line):
+            numbered += 1
+            if numbered >= _MIN_NUMBERED_OPTIONS:
+                return True
+    return False
 
 
 _TRANSCRIPT_MAX_AGE_SECS = 120.0

--- a/src/ccgram/providers/gemini.py
+++ b/src/ccgram/providers/gemini.py
@@ -146,6 +146,84 @@ GEMINI_UI_PATTERNS: list[UIPattern] = [
 ]
 
 
+# ── Boxed-prompt extraction (Gemini CLI ≥ 0.42) ─────────────────────────
+#
+# Modern Gemini wraps every interactive prompt in a rounded box:
+#
+#   ╭──────────────────────────────────────────────╮
+#   │ Allow execution of: 'whoami'?                 │
+#   │ ● 1. Allow once                               │
+#   │   2. Allow for this session                   │
+#   │   4. No, suggest changes (esc                 │
+#   ╰──────────────────────────────────────────────╯
+#
+# There is no bare "Action Required"/"Select" line in-pane — that text now
+# lives only in the OSC pane title. The regex UIPattern anchors therefore
+# never match real ≥0.42 output, so the question is extracted directly from
+# the box instead.  Older non-boxed renderings still go through
+# GEMINI_UI_PATTERNS below.
+_BOX_OPEN_RE = re.compile(r"^\s*[╭┌╔]")
+_BOX_CLOSE_RE = re.compile(r"^\s*[╰└╚]")
+_BOX_SIDE_RE = re.compile(r"^\s*[│┃║|]\s?|\s*[│┃║|]\s*$")
+_BOX_GLYPHS = frozenset("─━═│┃║|╭╮╰╯┌┐└┘╔╗╚╝ ")
+_GEMINI_INTERACTIVE_MARKERS = (
+    re.compile(r"^\s*[●❯]\s*\d+\."),  # selected option marker
+    re.compile(r"^\s*\d+\.\s"),  # numbered option
+    re.compile(r"(?i)\benter to (submit|select|confirm|continue)\b"),
+    re.compile(r"(?i)\(press esc to (close|cancel)\)"),
+    re.compile(r"(?i)\(esc\b"),
+)
+_PERMISSION_HINT_RE = re.compile(
+    r"(?i)\b(allow|permission|denied|proceed|approve)\b|\(esc\b"
+)
+
+
+def _clean_box_lines(lines: list[str]) -> list[str]:
+    """Strip box-drawing borders/rules from a captured box, keep content."""
+    out: list[str] = []
+    for raw in lines:
+        line = raw.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            out.append("")
+            continue
+        if set(stripped) <= _BOX_GLYPHS:  # pure border or horizontal rule
+            continue
+        out.append(_BOX_SIDE_RE.sub("", line).rstrip())
+    while out and not out[0].strip():
+        out.pop(0)
+    while out and not out[-1].strip():
+        out.pop()
+    return out
+
+
+def _extract_active_box(pane_text: str) -> str | None:
+    """Return the cleaned content of the last (active) box, or None."""
+    lines = pane_text.split("\n")
+    close_idx = next(
+        (i for i in range(len(lines) - 1, -1, -1) if _BOX_CLOSE_RE.match(lines[i])),
+        None,
+    )
+    if close_idx is None:
+        return None
+    open_idx = next(
+        (i for i in range(close_idx - 1, -1, -1) if _BOX_OPEN_RE.match(lines[i])),
+        None,
+    )
+    if open_idx is None:
+        return None
+    inner = _clean_box_lines(lines[open_idx + 1 : close_idx])
+    return "\n".join(inner) if inner else None
+
+
+def _box_is_interactive(box_text: str) -> bool:
+    """True when the box content carries an interactive affordance."""
+    return any(
+        any(marker.search(line) for marker in _GEMINI_INTERACTIVE_MARKERS)
+        for line in box_text.split("\n")
+    )
+
+
 _TRANSCRIPT_MAX_AGE_SECS = 120.0
 _MAX_TOOL_SUMMARY = 200
 _SHORT_SESSION_ID_LEN = 8
@@ -714,7 +792,24 @@ class GeminiProvider(JsonlProvider):
             "\u270b" in pane_title or "Action Required" in pane_title
         )  # ✋
 
-        # 3. Pane content for interactive UI details
+        # 3. Boxed prompt (Gemini ≥ 0.42) — extract the question from the box.
+        # GEMINI_UI_PATTERNS anchors no longer exist in-pane; the prompt is
+        # wrapped in box-drawing borders with the question as the first line.
+        box_text = _extract_active_box(pane_text)
+        if box_text and _box_is_interactive(box_text):
+            ui_type = (
+                "PermissionPrompt"
+                if action_required or _PERMISSION_HINT_RE.search(box_text)
+                else "SelectionUI"
+            )
+            return StatusUpdate(
+                raw_text=box_text,
+                display_label=ui_type,
+                is_interactive=True,
+                ui_type=ui_type,
+            )
+
+        # 4. Legacy non-boxed rendering (Gemini ≤ 0.41) — regex patterns.
         interactive = extract_interactive_content(pane_text, GEMINI_UI_PATTERNS)
         if interactive:
             return StatusUpdate(
@@ -724,7 +819,7 @@ class GeminiProvider(JsonlProvider):
                 ui_type=interactive.name,
             )
 
-        # 4. Title says action required but content didn't match patterns
+        # 5. Title says action required but content didn't match anything.
         if action_required:
             return StatusUpdate(
                 raw_text="Action Required",

--- a/tests/ccgram/providers/test_jsonl_providers.py
+++ b/tests/ccgram/providers/test_jsonl_providers.py
@@ -14,7 +14,12 @@ from ccgram.providers.codex import (
     _format_codex_tool_result,
     _resolve_pending,
 )
-from ccgram.providers.gemini import GeminiProvider
+from ccgram.providers.gemini import (
+    GeminiProvider,
+    _box_is_interactive,
+    _clean_box_lines,
+    _extract_active_box,
+)
 
 
 class TestResolvePending:
@@ -1086,6 +1091,144 @@ class TestGeminiTerminalStatus:
         gemini = GeminiProvider()
         status = gemini.parse_terminal_status(pane)
         assert status is None
+
+
+class TestGeminiBoxedPrompt:
+    REAL_TOOL_PERMISSION_BOX = (
+        "> use the shell tool to run: whoami\n"
+        "\n"
+        "  Responding with gemini-3-flash-preview\n"
+        "╭────────────────────────────────────────────────────────────────╮\n"
+        "│ Answer Questions                                                 │\n"
+        "│                                                                  │\n"
+        "│ The 'whoami' command was denied by policy. Is there another way "
+        "I can help you, or do you want to try a different approach?       │\n"
+        "│                                                                  │\n"
+        "│ > Explain why you need this or suggest an alternative.           │\n"
+        "│                                                                  │\n"
+        "│ Enter to submit · Esc to cancel                                  │\n"
+        "╰────────────────────────────────────────────────────────────────╯\n"
+    )
+    REAL_TRUST_SELECTION_BOX = (
+        " ╭───────────────────────────────────────────────────────────────╮\n"
+        " │                                                                 │\n"
+        " │ Do you trust the files in this folder?                          │\n"
+        " │                                                                 │\n"
+        " │ Trusting a folder allows Gemini CLI to load its local "
+        "configurations, including custom commands, hooks, and settings.  │\n"
+        " │ These configurations could execute code on your behalf.         │\n"
+        " │                                                                 │\n"
+        " │ ● 1. Trust folder (gemini-issue75)                              │\n"
+        " │   2. Trust parent folder (tmp)                                  │\n"
+        " │   3. Don't trust                                                │\n"
+        " │                                                                 │\n"
+        " ╰───────────────────────────────────────────────────────────────╯\n"
+    )
+    BOXED_ALLOW_PROMPT = (
+        "╭──────────────────────────────────────────────╮\n"
+        "│ Allow execution of: 'rm -rf build'?           │\n"
+        "│ ● 1. Allow once                               │\n"
+        "│   2. Allow for this session                   │\n"
+        "│   3. Allow for all future sessions            │\n"
+        "│   4. No, suggest changes (esc)                │\n"
+        "╰──────────────────────────────────────────────╯\n"
+    )
+    AUTH_STARTUP_BOX = (
+        "╭────────────────────────────────────────────────────────────╮\n"
+        "│                                                              │\n"
+        "│ ⠧ Waiting for authentication... (Press Esc or Ctrl+C to "
+        "cancel)  │\n"
+        "│                                                              │\n"
+        "╰────────────────────────────────────────────────────────────╯\n"
+    )
+    TOOL_EXEC_BOX = (
+        "╭──────────────────────────────────────────────╮\n"
+        "│ ✓  Shell ls -la                               │\n"
+        "│                                               │\n"
+        "╰──────────────────────────────────────────────╯\n"
+    )
+
+    def test_issue_75_real_tool_permission_shows_question(self) -> None:
+        gemini = GeminiProvider()
+        status = gemini.parse_terminal_status(
+            self.REAL_TOOL_PERMISSION_BOX, pane_title="Action Required: ✋"
+        )
+        assert status is not None
+        assert status.is_interactive is True
+        assert status.ui_type == "PermissionPrompt"
+        assert status.raw_text != "Action Required"
+        assert "Answer Questions" in status.raw_text
+        assert "denied by policy" in status.raw_text
+
+    def test_real_trust_selection_box_detected(self) -> None:
+        gemini = GeminiProvider()
+        status = gemini.parse_terminal_status(
+            self.REAL_TRUST_SELECTION_BOX, pane_title="Ready: ◇"
+        )
+        assert status is not None
+        assert status.is_interactive is True
+        assert status.ui_type == "SelectionUI"
+        assert "Do you trust the files in this folder?" in status.raw_text
+        assert "Don't trust" in status.raw_text
+
+    def test_boxed_allow_prompt_includes_options(self) -> None:
+        gemini = GeminiProvider()
+        status = gemini.parse_terminal_status(
+            self.BOXED_ALLOW_PROMPT, pane_title="Action Required: ✋"
+        )
+        assert status is not None
+        assert status.is_interactive is True
+        assert status.ui_type == "PermissionPrompt"
+        assert status.raw_text != "Action Required"
+        assert "Allow once" in status.raw_text
+        assert "Allow for this session" in status.raw_text
+
+    def test_box_content_strips_border_glyphs(self) -> None:
+        gemini = GeminiProvider()
+        status = gemini.parse_terminal_status(
+            self.REAL_TOOL_PERMISSION_BOX, pane_title="Action Required: ✋"
+        )
+        assert status is not None
+        for glyph in ("│", "╭", "╮", "╰", "╯"):
+            assert glyph not in status.raw_text
+
+    def test_auth_startup_box_not_interactive(self) -> None:
+        gemini = GeminiProvider()
+        status = gemini.parse_terminal_status(
+            self.AUTH_STARTUP_BOX, pane_title="Ready: ◇"
+        )
+        assert status is None
+
+    def test_tool_exec_box_not_interactive(self) -> None:
+        gemini = GeminiProvider()
+        status = gemini.parse_terminal_status(self.TOOL_EXEC_BOX, pane_title="")
+        assert status is None
+
+    def test_extract_active_box_returns_cleaned_inner(self) -> None:
+        box = (
+            "noise above\n"
+            "╭────────────╮\n"
+            "│ question?  │\n"
+            "│ ● 1. yes   │\n"
+            "╰────────────╯\n"
+        )
+        assert _extract_active_box(box) == "question?\n● 1. yes"
+
+    def test_extract_active_box_none_without_box(self) -> None:
+        assert _extract_active_box("just normal output\n> \n") is None
+
+    def test_extract_active_box_picks_last_box(self) -> None:
+        two = "╭───╮\n│ old │\n╰───╯\ninterim\n╭───╮\n│ new │\n╰───╯\n"
+        assert _extract_active_box(two) == "new"
+
+    def test_clean_box_lines_drops_borders_and_padding(self) -> None:
+        assert _clean_box_lines(["│ a │", "│   │", "│ b │", "──────"]) == ["a", "b"]
+
+    def test_box_is_interactive_true_for_options(self) -> None:
+        assert _box_is_interactive("header\n● 1. choose me\n  2. other") is True
+
+    def test_box_is_interactive_false_for_plain_text(self) -> None:
+        assert _box_is_interactive("just a status line\nno options here") is False
 
 
 class TestGeminiPaneTitleStatus:

--- a/tests/ccgram/providers/test_jsonl_providers.py
+++ b/tests/ccgram/providers/test_jsonl_providers.py
@@ -1230,6 +1230,38 @@ class TestGeminiBoxedPrompt:
     def test_box_is_interactive_false_for_plain_text(self) -> None:
         assert _box_is_interactive("just a status line\nno options here") is False
 
+    def test_box_is_interactive_single_numbered_line_is_prose(self) -> None:
+        assert _box_is_interactive("Step 1. do the thing first") is False
+
+    def test_box_is_interactive_two_numbered_lines_is_prompt(self) -> None:
+        assert _box_is_interactive("Pick:\n1. yes\n2. no") is True
+
+    def test_extract_active_box_none_on_dangling_open(self) -> None:
+        torn = (
+            "╭───╮\n│ old │\n╰───╯\n"
+            "interim output\n"
+            "╭───────────────────╮\n│ new question being drawn │\n"
+        )
+        assert _extract_active_box(torn) is None
+
+    def test_extract_active_box_none_when_crossing_box_boundary(self) -> None:
+        torn = "╭──╮\n│ a │\n╰──╯\n╰──╯\n"
+        assert _extract_active_box(torn) is None
+
+    def test_dangling_open_falls_back_not_stale_question(self) -> None:
+        torn = (
+            "╭────────────────────────────╮\n"
+            "│ Old answered prompt          │\n"
+            "│ ● 1. picked                  │\n"
+            "╰────────────────────────────╯\n"
+            "scrollback\n"
+            "╭────────────────────────────╮\n"
+            "│ New prompt still rendering   │\n"
+        )
+        gemini = GeminiProvider()
+        status = gemini.parse_terminal_status(torn, pane_title="Ready: ◇")
+        assert status is None
+
 
 class TestGeminiPaneTitleStatus:
     def test_working_title_returns_working_status(self) -> None:

--- a/tests/ccgram/test_doctor_cmd.py
+++ b/tests/ccgram/test_doctor_cmd.py
@@ -233,6 +233,10 @@ class TestDoctorMain:
             lambda: ("pass", "ok"),
         )
         monkeypatch.setattr("ccgram.doctor_cmd._find_orphaned_windows", lambda: [])
+        monkeypatch.setattr(
+            "ccgram.hook._codex_hooks_file",
+            lambda: tmp_path / ".codex" / "hooks.json",
+        )
 
         with pytest.raises(SystemExit):
             doctor_main()


### PR DESCRIPTION
Fixes #75.

## Problem

Gemini interactive prompts show the navigation keyboard in Telegram but **not the question**. Intermittent for the reporter (~2/30 displayed).

## Root cause (reproduced on real Gemini 0.42)

Ran Gemini in a tmux window, captured the actual permission-prompt pane + OSC title, fed both through `GeminiProvider.parse_terminal_status`:

- Gemini ≥ 0.42 wraps **every** interactive prompt in box-drawing borders. The question is the first in-box line; there is **no bare `Action Required` / `Select` line in-pane** — that text now lives only in the OSC pane title.
- `GEMINI_UI_PATTERNS` anchor `top` on `^…Action Required` / `^…Select`, which never match real ≥0.42 output.
- `extract_interactive_content` → `None`; the title contains `Action Required` → step-4 fallback returned `StatusUpdate(raw_text="Action Required", is_interactive=True)`.
- Result: keyboard renders, question discarded. Exactly #75.

The existing `TestGeminiTerminalStatus` fixtures hard-coded a bare `Action Required\n` line that real Gemini never emits, so the suite was green against a structure the CLI doesn't produce.

## Fix

Add box-aware extraction in `gemini.py` as a new step **before** the legacy regex patterns:

- `_extract_active_box` — grabs the last (active) `╭…╰` box, strips borders
- `_box_is_interactive` — gates on real affordances (`● N.`, numbered options, `Enter to submit`, `(Press Esc to close)`, `(esc`)
- `_clean_box_lines` — drops border/padding glyphs, keeps content

Legacy non-boxed rendering (Gemini ≤ 0.41) still flows through `GEMINI_UI_PATTERNS`; the title-only bare `Action Required` remains the last-resort fallback. No existing behaviour changes for non-boxed input.

## Scope notes

- **Related improvement (called out, not stealth scope):** footer-less boxed selection prompts whose title is `Ready` (e.g. the trust-folder prompt) were previously detected as *nothing*; they now produce a keyboard + question too. Gated on `_box_is_interactive`, so non-interactive boxes (auth-wait, tool-exec status) are not affected — negative tests included.
- **Version caveat:** verified on Gemini 0.42; reporter is on 0.40.1. The box approach targets the same `@inquirer`-style boxed UI and the same code path, but 0.40.1 was not captured. Reporter confirmation welcome.
- **Out of scope (tracked separately):** the pyte fast-path (`polling_state.parse_with_pyte` → `terminal_parser.parse_from_screen`) hardcodes Claude `UI_PATTERNS`; provider patterns never thread in. Not the cause of #75 (Claude patterns return `None` for Gemini boxes), and gating it touches `ws.last_rendered_text` / RC / vim-insert across all 5 providers — wrong vehicle for this PR. Tracked issue with analysis instead.

## Review follow-up commits

- `735ce7c` `test(doctor)`: made `test_reports_missing_hooks_for_codex_provider` hermetic. It read the real `~/.codex/hooks.json` via `_codex_hooks_file()`, so it passed in CI but failed on dev machines with codex hooks installed. Now monkeypatched into `tmp_path`. **No longer a pre-existing failure — fixed here.**
- `a28ec3d` `fix(gemini)`: hardened `_extract_active_box` (bails on torn captures — dangling open / crossed box boundary — instead of surfacing a stale earlier box) and tightened `_box_is_interactive` (strong markers vs. bare numbered list requiring ≥2, so a single `1.` in prose is not a prompt). +5 regression tests.

## Tests

17 tests in `TestGeminiBoxedPrompt`: real Gemini 0.42 captures (tool-permission, trust-selection, boxed allow-prompt) + negatives (auth-wait, tool-exec) + torn-capture / numbered-prose cases + pure-helper units.

## Verification

`make check` fully green: fmt + lint + lint-lazy + ruff + pyright (0 errors) + 4780 unit + 266 integration passed. 61/61 Gemini tests. No skipped quality gates.
