### PR TITLE
style(bootstrap): drop redundant parens (PEP 758)

### DIFF
--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -131,7 +131,7 @@ def verify_hooks_installed() -> None:
 
     try:
         settings = json.loads(settings_file.read_text())
-    except (json.JSONDecodeError, OSError):
+    except json.JSONDecodeError, OSError:
         logger.warning("Claude Code hooks not installed. Run: ccgram hook --install")
         return
 


### PR DESCRIPTION
Ruff format with `target-version = "py314"` drops parens around `except` tuples (PEP 758 makes them optional). PR #90's added parens triggered the format check failure on CI. Net effect: bootstrap.py returns to the pre-#90 state, which was already valid Python 3.14.

---
_Generated by [Claude Code](https://claude.ai/code/session_018957HHFKwS2gbN3ZBa6mH6)_