### PR TITLE
fix(bootstrap): parenthesize except clause in verify_hooks_installed

### DIFF
--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -131,7 +131,7 @@ def verify_hooks_installed() -> None:
 
     try:
         settings = json.loads(settings_file.read_text())
-    except json.JSONDecodeError, OSError:
+    except (json.JSONDecodeError, OSError):
         logger.warning("Claude Code hooks not installed. Run: ccgram hook --install")
         return
 


### PR DESCRIPTION
The bare `except json.JSONDecodeError, OSError:` in `bootstrap.py:134` is Python 2 syntax and raises `SyntaxError` on Python 3, preventing the module from importing. One-character fix: add parentheses around the tuple.

Required for v3.1.3 release.

---
_Generated by [Claude Code](https://claude.ai/code/session_018957HHFKwS2gbN3ZBa6mH6)_