### PR TITLE
fix(logging): audit and cut log noise; per-level colors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,26 @@ Bot commands in topics: `/send`, `/toolbar`, `/history`, `/sessions`, `/restore`
 - Catch specific exceptions (`OSError`, `ValueError`); never bare `except Exception`.
 - Tests: `tests/ccgram/` (unit, mirrors source), `tests/integration/`, `tests/e2e/`. `asyncio_mode = "auto"` — no `@pytest.mark.asyncio`. No comments or docstrings in test files.
 
+## Logging
+
+`structlog` everywhere (`structlog.get_logger()`); the hook subprocess uses stdlib `logging` (separate config in `hook.py`, not colored — fine, it's short-lived). Daemon level policy:
+
+- **DEBUG**: decisions / "why" / per-iteration detail. Off in normal runs.
+- **INFO**: durable lifecycle or state-change events only — never per poll/tick/callback. A genuine once-per-event transition (session changed, window deleted) is INFO; steady-state observations are not.
+- **WARNING**: recoverable anomaly, kept rare. Transient races (window/pane gone mid-capture, token rejected on refresh, missing optional config) are DEBUG — flooding WARNING with races trains operators to ignore it and hides the real ones.
+- **ERROR** / `logger.exception`: a unit of work failed and needs action. Recoverable fallbacks (previous menu kept, glob-scan fallback) are WARNING, not ERROR.
+
+**Steady-state rule**: in poll/tick loops, log on _transition_, not every iteration. Reuse existing patterns — do not invent:
+
+- `log_throttled(logger, key, msg, *args)` (`utils.py`) — first occurrence + 300s cooldown per key, debug-level. Used in `session_map.py` (preserve-primary), `transcript_reader.py` (provider mismatch / partial jsonl), `miniapp/api/terminal.py` stream loop, `polling_coordinator.py`.
+- Mutation-gating — log only when state actually changes (`session_map.py` `_sync_window_from_session_map`, the provider-correction log ~line 625).
+- Warn-once-then-debug counter — `ResilientPollingHTTPXRequest._should_warn_for_reset` (`telegram_request.py`): warn once per interval, debug after, reset on success. Use for a WARNING-level condition that must stay visible without flooding.
+- Per-entry prune loops: DEBUG per item + one INFO summary after (`session.py`, `window_state_store.py`, `user_preferences.py`).
+
+**Color**: `setup_logging` (`main.py`) sets `level_styles` (debug grey, info green, warning bold yellow, error bold red, critical bold bright red) and gates **both** `colors=` and `level_styles` on `_use_colors()` (`isatty()`, honoring `NO_COLOR`/`FORCE_COLOR`). `level_styles` colors the level even when `colors=False`, so both must be gated or raw ANSI leaks into redirected/piped log files. Keep the `key=value` layout — only the level token is colored.
+
+**Never log secrets or PII**: no bot-token bytes (not even a prefix), no full allowed-user-id lists (log a count), no raw message text / chat content.
+
 ## Tmux Auto-Detection
 
 When started inside tmux (`$TMUX` set) with no `--tmux-session` flag, attaches to current session — no creation, no `__main__` placeholder. Excludes own window. Refuses startup if another ccgram is in the same session. `--tmux-session` overrides. Outside tmux, creates `ccgram` session + `__main__` window.

--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -103,10 +103,10 @@ def verify_hooks_installed() -> None:
     provider_name = provider.capabilities.name
     if provider_name != "claude":
         if provider.capabilities.hook_install_managed_by_ccgram:
-            # INFO (not WARNING): Codex/Gemini fall back to transcript-scan
-            # discovery when hooks are absent, so missing hooks are an
-            # opt-in latency improvement, not a degraded state.
-            logger.info(
+            # DEBUG (not INFO/WARNING): Codex/Gemini fall back to transcript-scan
+            # discovery when hooks are absent, so this is an opt-in latency tip,
+            # not a degraded state — it should not greet every startup at INFO.
+            logger.debug(
                 "%s hooks can improve status tracking. Run: ccgram hook --provider %s --install",
                 provider_name,
                 provider_name,

--- a/src/ccgram/config.py
+++ b/src/ccgram/config.py
@@ -212,10 +212,8 @@ class Config:
         )
 
         logger.debug(
-            "Config initialized: dir=%s, token=%s..., allowed_users=%d, "
-            "tmux_session=%s",
+            "Config initialized: dir=%s, allowed_users=%d, tmux_session=%s",
             self.config_dir,
-            self.telegram_bot_token[:8],
             len(self.allowed_users),
             self.tmux_session_name,
         )

--- a/src/ccgram/handlers/commands/menu_sync.py
+++ b/src/ccgram/handlers/commands/menu_sync.py
@@ -234,7 +234,12 @@ def setup_menu_refresh_job(application: "Application") -> None:
                 await register_commands(context.bot, provider=refreshed_provider)
                 _global_provider_menu = refreshed_provider.capabilities.name
             except _CommandRefreshError:
-                logger.exception("Failed to refresh CC commands, keeping previous menu")
+                # Recoverable: the previous menu stays in place, so this is a
+                # warning, not an ERROR-level exception.
+                logger.warning(
+                    "Failed to refresh CC commands, keeping previous menu",
+                    exc_info=True,
+                )
 
     jq = getattr(application, "job_queue", None)
     if jq is not None:

--- a/src/ccgram/handlers/interactive/interactive_ui.py
+++ b/src/ccgram/handlers/interactive/interactive_ui.py
@@ -334,7 +334,7 @@ async def _send_interactive_with_retry(
             return None
         except (TimedOut, NetworkError) as e:
             if attempt < _INTERACTIVE_SEND_RETRIES:
-                logger.info("Interactive UI send transient error, retrying: %s", e)
+                logger.debug("Interactive UI send transient error, retrying: %s", e)
                 await asyncio.sleep(_INTERACTIVE_SEND_RETRY_BACKOFF_S)
                 continue
             logger.error("Failed to send interactive UI to %s: %s", chat_id, e)

--- a/src/ccgram/handlers/live/live_view.py
+++ b/src/ccgram/handlers/live/live_view.py
@@ -174,7 +174,7 @@ async def _tick_one_view(
         ra = exc.retry_after
         wait = ra.total_seconds() if isinstance(ra, timedelta) else float(ra)
         view.next_edit_after = time.monotonic() + wait
-        logger.info("live_view_retry_after", key=key, wait=wait)
+        logger.warning("live_view_retry_after", key=key, wait=wait)
     except TelegramError as exc:
         logger.warning("live_view_tick_error", key=key, error=str(exc))
         _active_views.pop(key, None)

--- a/src/ccgram/handlers/messaging_pipeline/message_routing.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_routing.py
@@ -37,7 +37,7 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
     Routes via thread_bindings to deliver to the correct topic.
     """
     status = "complete" if msg.is_complete else "streaming"
-    logger.info(
+    logger.debug(
         "handle_new_message [%s]: session=%s, text_len=%d",
         status,
         msg.session_id,
@@ -47,7 +47,7 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
     active_users = session_query.find_users_for_session(msg.session_id)
 
     if not active_users:
-        logger.info("No active users for session %s", msg.session_id)
+        logger.debug("No active users for session %s", msg.session_id)
         return
 
     for user_id, window_id, thread_id in active_users:

--- a/src/ccgram/handlers/polling/periodic_tasks.py
+++ b/src/ccgram/handlers/polling/periodic_tasks.py
@@ -99,9 +99,17 @@ async def _run_spawn_cycle(client: TelegramClient) -> None:
                 )
                 if not posted:
                     pop_pending(req.id)
-        except OSError, TelegramError:
+        except (OSError, TelegramError) as exc:
+            # The request is discarded (pop_pending), so the spawn the user
+            # asked for silently never happens — surface it at WARNING with
+            # detail, not a swallowed debug line.
             pop_pending(req.id)
-            logger.debug("Failed to process spawn request", request_id=req.id)
+            logger.warning(
+                "Dropped spawn request after error posting approval",
+                request_id=req.id,
+                requester_window=req.requester_window,
+                error=str(exc),
+            )
 
 
 def _run_mailbox_sweep() -> None:

--- a/src/ccgram/handlers/polling/periodic_tasks.py
+++ b/src/ccgram/handlers/polling/periodic_tasks.py
@@ -98,7 +98,15 @@ async def _run_spawn_cycle(client: TelegramClient) -> None:
                     client, req.requester_window, req
                 )
                 if not posted:
+                    # Same lost-work case as the except below: the approval
+                    # keyboard could not be posted (e.g. no topic bound to the
+                    # requester window), so the spawn silently never happens.
                     pop_pending(req.id)
+                    logger.warning(
+                        "Dropped spawn request: approval keyboard not posted",
+                        request_id=req.id,
+                        requester_window=req.requester_window,
+                    )
         except (OSError, TelegramError) as exc:
             # The request is discarded (pop_pending), so the spawn the user
             # asked for silently never happens — surface it at WARNING with

--- a/src/ccgram/handlers/recovery/recovery_banner.py
+++ b/src/ccgram/handlers/recovery/recovery_banner.py
@@ -298,7 +298,12 @@ async def _create_and_bind_window(
     if pending_text:
         send_ok, send_msg = await send_to_window(created_wid, pending_text)
         if not send_ok:
-            logger.warning("Failed to forward pending text: %s", send_msg)
+            logger.warning(
+                "Failed to forward pending text to window %s (user %s): %s",
+                created_wid,
+                user_id,
+                send_msg,
+            )
             await safe_send(
                 client,
                 thread_router.resolve_chat_id(user_id, thread_id),

--- a/src/ccgram/handlers/shell/shell_commands.py
+++ b/src/ccgram/handlers/shell/shell_commands.py
@@ -237,8 +237,8 @@ async def handle_shell_message(
 
     try:
         completer = get_completer()
-    except ValueError:
-        logger.warning("LLM misconfigured")
+    except ValueError as exc:
+        logger.warning("LLM misconfigured: %s", exc)
         await safe_send(
             client,
             chat_id,
@@ -274,8 +274,8 @@ async def handle_shell_message(
                 shell_tools=ctx["shell_tools"],
                 recent_output=recent_output,
             )
-    except RuntimeError:
-        logger.warning("LLM command generation failed")
+    except RuntimeError as exc:
+        logger.warning("LLM command generation failed: %s", exc)
         await safe_send(
             client,
             chat_id,

--- a/src/ccgram/handlers/topics/directory_callbacks.py
+++ b/src/ccgram/handlers/topics/directory_callbacks.py
@@ -983,7 +983,12 @@ async def _create_window_and_bind(  # noqa: PLR0915
         else:
             send_ok, send_msg = await send_to_window(created_wid, pending_text)
             if not send_ok:
-                logger.warning("Failed to forward pending text: %s", send_msg)
+                logger.warning(
+                    "Failed to forward pending text to window %s (user %s): %s",
+                    created_wid,
+                    user_id,
+                    send_msg,
+                )
                 # Lazy: telegram_client wraps PTB Bot.
                 from ...telegram_client import PTBTelegramClient
 

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -59,7 +59,7 @@ async def _create_forum_topic_with_retry(
         except (TimedOut, NetworkError) as exc:
             last_exc = exc
             if attempt < _TOPIC_CREATE_TRANSIENT_RETRIES:
-                logger.info("create_forum_topic transient error, retrying: %s", exc)
+                logger.debug("create_forum_topic transient error, retrying: %s", exc)
                 await asyncio.sleep(_TOPIC_CREATE_TRANSIENT_BACKOFF_S)
                 continue
             raise

--- a/src/ccgram/handlers/topics/window_callbacks.py
+++ b/src/ccgram/handlers/topics/window_callbacks.py
@@ -160,7 +160,12 @@ async def _forward_pending_text(
         # _ensure_prompt_marker racing with the offer keyboard just shown.
         send_ok, send_msg = await send_to_window(window_id, text)
         if not send_ok:
-            logger.warning("Failed to forward pending text: %s", send_msg)
+            logger.warning(
+                "Failed to forward pending text to window %s (user %s): %s",
+                window_id,
+                user_id,
+                send_msg,
+            )
             await safe_send(
                 client,
                 thread_router.resolve_chat_id(user_id, thread_id),

--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -448,7 +448,6 @@ def _install_hook(provider_name: str = "claude") -> int:  # noqa: PLR0912
         try:
             settings = json.loads(settings_file.read_text())
         except (json.JSONDecodeError, OSError) as e:
-            logger.exception("Error reading %s", settings_file)
             print(f"Error reading {settings_file}: {e}", file=sys.stderr)
             return 1
 
@@ -512,7 +511,6 @@ def _install_hook(provider_name: str = "claude") -> int:  # noqa: PLR0912
             json.dumps(settings, indent=2, ensure_ascii=False) + "\n"
         )
     except OSError as e:
-        logger.exception("Error writing %s", settings_file)
         print(f"Error writing {settings_file}: {e}", file=sys.stderr)
         return 1
 

--- a/src/ccgram/main.py
+++ b/src/ccgram/main.py
@@ -226,11 +226,10 @@ def run_bot() -> None:
         if not session:
             logger.error("Tmux session '%s' not found", config.tmux_session_name)
             sys.exit(1)
-        logger.info("Auto-detected tmux session '%s'", session.session_name)
+        logger.info("Using auto-detected tmux session '%s'", session.session_name)
     else:
         session = tmux_manager.get_or_create_session()
-
-    logger.info("Tmux session '%s' ready", session.session_name)
+        logger.info("Tmux session '%s' ready", session.session_name)
 
     # Lazy: main runs `ccgram` startup; defer imports until the relevant subcommand executes
     from . import __version__

--- a/src/ccgram/main.py
+++ b/src/ccgram/main.py
@@ -107,14 +107,51 @@ def _dim_debug_event(
     return event_dict
 
 
+def _use_colors(stream: object) -> bool:
+    """Colorize only on a TTY, honoring the NO_COLOR / FORCE_COLOR conventions.
+
+    Keeps raw ANSI escapes out of redirected/piped log files while still
+    coloring the interactive tmux pane the daemon runs in.
+    """
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    isatty = getattr(stream, "isatty", None)
+    return bool(isatty and isatty())
+
+
+def _log_level_styles() -> dict[str, str]:
+    """Per-level colors so anomalies stand out and routine debug recedes.
+
+    Values are raw ANSI escapes, matching structlog's own defaults. The key
+    change from the defaults: debug is grey (was green, indistinct from info),
+    and warning/error/critical are bold so they punctuate the stream.
+    """
+    styles = structlog.dev.ConsoleRenderer.get_default_level_styles().copy()
+    styles.update(
+        {
+            "debug": _GRAY_ON,  # grey — recedes on a dark terminal
+            "info": "\x1b[32m",  # green — normal flow (structlog default)
+            "warning": "\x1b[1;33m",  # bold yellow
+            "warn": "\x1b[1;33m",
+            "error": "\x1b[1;31m",  # bold red
+            "exception": "\x1b[1;31m",  # bold red
+            "critical": "\x1b[1;91m",  # bold bright red
+        }
+    )
+    return styles
+
+
 def setup_logging(log_level: str) -> None:
     """Configure structured, colored logging for interactive CLI use."""
     numeric_level = getattr(logging, log_level, None)
     if not isinstance(numeric_level, int):
         numeric_level = logging.INFO
 
-    level_styles = structlog.dev.ConsoleRenderer.get_default_level_styles(colors=True)
-    level_styles["debug"] = _GRAY_ON
+    level_styles = _log_level_styles()
+    stdout_colors = _use_colors(sys.stdout)
+    stderr_colors = _use_colors(sys.stderr)
 
     structlog.configure(
         processors=[
@@ -126,9 +163,11 @@ def setup_logging(log_level: str) -> None:
             structlog.processors.format_exc_info,
             _dim_debug_event,
             structlog.dev.ConsoleRenderer(
-                colors=True,
+                colors=stdout_colors,
                 pad_event=40,
-                level_styles=level_styles,
+                # level_styles colors the level even when colors=False, so gate
+                # it on the same flag to keep ANSI out of redirected output.
+                level_styles=level_styles if stdout_colors else None,
             ),
         ],
         wrapper_class=structlog.stdlib.BoundLogger,
@@ -143,7 +182,10 @@ def setup_logging(log_level: str) -> None:
     handler = logging.StreamHandler()
     handler.setFormatter(
         structlog.stdlib.ProcessorFormatter(
-            processor=structlog.dev.ConsoleRenderer(colors=True),
+            processor=structlog.dev.ConsoleRenderer(
+                colors=stderr_colors,
+                level_styles=level_styles if stderr_colors else None,
+            ),
             foreign_pre_chain=[
                 structlog.stdlib.add_log_level,
                 structlog.stdlib.add_logger_name,

--- a/src/ccgram/main.py
+++ b/src/ccgram/main.py
@@ -113,9 +113,11 @@ def _use_colors(stream: object) -> bool:
     Keeps raw ANSI escapes out of redirected/piped log files while still
     coloring the interactive tmux pane the daemon runs in.
     """
-    if os.environ.get("NO_COLOR"):
+    # Presence-based, per the NO_COLOR / FORCE_COLOR conventions: set with any
+    # value (including empty) counts. NO_COLOR wins over FORCE_COLOR.
+    if "NO_COLOR" in os.environ:
         return False
-    if os.environ.get("FORCE_COLOR"):
+    if "FORCE_COLOR" in os.environ:
         return True
     isatty = getattr(stream, "isatty", None)
     return bool(isatty and isatty())

--- a/src/ccgram/main.py
+++ b/src/ccgram/main.py
@@ -217,7 +217,7 @@ def run_bot() -> None:
     # Lazy: main runs `ccgram` startup; defer imports until the relevant subcommand executes
     from .tmux_manager import tmux_manager
 
-    logger.info("Allowed users: %s", config.allowed_users)
+    logger.info("Allowed users: %d configured", len(config.allowed_users))
     logger.info("Claude projects path: %s", config.claude_projects_path)
 
     # In auto-detect mode, session must already exist

--- a/src/ccgram/miniapp/api/terminal.py
+++ b/src/ccgram/miniapp/api/terminal.py
@@ -199,7 +199,7 @@ async def _authenticate_websocket(
         if init_data_user_id(params) != payload.user_id:
             raise InvalidTokenError("user mismatch")
     except InvalidTokenError as exc:
-        logger.info("rejected ws auth: %s", exc)
+        logger.debug("rejected ws auth: %s", exc)
         await ws.close(code=_WS_AUTH_FAILED_CODE, message=b"auth failed")
         return False
     return True
@@ -218,7 +218,7 @@ async def _terminal_handler(request: web.Request) -> web.StreamResponse:
     try:
         payload = verify_token(token, bot_token=bot_token)
     except InvalidTokenError as exc:
-        logger.info("rejected terminal websocket token: %s", exc)
+        logger.debug("rejected terminal websocket token: %s", exc)
         return web.Response(status=403, text="invalid or expired token")
 
     pane_id = (request.query.get("pane") or "").strip() or None
@@ -283,7 +283,7 @@ async def _panes_handler(request: web.Request) -> web.Response:
             bot_token=bot_token, token=token, init_data=init_data
         )
     except InvalidTokenError as exc:
-        logger.info("rejected panes list token: %s", exc)
+        logger.debug("rejected panes list token: %s", exc)
         return web.Response(status=403, text="invalid or expired token")
 
     try:

--- a/src/ccgram/miniapp/api/terminal.py
+++ b/src/ccgram/miniapp/api/terminal.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 from aiohttp import WSMsgType, web
 
+from ...utils import log_throttled
 from ..auth import (
     InvalidTokenError,
     TokenPayload,
@@ -318,15 +319,28 @@ async def _stream_loop(
                     pane_capture(window_id, pane_id), timeout=_CAPTURE_TIMEOUT
                 )
         except TimeoutError:
-            logger.warning(
-                "terminal capture timeout for %s pane=%s", window_id, pane_id
+            # Throttled: fires every `interval` (~0.2s) for a stuck/gone pane.
+            # The client still gets an error frame each tick; the log need not.
+            log_throttled(
+                logger,
+                f"term-capture-timeout:{window_id}:{pane_id}",
+                "terminal capture timeout for %s pane=%s",
+                window_id,
+                pane_id,
             )
             await _send_json(ws, {"type": "error", "message": "capture timeout"})
             await asyncio.sleep(interval)
             continue
         except Exception:  # noqa: BLE001 — capture failure must not kill stream
-            logger.exception(
-                "terminal capture failed for %s pane=%s", window_id, pane_id
+            # Throttled: same per-tick cadence. The underlying capture path
+            # (tmux_manager) already logs the specific tmux error; this is a
+            # backstop, and the client gets an error frame regardless.
+            log_throttled(
+                logger,
+                f"term-capture-failed:{window_id}:{pane_id}",
+                "terminal capture failed for %s pane=%s",
+                window_id,
+                pane_id,
             )
             await _send_json(ws, {"type": "error", "message": "capture failed"})
             await asyncio.sleep(interval)

--- a/src/ccgram/miniapp/api/transcript.py
+++ b/src/ccgram/miniapp/api/transcript.py
@@ -75,7 +75,7 @@ def _verify(request: web.Request) -> str | web.Response:
             bot_token=bot_token, token=token, init_data=init_data
         )
     except InvalidTokenError as exc:
-        logger.info("rejected transcript token: %s", exc)
+        logger.debug("rejected transcript token: %s", exc)
         return web.Response(status=403, text="invalid or expired token")
     return payload.window_id
 

--- a/src/ccgram/miniapp/server.py
+++ b/src/ccgram/miniapp/server.py
@@ -75,7 +75,7 @@ async def _handle_app(request: web.Request) -> web.Response:
     try:
         payload = verify_token(token, bot_token=bot_token)
     except InvalidTokenError as exc:
-        logger.info("rejected miniapp token: %s", exc)
+        logger.debug("rejected miniapp token: %s", exc)
         return web.Response(status=403, text="invalid or expired token")
 
     # Escape every interpolated value: today the payload fields are

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -356,10 +356,15 @@ class SessionManager:
 
         for wid in stale_display:
             name = thread_router.pop_display_name(wid)
-            logger.info("Pruning stale display name: %s (%s)", wid, name)
+            logger.debug("Pruning stale display name: %s (%s)", wid, name)
         for key in stale_chat:
-            logger.info("Pruning stale group_chat_id: %s", key)
+            logger.debug("Pruning stale group_chat_id: %s", key)
             del thread_router.group_chat_ids[key]
+        logger.info(
+            "Pruned stale state: %d display name(s), %d group chat id(s)",
+            len(stale_display),
+            len(stale_chat),
+        )
 
         self._save_state()
         return True
@@ -539,8 +544,9 @@ class SessionManager:
         if not stale:
             return False
         for wid in stale:
-            logger.info("Pruning stale window_state: %s", wid)
+            logger.debug("Pruning stale window_state: %s", wid)
             del self.window_states[wid]
+        logger.info("Pruned %d stale window_state(s)", len(stale))
         self._save_state()
         return True
 

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -34,19 +34,13 @@ from typing import Any, cast
 import aiofiles
 
 from .config import config
-from .utils import atomic_write_json
+from .utils import atomic_write_json, log_throttle_reset, log_throttled
 from .window_resolver import EMDASH_SESSION_PREFIX, is_foreign_window, is_window_id
 
 logger = structlog.get_logger()
 
 _LEGACY_SESSION_PREFIX = "ccbot:"
 _DEFAULT_PRIMARY_SESSION_GRACE_SEC = 60.0
-
-# Per-window memo of the last incoming session_id we logged a "preserve" for.
-# Decision is stable across poll cycles (steady state: same nested sid arrives
-# every ~1s); logging the conclusion every cycle is pure noise.  Log only on
-# transition — when the incoming sid we're rejecting changes.
-_preserve_log_memo: dict[str, str] = {}
 
 
 def _primary_session_grace_sec() -> float:
@@ -129,14 +123,14 @@ def _prefer_existing_primary(
     if not existing_is_fresh and not existing_is_newer:
         return None
 
-    if _preserve_log_memo.get(window_id) != incoming_sid:
-        _preserve_log_memo[window_id] = incoming_sid
-        logger.debug(
-            "Preserving primary session for window_id %s: existing %s, incoming %s treated as nested",
-            window_id,
-            state.session_id,
-            incoming_sid,
-        )
+    log_throttled(
+        logger,
+        f"preserve-primary:{window_id}",
+        "Preserving primary session for window_id %s: existing %s, incoming %s treated as nested",
+        window_id,
+        state.session_id,
+        incoming_sid,
+    )
     return {
         "session_id": state.session_id,
         "cwd": state.cwd,
@@ -429,7 +423,7 @@ class SessionMapSync:
                 "Pruning dead session_map entry: %s (window %s)", key, window_id
             )
             del raw[key]
-            _preserve_log_memo.pop(window_id, None)
+            log_throttle_reset(f"preserve-primary:{window_id}")
             if window_store.has_window(window_id):
                 window_store.remove_window(window_id)
                 changed_state = True

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -571,8 +571,11 @@ class SessionMapSync:
                     return
                 finally:
                     fcntl.flock(lock_f, fcntl.LOCK_UN)
-        except OSError:
-            logger.debug("Failed to lock session_map for clearing %s", window_id)
+        except OSError as exc:
+            # Lock failure means the entry clear was lost — surface it.
+            logger.warning(
+                "Failed to lock session_map for clearing %s: %s", window_id, exc
+            )
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -316,7 +316,10 @@ class SessionMonitor:
                     try:
                         await self._new_window_callback(event)
                     except _CallbackError:
-                        logger.exception("New window callback error for %s", window_id)
+                        logger.exception(
+                            "New window callback error (session_map path) for %s",
+                            window_id,
+                        )
 
         return result.current_map
 
@@ -369,7 +372,7 @@ class SessionMonitor:
                             await self._new_window_callback(event)
                         except _CallbackError:
                             logger.exception(
-                                "New window callback error for %s",
+                                "New window callback error (unbound window path) for %s",
                                 window.window_id,
                             )
 
@@ -424,7 +427,9 @@ class SessionMonitor:
             self._task.cancel()
             self._task = None
         self.state.save()
-        logger.info("Session monitor stopped and state saved")
+        # Distinct from the loop's "Session monitor stopped" (logged when the
+        # poll loop actually exits) — this marks the stop request + state save.
+        logger.info("Session monitor stop requested; state saved")
 
 
 _active_monitor: SessionMonitor | None = None

--- a/src/ccgram/session_resolver.py
+++ b/src/ccgram/session_resolver.py
@@ -99,7 +99,7 @@ class SessionResolver:
         if window_id and decoded_cwd.startswith("/") and Path(decoded_cwd).is_dir():
             current_cwd = identity_state.get_cwd(window_id)
             if current_cwd and current_cwd != decoded_cwd:
-                logger.info(
+                logger.debug(
                     "Glob fallback: updating cwd for window %s: %r -> %r",
                     window_id,
                     current_cwd,

--- a/src/ccgram/telegram_draft.py
+++ b/src/ccgram/telegram_draft.py
@@ -36,6 +36,8 @@ from telegram import Bot, InlineKeyboardMarkup
 from telegram.error import BadRequest, NetworkError, RetryAfter, TelegramError, TimedOut
 from telegram.warnings import PTBUserWarning
 
+from .utils import log_throttled
+
 # PTB v22.6+ exposes a typed `send_message_draft` whose signature requires a
 # `draft_id` and returns `bool` rather than a Message dict — incompatible with
 # our message_id-keyed edit flow. Keep using `do_api_request` and silence the
@@ -449,7 +451,7 @@ class DraftStream:
             # message not modified — treat as success (no-op edit)
             if "not modified" in (exc.message or "").lower():
                 return
-            logger.warning("DraftStream legacy edit failed: %s", exc)
+            self._warn_legacy_edit_failed(exc)
         except RetryAfter as exc:
             await asyncio.sleep(_retry_after_seconds(exc) + 1)
             with contextlib.suppress(TelegramError):
@@ -460,7 +462,19 @@ class DraftStream:
                     **edit_kwargs,
                 )
         except TelegramError as exc:
-            logger.warning("DraftStream legacy edit failed: %s", exc)
+            self._warn_legacy_edit_failed(exc)
+
+    def _warn_legacy_edit_failed(self, exc: TelegramError) -> None:
+        # Throttled: _push_legacy runs on every append()/finalize(). When the
+        # target message is gone or persistently rejecting edits this would
+        # warn per delta. The degrade into legacy mode was already announced at
+        # WARNING by _handle_stream_failure, so repeats here are low value.
+        log_throttled(
+            logger,
+            f"draft-legacy-edit:{self._chat_id}:{self._message_id}",
+            "DraftStream legacy edit failed: %s",
+            exc,
+        )
 
     async def _handle_stream_failure(self, exc: TelegramError) -> None:
         self._stream_failures += 1

--- a/src/ccgram/thread_router.py
+++ b/src/ccgram/thread_router.py
@@ -268,7 +268,7 @@ class ThreadRouter:
         if self.group_chat_ids.get(key) != chat_id:
             self.group_chat_ids[key] = chat_id
             self._schedule_save()
-            logger.info(
+            logger.debug(
                 "Stored group chat_id %d for user %d, thread %d",
                 chat_id,
                 user_id,
@@ -334,7 +334,7 @@ class ThreadRouter:
             if old and old != window_name:
                 self.window_display_names[window_id] = window_name
                 changed = True
-                logger.info(
+                logger.debug(
                     "Synced display name: %s %s → %s", window_id, old, window_name
                 )
         if changed:

--- a/src/ccgram/tmux_manager.py
+++ b/src/ccgram/tmux_manager.py
@@ -398,7 +398,10 @@ class TmuxManager:
             async with asyncio.timeout(5.0):
                 stdout, stderr = await proc.communicate()
             if proc.returncode != 0:
-                logger.warning(
+                # Window/pane gone mid-capture — a race in the live-view poll,
+                # not an operator-actionable error. TimeoutError below stays
+                # WARNING (tmux genuinely wedged).
+                logger.debug(
                     "Failed to get pane dimensions %s: %s",
                     window_id,
                     stderr.decode("utf-8", errors="replace"),
@@ -446,7 +449,8 @@ class TmuxManager:
             async with asyncio.timeout(5.0):
                 stdout, stderr = await proc.communicate()
             if proc.returncode != 0:
-                logger.warning(
+                # Window/pane gone mid-capture — live-view race, not actionable.
+                logger.debug(
                     "Failed to capture pane %s: %s",
                     window_id,
                     stderr.decode("utf-8", errors="replace"),
@@ -555,7 +559,9 @@ class TmuxManager:
                     # Window closed mid-capture — race, not an error.
                     logger.debug("Pane capture skipped (window gone): %s", window_id)
                 else:
-                    logger.warning("Failed to capture pane %s: %s", window_id, e)
+                    # Other libtmux errors here are transient races on the
+                    # status-poll path (~1s); server reset below recovers.
+                    logger.debug("Failed to capture pane %s: %s", window_id, e)
                 self._reset_server()
                 return None
 
@@ -953,7 +959,9 @@ class TmuxManager:
                     )
                 return result
             except _TmuxError as exc:
-                logger.warning("Failed to list panes for %s: %s", window_id, exc)
+                # Miniapp polls panes at ~0.2s; a gone window races here. Debug,
+                # not warning — server reset below recovers.
+                logger.debug("Failed to list panes for %s: %s", window_id, exc)
                 self._reset_server()
                 return []
 
@@ -996,7 +1004,9 @@ class TmuxManager:
                 text = text.rstrip()
                 return text if text else None
             except _TmuxError as exc:
-                logger.warning("Failed to capture pane %s: %s", pane_id, exc)
+                # Miniapp polls captures at ~0.2s; a gone pane races here. Debug,
+                # not warning — server reset below recovers.
+                logger.debug("Failed to capture pane %s: %s", pane_id, exc)
                 self._reset_server()
                 return None
 

--- a/src/ccgram/tmux_manager.py
+++ b/src/ccgram/tmux_manager.py
@@ -750,7 +750,7 @@ class TmuxManager:
         Foreign windows (emdash) are never killed — they are owned externally.
         """
         if is_foreign_window(window_id):
-            logger.info("Skipping kill for external window %s", window_id)
+            logger.debug("Skipping kill for external window %s", window_id)
             return False
 
         def _sync_kill() -> bool:

--- a/src/ccgram/tmux_manager.py
+++ b/src/ccgram/tmux_manager.py
@@ -580,16 +580,16 @@ class TmuxManager:
             )
         session = self.get_session()
         if not session:
-            logger.warning("No tmux session found")
+            logger.debug("No tmux session found")
             return False
         try:
             window = session.windows.get(window_id=window_id, default=None)
             if not window:
-                logger.warning("Window %s not found", window_id)
+                logger.debug("Window %s not found", window_id)
                 return False
             pane = window.active_pane
             if not pane:
-                logger.warning("No active pane in window %s", window_id)
+                logger.debug("No active pane in window %s", window_id)
                 return False
             pane.send_keys(chars, enter=enter, literal=literal)
             return True
@@ -987,7 +987,7 @@ class TmuxManager:
                 # Validate pane belongs to the specified window before capture
                 panes = await self.list_panes(window_id)
                 if not any(p.pane_id == pane_id for p in panes):
-                    logger.warning("Pane %s not found in window %s", pane_id, window_id)
+                    logger.debug("Pane %s not found in window %s", pane_id, window_id)
                     return None
             return await self._capture_pane_ansi(pane_id)
 
@@ -1037,7 +1037,7 @@ class TmuxManager:
             try:
                 pane = self._find_pane(pane_id, session, window_id=window_id)
                 if not pane:
-                    logger.warning("Pane %s not found", pane_id)
+                    logger.debug("Pane %s not found", pane_id)
                     return False
                 pane.send_keys(text, enter=enter, literal=literal)
                 return True

--- a/src/ccgram/toolbar_config.py
+++ b/src/ccgram/toolbar_config.py
@@ -384,9 +384,10 @@ def _parse_layout(
 
 
 def _read_toml(path: Path) -> dict | None:
-    """Read and parse a TOML file. Returns None on any error (logs warning)."""
+    """Read and parse a TOML file. Returns None on any error."""
     if not path.exists():
-        logger.warning("Toolbar config file not found: %s — using defaults", path)
+        # Optional config — its absence is the normal default case, not a warning.
+        logger.debug("Toolbar config file not found: %s — using defaults", path)
         return None
     try:
         with path.open("rb") as fh:

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -345,7 +345,9 @@ class TranscriptReader:
                             )
 
                 except (json.JSONDecodeError, OSError) as e:
-                    logger.debug("Error reading index %s: %s", index_file, e)
+                    # Degraded discovery: index unreadable, falling back to a
+                    # glob scan below. Worth surfacing — not a per-poll hot path.
+                    logger.warning("Error reading index %s: %s", index_file, e)
 
             try:
                 for jsonl_file in project_dir.glob("*.jsonl"):
@@ -374,6 +376,6 @@ class TranscriptReader:
                         )
                     )
             except OSError as e:
-                logger.debug("Error scanning jsonl files in %s: %s", project_dir, e)
+                logger.warning("Error scanning jsonl files in %s: %s", project_dir, e)
 
         return sessions

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -61,10 +61,13 @@ def _resolve_provider_for_file(window_id: str, file_path: Path) -> Any:
         and registry.is_valid(inferred)
     ):
         # Throttled debug, not warning: this read-path observation repeats every
-        # poll until session_map corrects the in-memory state, and the
-        # authoritative WARNING already fires once on that mutation
-        # (session_map._sync_window_from_session_map). Logging here every poll
-        # only floods.
+        # poll until session_map corrects the in-memory state. The read itself
+        # self-heals (we return the inferred provider below), and when the hook
+        # is functional session_map._sync_window_from_session_map emits the
+        # authoritative WARNING on the state mutation. Caveat: if the hook is
+        # broken so session_map never updates, that correction (and its WARNING)
+        # never fires and this stays debug-only — accepted, since the read still
+        # works and a per-poll WARNING here would just flood.
         log_throttled(
             logger,
             f"provider-mismatch:{window_id}",

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -60,11 +60,18 @@ def _resolve_provider_for_file(window_id: str, file_path: Path) -> Any:
         and provider.capabilities.supports_hook
         and registry.is_valid(inferred)
     ):
-        logger.warning(
+        # Throttled debug, not warning: this read-path observation repeats every
+        # poll until session_map corrects the in-memory state, and the
+        # authoritative WARNING already fires once on that mutation
+        # (session_map._sync_window_from_session_map). Logging here every poll
+        # only floods.
+        log_throttled(
+            logger,
+            f"provider-mismatch:{window_id}",
             "Provider mismatch for window %s: state=%s transcript=%s; using %s",
             window_id,
             current,
-            file_path,
+            str(file_path),
             inferred,
         )
         return registry.get(inferred)

--- a/src/ccgram/user_preferences.py
+++ b/src/ccgram/user_preferences.py
@@ -142,17 +142,21 @@ class UserPreferences:
         """
         changed = False
         empty_users: list[int] = []
+        pruned = 0
         for uid, offsets in self.user_window_offsets.items():
             stale = [wid for wid in offsets if wid not in known_window_ids]
             for wid in stale:
-                logger.info("Pruning stale offset: user %d, window %s", uid, wid)
+                logger.debug("Pruning stale offset: user %d, window %s", uid, wid)
                 del offsets[wid]
                 changed = True
+                pruned += 1
             if not offsets:
                 empty_users.append(uid)
         for uid in empty_users:
             del self.user_window_offsets[uid]
             changed = True
+        if pruned:
+            logger.info("Pruned %d stale window offset(s)", pruned)
         if changed:
             self._schedule_save()
         return changed

--- a/src/ccgram/utils.py
+++ b/src/ccgram/utils.py
@@ -49,6 +49,11 @@ def log_throttled(
     First occurrence always logs. Subsequent calls with the same *key* and
     identical formatted message are suppressed until *cooldown* seconds elapse.
     A changed message resets the timer and logs immediately.
+
+    Not thread-safe: the read-check-write of ``_throttle_state`` is unlocked, so
+    all callers must run on the asyncio event loop (never from asyncio.to_thread
+    or a threadpool). Use distinct, bounded keys — entries persist until
+    log_throttle_sweep() evicts them.
     """
     formatted = msg % args if args else msg
     now = _clock()

--- a/src/ccgram/window_state_store.py
+++ b/src/ccgram/window_state_store.py
@@ -345,7 +345,7 @@ class WindowStateStore:
         state = self.get_window_state(window_id)
         state.session_id = ""
         self._schedule_save()
-        logger.info("Cleared session for window_id %s", window_id)
+        logger.debug("Cleared session for window_id %s", window_id)
 
     def set_provider_manual_override(self, window_id: str, *, value: bool) -> None:
         """Mark or clear the provider manual-override flag. No-op when unchanged."""

--- a/src/ccgram/window_state_store.py
+++ b/src/ccgram/window_state_store.py
@@ -627,8 +627,9 @@ class WindowStateStore:
         if not stale:
             return False
         for wid in stale:
-            logger.info("Pruning stale window_state: %s", wid)
+            logger.debug("Pruning stale window_state: %s", wid)
             del self.window_states[wid]
+        logger.info("Pruned %d stale window_state(s)", len(stale))
         self._schedule_save()
         return True
 

--- a/tests/ccgram/test_bootstrap.py
+++ b/tests/ccgram/test_bootstrap.py
@@ -264,9 +264,10 @@ class TestVerifyHooksInstalled:
         ):
             bootstrap.verify_hooks_installed()
 
-        logger.info.assert_called_once()
+        # DEBUG, not INFO: an opt-in latency tip should not greet every startup.
+        logger.debug.assert_called_once()
         # Message includes the provider name and the install command.
-        args = logger.info.call_args[0]
+        args = logger.debug.call_args[0]
         assert "codex" in args
 
     def test_no_hint_for_non_managed_provider(self):

--- a/tests/integration/test_tmux_manager.py
+++ b/tests/integration/test_tmux_manager.py
@@ -250,16 +250,30 @@ async def test_capture_pane_with_ansi(tmux, tmp_path) -> None:
     )
     assert ok
 
-    await tmux.send_keys(window_id, r'printf "\033[31mred\033[0m normal"')
-    await asyncio.sleep(0.5)
+    # raw=True: plain shell window — use the direct send path, not the
+    # Claude-TUI path (vim-mode probe + 500ms Enter delay).
+    await tmux.send_keys(window_id, r'printf "\033[31mred\033[0m normal\n"', raw=True)
+
+    # Poll for the rendered ANSI output. The real ESC byte (\x1b) only appears
+    # once the shell actually executes printf — that is the signal we assert
+    # on (the literal command text contains "red"/"normal" but not \x1b, so a
+    # substring match alone would be a false positive). Some sandboxed CI
+    # environments run the pane under a shell that never executes piped
+    # keystrokes; skip there rather than fail on an environment limitation.
+    ansi = ""
+    for _ in range(10):
+        await asyncio.sleep(0.3)
+        ansi = await tmux.capture_pane(window_id, with_ansi=True) or ""
+        if "\x1b[" in ansi:
+            break
+    if "\x1b[" not in ansi:
+        pytest.skip("tmux pane shell did not execute the command in this environment")
 
     plain = await tmux.capture_pane(window_id, with_ansi=False)
-    ansi = await tmux.capture_pane(window_id, with_ansi=True)
     assert plain is not None
-    assert ansi is not None
     assert "red" in plain
     assert "normal" in plain
-    assert "\x1b[" in ansi
+    assert "\x1b[31m" in ansi
     assert "red" in ansi
 
 

--- a/tests/integration/test_tmux_manager.py
+++ b/tests/integration/test_tmux_manager.py
@@ -251,22 +251,30 @@ async def test_capture_pane_with_ansi(tmux, tmp_path) -> None:
     assert ok
 
     # raw=True: plain shell window — use the direct send path, not the
-    # Claude-TUI path (vim-mode probe + 500ms Enter delay).
-    await tmux.send_keys(window_id, r'printf "\033[31mred\033[0m normal\n"', raw=True)
+    # Claude-TUI path (vim-mode probe + 500ms Enter delay). The trailing
+    # `touch` of a sentinel file proves the shell actually executed the line,
+    # independent of pane capture: the command is always *echoed* on screen
+    # (so "red"/"normal"/the ESC sequence appear whether or not it ran), making
+    # the captured text alone an unreliable execution signal.
+    done = tmp_path / ".ansi_executed"
+    await tmux.send_keys(
+        window_id,
+        f'printf "\\033[31mred\\033[0m normal"; touch "{done}"',
+        raw=True,
+    )
 
-    # Poll for the rendered ANSI output. The real ESC byte (\x1b) only appears
-    # once the shell actually executes printf — that is the signal we assert
-    # on (the literal command text contains "red"/"normal" but not \x1b, so a
-    # substring match alone would be a false positive). Some sandboxed CI
-    # environments run the pane under a shell that never executes piped
-    # keystrokes; skip there rather than fail on an environment limitation.
     ansi = ""
     for _ in range(10):
         await asyncio.sleep(0.3)
         ansi = await tmux.capture_pane(window_id, with_ansi=True) or ""
-        if "\x1b[" in ansi:
+        if done.exists():
             break
-    if "\x1b[" not in ansi:
+
+    # Some sandboxed CI environments run the pane under a shell that never
+    # executes piped keystrokes — skip there. But if the shell DID execute
+    # (sentinel present) yet ANSI capture lost the escape, that is a real
+    # capture regression and must fail, not skip.
+    if not done.exists():
         pytest.skip("tmux pane shell did not execute the command in this environment")
 
     plain = await tmux.capture_pane(window_id, with_ansi=False)


### PR DESCRIPTION
## Summary

Audit and cleanup of all ~400 log statements across the app. The daemon was burying actionable logs under per-poll/per-tick floods (the trigger: `session_map.py` spamming "Preserving primary session" every ~3s for a steady-state condition). Distribution was inverted — 130 WARNING vs 105 INFO — a warning-fatigue smell, since warnings should be rarer than lifecycle info.

Fixes are grouped by tier, one commit each. The guiding rubric (now recorded in `CLAUDE.md` → **Logging**): in poll/tick loops log on *transition*, not every iteration; WARNING stays rare; transient races are DEBUG.

## What changed

- **Tier 1 — prod-visible floods** (`99f2fb8`): transcript provider-mismatch, tmux capture races, miniapp stream loop, draft legacy edits → throttled / debug. Reuses the existing `log_throttled` helper; `TimeoutError` paths kept at WARNING (genuinely wedged).
- **Audit-surfaced bugs** (`314fa9d`): silently-dropped spawn requests now WARNING with `request_id`/detail (was lost work); fixed the env-flaky `test_capture_pane_with_ansi` (its `red`/`normal` asserts matched the literal command text — false positives — and it raced execution; now polls for rendered ANSI and skips when the pane shell can't execute, e.g. sandboxed CI).
- **Initial finding** (`2c16475`): `session_map` preserve-primary deduped on transition.
- **Tier 2 — warning fatigue** (`15a1b3a`): transient races / routine events → DEBUG.
- **Tier 3 — under-logged failures** (`1c34b16`): index/scan/lock failures, recoverable refresh, LLM errors promoted + given detail.
- **Tier 4 — loop noise** (`de55073`): per-entry prune loops → DEBUG + one INFO summary; internal bookkeeping demoted.
- **Tier 5 — duplicates** (`26f30c5`): disambiguated repeated messages; deduped double stderr; added window/user context.
- **Tier 6 — secrets/PII** (`71954e3`): stopped logging user-ID lists and bot-token bytes.
- **Per-level color** (`9d0b15b`): debug grey, warning bold yellow, error bold red, critical bold bright red. Gates `colors=` **and** `level_styles` on `isatty()` (honoring `NO_COLOR`/`FORCE_COLOR`) so no ANSI leaks into piped/redirected logs. `key=value` layout preserved.
- **Docs** (`71761cb`): `## Logging` conventions in `CLAUDE.md`, referencing the concrete patterns by name/location.

## Judgment calls (diverged from the mechanical audit)

- Kept `tmux_manager:225` at DEBUG — promoting would flood per-poll window enumeration.
- Kept `session_lifecycle` session-changed / window-deleted at INFO — genuine once-per-event transitions, exactly what INFO is for.
- Corrected an overstated "token leak" finding: the logged `token[:8]` is mostly the non-secret bot ID, not a replay risk — dropped anyway.

## Verification

- `make test`: **4983 passed, 28 skipped** (matches baseline).
- `make lint` clean, `make typecheck` 0 errors throughout.
- Color verified empirically: ANSI present on a TTY (`FORCE_COLOR=1`), **zero** ANSI when piped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
