### PR TITLE
Capture scrollback for screenshots, slice last command on shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,8 +174,11 @@ The LLM is also used for **completion summaries**: when an agent finishes (Stop 
 | Auto-stop timeout | `CCGRAM_LIVE_VIEW_TIMEOUT`    | `300` (s) |
 | Monitor poll      | `MONITOR_POLL_INTERVAL`       | `1.0` (s) |
 | Status poll       | `CCGRAM_STATUS_POLL_INTERVAL` | `1.0` (s) |
+| Screenshot lines  | `CCGRAM_SCREENSHOT_HISTORY`   | `500`     |
 
 Live view and poll intervals are clamped to a minimum of 0.5s (live view: 1s). Live view auto-refreshes terminal screenshots via `editMessageMedia` at the configured interval, and auto-stops after the timeout.
+
+Screenshots (`/screenshot`, 📷 status-bar button) capture scrollback (default 500 lines) with ANSI color rather than just the visible viewport. For shell topics, the last command and its output are extracted from between prompt markers when available, falling back to full scrollback. Live view keeps viewport capture unchanged.
 
 ### /send Command — File Delivery
 

--- a/src/ccgram/config.py
+++ b/src/ccgram/config.py
@@ -231,6 +231,9 @@ class Config:
         self.live_view_timeout: int = max(
             1, _parse_int_env("CCGRAM_LIVE_VIEW_TIMEOUT", 300)
         )
+        self.screenshot_history: int = max(
+            50, _parse_int_env("CCGRAM_SCREENSHOT_HISTORY", 500)
+        )
 
     def _init_shell_and_llm(self) -> None:
         self.prompt_mode = os.getenv("CCGRAM_PROMPT_MODE", "wrap")

--- a/src/ccgram/handlers/live/screenshot_callbacks.py
+++ b/src/ccgram/handlers/live/screenshot_callbacks.py
@@ -30,10 +30,12 @@ from telegram import (
     Update,
 )
 from telegram.error import TelegramError
+from ...last_unit import capture_for_screenshot
 from ...screenshot import text_to_image
 from ...telegram_client import PTBTelegramClient
 from ...thread_router import thread_router
 from ...tmux_manager import tmux_manager
+from ...window_query import get_window_provider
 from ..callback_data import (
     CB_KEYS_PREFIX,
     CB_LIVE_START,
@@ -307,7 +309,7 @@ async def _handle_refresh(query: CallbackQuery, user_id: int, data: str) -> None
             pane_id, with_ansi=True, window_id=window_id
         )
     else:
-        text = await tmux_manager.capture_pane(w.window_id, with_ansi=True)
+        text = await capture_for_screenshot(window_id, get_window_provider(window_id))
     if not text:
         await query.answer("Failed to capture pane", show_alert=True)
         return
@@ -339,7 +341,7 @@ async def _handle_status_screenshot(
     if not w:
         await query.answer("Window not found", show_alert=True)
         return
-    text = await tmux_manager.capture_pane(w.window_id, with_ansi=True)
+    text = await capture_for_screenshot(window_id, get_window_provider(window_id))
     if not text:
         await query.answer("Failed to capture", show_alert=True)
         return
@@ -418,7 +420,7 @@ async def screenshot_command(
         await safe_reply(update.message, "\u274c Window no longer exists.")
         return
 
-    pane_text = await tmux_manager.capture_pane(w.window_id, with_ansi=True)
+    pane_text = await capture_for_screenshot(window_id, get_window_provider(window_id))
     if not pane_text:
         await safe_reply(update.message, "\u274c Failed to capture terminal.")
         return

--- a/src/ccgram/handlers/status/status_bar_actions.py
+++ b/src/ccgram/handlers/status/status_bar_actions.py
@@ -29,6 +29,7 @@ from telegram import (
 from telegram.error import TelegramError
 
 from ...config import config
+from ...last_unit import capture_for_screenshot
 from ...miniapp.auth import sign_token
 from ...screenshot import text_to_image
 from ... import window_query
@@ -316,7 +317,9 @@ def _schedule_key_refresh(
                     pane_id, with_ansi=True, window_id=window_id
                 )
             else:
-                text = await tmux_manager.capture_pane(window_id, with_ansi=True)
+                text = await capture_for_screenshot(
+                    window_id, window_query.get_window_provider(window_id)
+                )
             if text:
                 png_bytes = await text_to_image(text, with_ansi=True)
                 keyboard = build_screenshot_keyboard(window_id, pane_id=pane_id)

--- a/src/ccgram/last_unit.py
+++ b/src/ccgram/last_unit.py
@@ -1,0 +1,94 @@
+"""Last-unit capture — smart scrollback for screenshots.
+
+Provides scrollback-based terminal capture for screenshot rendering, with
+shell-specific marker extraction that isolates the last command and its output.
+
+Core responsibilities:
+  - ``extract_last_shell_block``: slice last command+output from scrollback
+    text using prompt markers (handles ANSI-laden text by stripping escapes
+    before matching but returning original colored lines).
+  - ``capture_for_screenshot``: capture scrollback with ANSI from tmux,
+    applying marker extraction for shell topics and returning full scrollback
+    for all other providers.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .config import config
+from .tmux_manager import tmux_manager
+
+# Strip ANSI escape sequences for marker matching purposes only.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mGKHF]|\x1b\][^\x07]*\x07|\x1b[()][AB012]")
+
+
+def _strip_ansi(line: str) -> str:
+    return _ANSI_RE.sub("", line)
+
+
+def extract_last_shell_block(scrollback_text: str) -> str | None:
+    """Slice last command+output between prompt markers.
+
+    Scans from the bottom of *scrollback_text* for the last bare prompt
+    (marker with empty trailing text after stripping ANSI), then scans upward
+    for the most recent command echo (marker with non-empty trailing text).
+    Returns lines from the command-echo through to the end of the scrollback,
+    inclusive. Returns None if either pivot is not found (no markers, command
+    still running, or only one marker present).
+    """
+    # Lazy: provider.shell_infra imported here to avoid coupling last_unit into
+    # the providers package at module level — last_unit is a leaf used by
+    # handlers, and providers also import from handlers indirectly via config.
+    from .providers.shell_infra import match_prompt
+
+    lines = scrollback_text.splitlines()
+    if not lines:
+        return None
+
+    # Scan from bottom for last bare prompt (trailing_text empty after stripping ANSI)
+    bare_idx: int | None = None
+    for i in range(len(lines) - 1, -1, -1):
+        m = match_prompt(_strip_ansi(lines[i]))
+        if m is not None and not _strip_ansi(m.trailing_text).strip():
+            bare_idx = i
+            break
+
+    if bare_idx is None:
+        return None
+
+    # Scan upward from bare_idx for command echo (trailing_text non-empty after stripping)
+    echo_idx: int | None = None
+    for i in range(bare_idx - 1, -1, -1):
+        m = match_prompt(_strip_ansi(lines[i]))
+        if m is not None and _strip_ansi(m.trailing_text).strip():
+            echo_idx = i
+            break
+
+    if echo_idx is None:
+        return None
+
+    return "\n".join(lines[echo_idx:])
+
+
+async def capture_for_screenshot(
+    window_id: str, provider_name: str | None
+) -> str | None:
+    """Capture scrollback with ANSI for screenshot rendering.
+
+    For provider_name == 'shell', attempts marker-based extraction and falls
+    back to full scrollback if no markers found. For all other providers,
+    returns full scrollback unchanged.
+    """
+    scrollback = await tmux_manager.capture_pane_scrollback(
+        window_id, history=config.screenshot_history, with_ansi=True
+    )
+    if scrollback is None:
+        return None
+
+    if provider_name == "shell":
+        extracted = extract_last_shell_block(scrollback)
+        if extracted is not None:
+            return extracted
+
+    return scrollback

--- a/src/ccgram/last_unit.py
+++ b/src/ccgram/last_unit.py
@@ -17,10 +17,15 @@ from __future__ import annotations
 import re
 
 from .config import config
+from .providers.shell_infra import match_prompt
 from .tmux_manager import tmux_manager
 
 # Strip ANSI escape sequences for marker matching purposes only.
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mGKHF]|\x1b\][^\x07]*\x07|\x1b[()][AB012]")
+# Covers full CSI range (cursor movement, SGR, private-mode such as
+# bracketed paste \x1b[?2004h), OSC strings, and simple two-byte
+# designators. tmux ``capture-pane -e`` can interleave these around prompt
+# markers, so the marker regex must not trip on residual escape bytes.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07|\x1b[()][AB012]")
 
 
 def _strip_ansi(line: str) -> str:
@@ -37,11 +42,6 @@ def extract_last_shell_block(scrollback_text: str) -> str | None:
     inclusive. Returns None if either pivot is not found (no markers, command
     still running, or only one marker present).
     """
-    # Lazy: provider.shell_infra imported here to avoid coupling last_unit into
-    # the providers package at module level — last_unit is a leaf used by
-    # handlers, and providers also import from handlers indirectly via config.
-    from .providers.shell_infra import match_prompt
-
     lines = scrollback_text.splitlines()
     if not lines:
         return None

--- a/src/ccgram/tmux_manager.py
+++ b/src/ccgram/tmux_manager.py
@@ -334,25 +334,23 @@ class TmuxManager:
         return await self._capture_pane_plain(window_id)
 
     async def capture_pane_scrollback(
-        self, window_id: str, history: int = 200
+        self, window_id: str, history: int = 200, with_ansi: bool = False
     ) -> str | None:
         """Capture pane text including scrollback history.
 
         Uses ``tmux capture-pane -p -J -S -{history}``. The ``-J`` flag joins
         wrapped lines so prompt markers are never split across lines on narrow
-        terminals. Returns stripped text or None on failure.
+        terminals. When *with_ansi* is True, adds ``-e`` to include ANSI color
+        escape sequences in the output. Returns stripped text or None on failure.
         """
         proc: asyncio.subprocess.Process | None = None
         try:
+            cmd = ["tmux", "capture-pane", "-p", "-J"]
+            if with_ansi:
+                cmd.append("-e")
+            cmd.extend(["-S", f"-{history}", "-t", window_id])
             proc = await asyncio.create_subprocess_exec(
-                "tmux",
-                "capture-pane",
-                "-p",
-                "-J",
-                "-S",
-                f"-{history}",
-                "-t",
-                window_id,
+                *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/tests/ccgram/handlers/live/test_live_view.py
+++ b/tests/ccgram/handlers/live/test_live_view.py
@@ -798,6 +798,11 @@ class TestHandleKeysLiveGuard:
                 "ccgram.handlers.status.status_bar_actions.tmux_manager"
             ) as mock_tmux,
             patch(
+                "ccgram.handlers.status.status_bar_actions.capture_for_screenshot",
+                new_callable=AsyncMock,
+                return_value="terminal text",
+            ),
+            patch(
                 "ccgram.handlers.status.status_bar_actions.text_to_image",
                 new_callable=AsyncMock,
                 return_value=b"PNG",
@@ -808,7 +813,6 @@ class TestHandleKeysLiveGuard:
                 return_value=MagicMock(window_id="@0")
             )
             mock_tmux.send_keys = AsyncMock()
-            mock_tmux.capture_pane = AsyncMock(return_value="terminal text")
             await _handle_keys(query, 1, f"{CB_KEYS_PREFIX}ent:@0", update)
             import asyncio
 

--- a/tests/ccgram/test_last_unit.py
+++ b/tests/ccgram/test_last_unit.py
@@ -1,0 +1,92 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ccgram.last_unit import capture_for_screenshot, extract_last_shell_block
+
+# Wrap-mode markers: ⌘N⌘ with optional ANSI around them.
+# Bare prompt: marker followed only by ANSI reset codes (strip → empty after strip)
+# Command echo: marker followed by ANSI reset + command text (non-empty after strip)
+# The conftest sets replace mode by default; tests that use wrap markers must
+# request the _wrap_mode fixture to override it for the duration of the test.
+
+_RESET = "\x1b[0m"
+_DIM = "\x1b[2m"
+
+BARE = f"user@host $ {_DIM}⌘0⌘{_RESET}"
+ECHO = f"user@host $ {_DIM}⌘0⌘{_RESET} ls -la"
+OUTPUT = "total 8\ndrwxr-xr-x  2 user group 64 Jan  1 00:00 ."
+
+
+def _scrollback(*lines: str) -> str:
+    return "\n".join(lines)
+
+
+def test_extract_happy_path(_wrap_mode: None) -> None:
+    scrollback = _scrollback(
+        "some earlier output",
+        ECHO,
+        OUTPUT,
+        BARE,
+    )
+    result = extract_last_shell_block(scrollback)
+    assert result is not None
+    assert result == _scrollback(ECHO, OUTPUT, BARE)
+
+
+def test_extract_no_markers_returns_none() -> None:
+    scrollback = _scrollback("line one", "line two", "line three")
+    assert extract_last_shell_block(scrollback) is None
+
+
+def test_extract_only_bare_prompt_no_echo_returns_none(_wrap_mode: None) -> None:
+    scrollback = _scrollback("some output", "more output", BARE)
+    assert extract_last_shell_block(scrollback) is None
+
+
+def test_extract_command_running_returns_none(_wrap_mode: None) -> None:
+    scrollback = _scrollback("earlier output", ECHO, "partial output")
+    assert extract_last_shell_block(scrollback) is None
+
+
+@pytest.mark.asyncio
+async def test_capture_shell_with_markers(_wrap_mode: None) -> None:
+    scrollback = _scrollback("earlier", ECHO, OUTPUT, BARE)
+    with patch(
+        "ccgram.last_unit.tmux_manager.capture_pane_scrollback",
+        new=AsyncMock(return_value=scrollback),
+    ):
+        result = await capture_for_screenshot("@0", "shell")
+    assert result == _scrollback(ECHO, OUTPUT, BARE)
+
+
+@pytest.mark.asyncio
+async def test_capture_shell_without_markers_returns_full_scrollback() -> None:
+    scrollback = "no markers here\njust plain text"
+    with patch(
+        "ccgram.last_unit.tmux_manager.capture_pane_scrollback",
+        new=AsyncMock(return_value=scrollback),
+    ):
+        result = await capture_for_screenshot("@0", "shell")
+    assert result == scrollback
+
+
+@pytest.mark.asyncio
+async def test_capture_claude_returns_full_scrollback(_wrap_mode: None) -> None:
+    scrollback = _scrollback("earlier", ECHO, OUTPUT, BARE)
+    with patch(
+        "ccgram.last_unit.tmux_manager.capture_pane_scrollback",
+        new=AsyncMock(return_value=scrollback),
+    ):
+        result = await capture_for_screenshot("@0", "claude")
+    assert result == scrollback
+
+
+@pytest.mark.asyncio
+async def test_capture_returns_none_when_scrollback_fails() -> None:
+    with patch(
+        "ccgram.last_unit.tmux_manager.capture_pane_scrollback",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await capture_for_screenshot("@0", "shell")
+    assert result is None

--- a/tests/ccgram/test_last_unit.py
+++ b/tests/ccgram/test_last_unit.py
@@ -12,9 +12,13 @@ from ccgram.last_unit import capture_for_screenshot, extract_last_shell_block
 
 _RESET = "\x1b[0m"
 _DIM = "\x1b[2m"
+_BRACKETED_PASTE = "\x1b[?2004h"
+_CURSOR_UP = "\x1b[A"
 
 BARE = f"user@host $ {_DIM}⌘0⌘{_RESET}"
 ECHO = f"user@host $ {_DIM}⌘0⌘{_RESET} ls -la"
+ECHO_FAILED = f"user@host $ {_DIM}⌘1⌘{_RESET} ls /missing"
+BARE_AFTER_FAIL = f"user@host $ {_DIM}⌘1⌘{_RESET}"
 OUTPUT = "total 8\ndrwxr-xr-x  2 user group 64 Jan  1 00:00 ."
 
 
@@ -47,6 +51,47 @@ def test_extract_only_bare_prompt_no_echo_returns_none(_wrap_mode: None) -> None
 def test_extract_command_running_returns_none(_wrap_mode: None) -> None:
     scrollback = _scrollback("earlier output", ECHO, "partial output")
     assert extract_last_shell_block(scrollback) is None
+
+
+def test_extract_with_bracketed_paste_around_marker(_wrap_mode: None) -> None:
+    # tmux -e capture commonly emits private-mode CSI on prompt lines.
+    bare_with_paste = f"{_BRACKETED_PASTE}{BARE}{_BRACKETED_PASTE}"
+    echo_with_paste = f"{_BRACKETED_PASTE}{ECHO}"
+    scrollback = _scrollback("earlier", echo_with_paste, OUTPUT, bare_with_paste)
+    result = extract_last_shell_block(scrollback)
+    assert result == _scrollback(echo_with_paste, OUTPUT, bare_with_paste)
+
+
+def test_extract_bare_prompt_with_trailing_cursor_movement(_wrap_mode: None) -> None:
+    # Cursor-movement CSI after the marker must not be misread as command text.
+    bare_with_cursor = f"{BARE}{_CURSOR_UP}"
+    scrollback = _scrollback("earlier", ECHO, OUTPUT, bare_with_cursor)
+    result = extract_last_shell_block(scrollback)
+    assert result == _scrollback(ECHO, OUTPUT, bare_with_cursor)
+
+
+def test_extract_picks_last_completed_command(_wrap_mode: None) -> None:
+    # Multiple commands in scrollback — extraction starts at the most recent echo.
+    scrollback = _scrollback(
+        f"user@host $ {_DIM}⌘0⌘{_RESET} echo old",
+        "old",
+        ECHO_FAILED,
+        "ls: /missing: No such file or directory",
+        BARE_AFTER_FAIL,
+    )
+    result = extract_last_shell_block(scrollback)
+    assert result == _scrollback(
+        ECHO_FAILED, "ls: /missing: No such file or directory", BARE_AFTER_FAIL
+    )
+
+
+def test_extract_replace_mode_happy_path() -> None:
+    # Replace mode marker: {prefix}:N❯ at line start. conftest defaults to replace.
+    echo = "ccgram:0❯ ls -la"
+    bare = "ccgram:0❯ "
+    scrollback = _scrollback("earlier", echo, OUTPUT, bare)
+    result = extract_last_shell_block(scrollback)
+    assert result == _scrollback(echo, OUTPUT, bare)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes the screenshot bug where only the visible viewport (~80x24 chars) was captured, slicing long agent replies and shell outputs mid-content.

- Screenshots now capture **scrollback with ANSI** (default 500 lines, configurable via `CCGRAM_SCREENSHOT_HISTORY`, min 50).
- **Shell topics** use the existing `⌘N⌘` prompt markers to extract the **last command + its full output** (falls back to full scrollback if no markers).
- **Other providers** (claude/codex/gemini/pi) get the full scrollback unchanged — vastly more context than the viewport.
- **Live view** and **pane-specific** screenshots are unchanged (live needs current-state, pane-pick is a user-targeted view).

## What changed

- New `src/ccgram/last_unit.py`: pure `extract_last_shell_block` + async `capture_for_screenshot` orchestrator.
- `tmux_manager.capture_pane_scrollback` gains `with_ansi: bool = False` (adds `-e` to the tmux command).
- `CCGRAM_SCREENSHOT_HISTORY` env var added to `Config`.
- Wired into 4 call sites: `screenshot_command`, `_handle_refresh`, `_handle_status_screenshot`, `_do_refresh` (debounced key-press refresh).
- 8 new tests in `tests/ccgram/test_last_unit.py`.
- `CLAUDE.md` updated with the new env var and behavior note.

## Test plan

- [x] `make check` (fmt + lint + lint-lazy + ruff + pyright + 4982 unit + 284 integration) — green
- [ ] Manual: long Claude Code reply → screenshot shows the whole reply (scrollable image), not just viewport tail
- [ ] Manual: shell topic, run `ls -la /usr/bin` → screenshot shows the command and full output, not a partial slice
- [ ] Manual: shell topic with no markers (fresh session before first prompt) → falls back to full scrollback
- [ ] Manual: `📷` button on status bubble + key-press refresh exercise the same path

## Out of scope (deferred)

- Per-agent visual heuristics (e.g. Claude's `╭─`/`╰─` response-box bounds) to slice exactly the last reply for non-shell providers. Today they get full scrollback; smart slicing is a follow-up.