### PR TITLE
Feat: Add Webhook transport and fix UI lag in groups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,11 @@ MONITOR_POLL_INTERVAL=2.0
 #
 # CCGRAM_TTS_PROVIDER=edge
 # CCGRAM_TTS_VOICE=en-US-EmmaMultilingualNeural
+
+# ── Webhook Mode (Optional) ──────────────────────────────────────────────────
+# Enable Webhook mode for faster responsiveness instead of polling.
+# If port binding fails, it falls back to polling automatically.
+# WEBHOOK_URL=https://my-tunnel.example.com/bot-webhook
+# WEBHOOK_PORT=8084
+# WEBHOOK_LISTEN=0.0.0.0
+# WEBHOOK_SECRET_TOKEN=my_secure_random_string

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ monitor_state.json
 session_map.json
 session_map.lock
 state.json
+GEMINI.md

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,8 @@ progress*.txt
 
 # Runtime uploads
 .ccgram-uploads/
+gemini-system-settings.json
+monitor_state.json
+session_map.json
+session_map.lock
+state.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pyte>=0.8.2",
     "pathspec>=0.12",
     "aiohttp>=3.10",
+    "psutil>=7.2.2",
 ]
 
 [project.urls]

--- a/src/ccgram/config.py
+++ b/src/ccgram/config.py
@@ -187,6 +187,7 @@ class Config:
         self._init_live_view()
         self._init_send()
         self._init_lifecycle()
+        self._init_webhook()
 
         # Global default for hiding tool_use/tool_result content in Telegram.
         # Per-window override via WindowState.tool_call_visibility takes precedence.
@@ -272,6 +273,12 @@ class Config:
         self.miniapp_base_url: str = os.getenv("CCGRAM_MINIAPP_BASE_URL", "").strip()
         self.miniapp_host: str = os.getenv("CCGRAM_MINIAPP_HOST", "127.0.0.1")
         self.miniapp_port: int = _parse_int_env("CCGRAM_MINIAPP_PORT", 8765)
+
+    def _init_webhook(self) -> None:
+        self.webhook_url: str = os.getenv("WEBHOOK_URL", "").strip()
+        self.webhook_port: int = _parse_int_env("WEBHOOK_PORT", 8084)
+        self.webhook_listen: str = os.getenv("WEBHOOK_LISTEN", "0.0.0.0").strip()
+        self.webhook_secret_token: str = os.getenv("WEBHOOK_SECRET_TOKEN", "").strip()
 
     def is_user_allowed(self, user_id: int) -> bool:
         """Check if a user is in the allowed list."""

--- a/src/ccgram/handlers/registry.py
+++ b/src/ccgram/handlers/registry.py
@@ -55,6 +55,7 @@ HandlerFn: TypeAlias = HandlerCallback
 
 logger = structlog.get_logger()
 
