### PR TITLE
Add Pi to provider picker

### DIFF
--- a/src/ccgram/handlers/topics/directory_browser.py
+++ b/src/ccgram/handlers/topics/directory_browser.py
@@ -333,6 +333,7 @@ _PROVIDER_META: dict[str, tuple[str, str]] = {
     "claude": ("Claude", "\U0001f7e0"),
     "codex": ("Codex", "\U0001f9e9"),
     "gemini": ("Gemini", "\u264a"),
+    "pi": ("Pi", "\U0001f916"),
     "shell": ("Shell", "\U0001f41a"),
 }
 

--- a/tests/ccgram/handlers/topics/test_selection.py
+++ b/tests/ccgram/handlers/topics/test_selection.py
@@ -28,13 +28,15 @@ class TestBuildProviderPicker:
         assert "Select Provider" in text
         assert isinstance(keyboard, InlineKeyboardMarkup)
 
-    def test_shows_all_three_providers(self) -> None:
+    def test_shows_all_providers(self) -> None:
         text, keyboard = build_provider_picker("/tmp/test")
         buttons = keyboard.inline_keyboard
         labels = [btn.text for row in buttons for btn in row]
         assert any("Claude" in label for label in labels)
         assert any("Codex" in label for label in labels)
         assert any("Gemini" in label for label in labels)
+        assert any("Pi" in label for label in labels)
+        assert any("Shell" in label for label in labels)
 
     def test_claude_marked_as_default(self) -> None:
         _text, keyboard = build_provider_picker("/tmp/test")
@@ -57,6 +59,8 @@ class TestBuildProviderPicker:
         assert f"{CB_PROV_SELECT}claude" in provider_callbacks
         assert f"{CB_PROV_SELECT}codex" in provider_callbacks
         assert f"{CB_PROV_SELECT}gemini" in provider_callbacks
+        assert f"{CB_PROV_SELECT}pi" in provider_callbacks
+        assert f"{CB_PROV_SELECT}shell" in provider_callbacks
 
     def test_has_cancel_button(self) -> None:
         _text, keyboard = build_provider_picker("/tmp/test")


### PR DESCRIPTION
## Summary

Add Pi to the Telegram provider picker.

Claude remains the default provider.

## Tests

- `uv run pytest tests/ccgram/handlers/topics/test_selection.py -q`
- `make test`
