### PR TITLE
docs: update CHANGELOG.md for v3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [3.1.3] - 2026-05-21
+
+### Added
+- Add Pi to provider picker ([#88](https://github.com/alexei-led/ccgram/pull/88))
+
+
+### Fixed
+- Parenthesize except clause in verify_hooks_installed ([#90](https://github.com/alexei-led/ccgram/pull/90))
+
 ## [3.1.2] - 2026-05-16
 
 ### Fixed


### PR DESCRIPTION
CHANGELOG update for v3.1.3. Required to land on main before tagging (per the project's documented release flow — CI cannot push to protected main).

---
_Generated by [Claude Code](https://claude.ai/code/session_018957HHFKwS2gbN3ZBa6mH6)_