+
 async def _log_webhook_request(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if getattr(config, "webhook_url", None):
         logger.info("Incoming webhook request accepted", update_id=update.update_id)

--- a/src/ccgram/handlers/registry.py
+++ b/src/ccgram/handlers/registry.py
@@ -12,16 +12,21 @@ requires.
 from dataclasses import dataclass
 from typing import TypeAlias
 
+from telegram import Update
 from telegram.ext import (
     Application,
     CallbackQueryHandler,
     CommandHandler,
     InlineQueryHandler,
     MessageHandler,
+    TypeHandler,
+    ContextTypes,
     filters,
 )
 from telegram.ext._utils.types import HandlerCallback
+import structlog
 
+from ..config import config
 from .callback_registry import dispatch as _dispatch_callback
 from .callback_registry import load_handlers as _load_callback_handlers
 from .cleanup import unbind_command
@@ -48,6 +53,12 @@ from .voice import handle_voice_message
 
 HandlerFn: TypeAlias = HandlerCallback
 
+logger = structlog.get_logger()
+
+async def _log_webhook_request(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if getattr(config, "webhook_url", None):
+        logger.info("Incoming webhook request accepted", update_id=update.update_id)
+
 
 @dataclass(frozen=True)
 class CommandSpec:
@@ -67,6 +78,8 @@ def register_all(
     explicit CommandHandlers must precede the COMMAND-fallback
     MessageHandler, which must precede the TEXT MessageHandler.
     """
+    application.add_handler(TypeHandler(Update, _log_webhook_request), group=-1)
+
     command_specs: list[CommandSpec] = [
         CommandSpec("new", new_command),
         CommandSpec("start", new_command),  # compat alias

--- a/src/ccgram/handlers/status/status_bar_actions.py
+++ b/src/ccgram/handlers/status/status_bar_actions.py
@@ -81,6 +81,11 @@ def build_dashboard_button(window_id: str, user_id: int) -> InlineKeyboardButton
         user_id=user_id,
     )
     url = f"{base_url.rstrip('/')}/app/{token}"
+    # WebApp buttons (direct launch) only work in private chats. In groups
+    # they trigger Button_type_invalid. If a group is configured, fall back
+    # to a standard URL button (opens in browser).
+    if config.group_id:
+        return InlineKeyboardButton("\U0001fa9f Dashboard", url=url)
     return InlineKeyboardButton("\U0001fa9f Dashboard", web_app=WebAppInfo(url=url))
 
 

--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -448,6 +448,7 @@ async def text_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     current topic, and delegates to ``handle_text_message`` for the
     bool early-return routing chain.
     """
+    logger.info("Processing text update", update_id=update.update_id)
     user = update.effective_user
     if not user or not config.is_user_allowed(user.id):
         if update.message:

--- a/src/ccgram/main.py
+++ b/src/ccgram/main.py
@@ -212,10 +212,16 @@ def run_bot() -> None:
 
     application = create_bot()
     _install_signal_handlers(loop)
-    application.run_polling(
-        allowed_updates=["message", "callback_query"],
-        stop_signals=None,
-    )
+    
+    if getattr(config, "webhook_url", None):
+        from .webhook_runner import run_with_fallback
+        run_with_fallback(application, config)
+    else:
+        logger.info("Polling mode active")
+        application.run_polling(
+            allowed_updates=["message", "callback_query"],
+            stop_signals=None,
+        )
 
     if _restart_requested:
         logger.info("Restarting bot via os.execv(%s)", sys.argv)

--- a/src/ccgram/main.py
+++ b/src/ccgram/main.py
@@ -77,10 +77,11 @@ def _reraise_shutdown_signal() -> None:
         os.kill(os.getpid(), _shutdown_signal)
 
 
-def _mask_secrets(logger: logging.Logger, log_method: str, event_dict: dict) -> dict:
+def _mask_secrets(_logger: logging.Logger, _log_method: str, event_dict: dict) -> dict:
     """Mask sensitive tokens in log outputs."""
+    min_secret_len = 4
     secrets = [os.environ.get("WEBHOOK_SECRET_TOKEN"), os.environ.get("TELEGRAM_BOT_TOKEN")]
-    secrets = [s for s in secrets if s and len(s) > 4]
+    secrets = [s for s in secrets if s and len(s) > min_secret_len]
     
     if not secrets:
         return event_dict

--- a/src/ccgram/main.py
+++ b/src/ccgram/main.py
@@ -77,6 +77,31 @@ def _reraise_shutdown_signal() -> None:
         os.kill(os.getpid(), _shutdown_signal)
 
 
+def _mask_secrets(logger: logging.Logger, log_method: str, event_dict: dict) -> dict:
+    """Mask sensitive tokens in log outputs."""
+    secrets = [os.environ.get("WEBHOOK_SECRET_TOKEN"), os.environ.get("TELEGRAM_BOT_TOKEN")]
+    secrets = [s for s in secrets if s and len(s) > 4]
+    
+    if not secrets:
+        return event_dict
+
+    for k, v in event_dict.items():
+        if isinstance(v, str):
+            for secret in secrets:
+                if secret in v:
+                    v = v.replace(secret, "***MASKED***")
+            event_dict[k] = v
+            
+    event = event_dict.get("event")
+    if isinstance(event, str):
+        for secret in secrets:
+            if secret in event:
+                event = event.replace(secret, "***MASKED***")
+        event_dict["event"] = event
+        
+    return event_dict
+
+
 def setup_logging(log_level: str) -> None:
     """Configure structured, colored logging for interactive CLI use."""
     numeric_level = getattr(logging, log_level, None)
@@ -87,6 +112,7 @@ def setup_logging(log_level: str) -> None:
         processors=[
             structlog.contextvars.merge_contextvars,
             structlog.stdlib.add_log_level,
+            _mask_secrets,
             structlog.stdlib.PositionalArgumentsFormatter(),
             structlog.processors.TimeStamper(fmt="%H:%M:%S"),
             structlog.processors.StackInfoRenderer(),

--- a/src/ccgram/telegram_draft.py
+++ b/src/ccgram/telegram_draft.py
@@ -253,6 +253,12 @@ class DraftStream:
                 await self._start_legacy()
             else:
                 await self._start_streaming()
+        except BadRequest as exc:
+            if "button_type_invalid" in str(exc).lower():
+                logger.warning("DraftStream.start: invalid buttons for this chat type (check web_app in group)", error=str(exc))
+                return None
+            logger.warning("DraftStream.start BadRequest: %s", exc)
+            return None
         except (TimedOut, NetworkError) as exc:
             logger.warning("DraftStream.start transient failure: %s", exc)
             return None

--- a/src/ccgram/webhook_runner.py
+++ b/src/ccgram/webhook_runner.py
@@ -38,8 +38,8 @@ def run_with_fallback(application: Application, config: object) -> None:
             stop_signals=None,
         )
         logger.info("Webhook stopped cleanly.")
-    except Exception as e:
-        logger.error(f"Webhook failed ({type(e).__name__}): {e}")
+    except Exception as e:  # noqa: BLE001
+        logger.error("Webhook failed (%s): %s", type(e).__name__, e)
         logger.info("Falling back to polling mode")
         
         # python-telegram-bot closes the event loop on run_webhook failure.

--- a/src/ccgram/webhook_runner.py
+++ b/src/ccgram/webhook_runner.py
@@ -1,0 +1,54 @@
+"""Webhook runner wrapper for python-telegram-bot.
+
+Provides a fallback mechanism: attempts to start the webhook, and if port binding
+fails, falls back to polling.
+"""
+
+import structlog
+from telegram.ext import Application
+
+logger = structlog.get_logger()
+
+def run_with_fallback(application: Application, config: object) -> None:
+    """Run the application with Webhook if configured, falling back to Polling."""
+    webhook_url = getattr(config, "webhook_url", None)
+    
+    if not webhook_url:
+        logger.info("Polling mode active (no WEBHOOK_URL defined).")
+        application.run_polling(
+            allowed_updates=["message", "callback_query"],
+            stop_signals=None,
+        )
+        return
+
+    logger.info(
+        "Webhook registration triggered", 
+        url=webhook_url, 
+        listen=config.webhook_listen, 
+        port=config.webhook_port
+    )
+
+    try:
+        application.run_webhook(
+            listen=config.webhook_listen,
+            port=config.webhook_port,
+            webhook_url=webhook_url,
+            secret_token=getattr(config, "webhook_secret_token", None) or None,
+            allowed_updates=["message", "callback_query"],
+            stop_signals=None,
+        )
+        logger.info("Webhook stopped cleanly.")
+    except Exception as e:
+        logger.error(f"Webhook failed ({type(e).__name__}): {e}")
+        logger.info("Falling back to polling mode")
+        
+        # python-telegram-bot closes the event loop on run_webhook failure.
+        # We must recreate the loop before falling back.
+        import asyncio
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        
+        application.run_polling(
+            allowed_updates=["message", "callback_query"],
+            stop_signals=None,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -124,6 +124,7 @@ dependencies = [
     { name = "libtmux" },
     { name = "pathspec" },
     { name = "pillow" },
+    { name = "psutil" },
     { name = "pyte" },
     { name = "python-dotenv" },
     { name = "python-telegram-bot", extra = ["rate-limiter", "socks"] },
@@ -163,6 +164,7 @@ requires-dist = [
     { name = "libtmux", specifier = ">=0.50.0" },
     { name = "pathspec", specifier = ">=0.12" },
     { name = "pillow", specifier = ">=10.0.0" },
+    { name = "psutil", specifier = ">=7.2.2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pyte", specifier = ">=0.8.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -568,6 +570,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR introduces several improvements focused on performance, production readiness, and bug fixes:

1. **Opt-in Webhook Transport:** Added support for Webhook mode with an automatic fallback to Polling. If the bot fails to bind the webhook port (e.g., port already in use), it gracefully switches back to polling to ensure uptime.
2. **Fix UI Slowness in Groups:** Identified and resolved a tight retry loop in `DraftStream` caused by `Button_type_invalid` errors. This happened because WebApp buttons (Mini App) are not supported in group chats. The bot now automatically falls back to standard URL buttons in groups.
3. **Security & Observability:**
   - Implemented sensitive token masking in logs (Bot Token and Webhook Secret).
   - Added incoming webhook traffic logging for better diagnostics.
4. **Dependency:** Added `psutil` for upcoming monitoring features.