### PR TITLE
feat(ccgram-pro): add workflow layer for project picker, workspaces, wizard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,32 @@
-.PHONY: fmt lint lint-lazy test test-integration test-integration-llm test-e2e test-all typecheck deptry check install dev build clean
+.PHONY: fmt lint lint-lazy test test-integration test-integration-llm test-e2e test-all typecheck deptry check check-layer install dev build clean
 
 fmt:
-	uv run ruff format src/ tests/
+	uv run ruff format src/ tests/ ccgram-pro/src/ ccgram-pro/tests/
 
 lint: lint-lazy
-	uv run ruff check src/ tests/
+	uv run ruff check src/ tests/ ccgram-pro/src/ ccgram-pro/tests/
 
 lint-lazy:
 	uv run python scripts/lint_lazy_imports.py
+	uv run python scripts/lint_lazy_imports.py ccgram-pro/src
 
 typecheck:
 	uv run pyright src/ccgram/ tests/
+	uv run pyright ccgram-pro/src/
 
 deptry:
 	uv run deptry src
 
 test:
 	uv run pytest tests/ -m "not integration and not e2e" -n auto --dist=loadscope
+
+# ccgram-pro layer — runs alongside `check` so a layer regression fails CI.
+check-layer:
+	uv run ruff format --check ccgram-pro/src/ ccgram-pro/tests/
+	uv run ruff check ccgram-pro/src/ ccgram-pro/tests/
+	uv run python scripts/lint_lazy_imports.py ccgram-pro/src
+	uv run pyright ccgram-pro/src/
+	TELEGRAM_BOT_TOKEN=test ALLOWED_USERS=1 uv run pytest ccgram-pro/tests/ -q
 
 test-serial:
 	uv run pytest tests/ -m "not integration and not e2e"
@@ -33,7 +43,7 @@ test-e2e:
 test-all:
 	uv run pytest tests/ -n auto --dist=loadscope -v -m "not e2e"
 
-check: fmt lint typecheck deptry test test-integration
+check: fmt lint typecheck deptry test test-integration check-layer
 
 install:
 	uv sync

--- a/ccgram-pro/.gitignore
+++ b/ccgram-pro/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.pytest_cache/
+.ruff_cache/
+__pycache__/
+*.egg-info/
+dist/
+build/
+*.pyc

--- a/ccgram-pro/README.md
+++ b/ccgram-pro/README.md
@@ -1,0 +1,93 @@
+# ccgram-pro
+
+Workflow layer on top of [ccgram](../). Adds:
+
+- predefined project picker, model + reasoning selector
+- batched text + voice input (Send when ready)
+- input/output transforms (preamble injection, output silencing + summarization)
+- plan/execute mode flow with approve/edit gating
+- React + Monaco diff viewer with branch + PR management
+- `/pr-fix` review loop against Cursor-bot feedback
+
+Installed as a sibling package that hooks into ccgram via two entry-point
+groups (`ccgram.extensions`, `ccgram.miniapp_factory`). The only upstream
+change is two small hook dispatch sites in `src/ccgram/bootstrap.py` and
+`src/ccgram/main.py`.
+
+## Compatibility
+
+Requires Python 3.14+ (matches ccgram) and a build of ccgram that ships the
+two entry-point hooks (`bootstrap.dispatch_extensions` and
+`main._resolve_miniapp_factory`). Verify with `ccgram-pro doctor`.
+
+Phase 7 (`/pr-fix` PR review loop) additionally needs the GitHub CLI
+(`gh auth login`) on `$PATH`. Earlier phases do not.
+
+## Install
+
+From the repo root:
+
+```bash
+uv pip install -e ccgram-pro
+ccgram-pro doctor
+```
+
+Then run ccgram normally — the layer activates via entry-point dispatch.
+
+## Configuration
+
+State lives under `<CCGRAM_DIR>/layer/` (default `~/.ccgram/layer/`). When
+running multiple ccgram instances (`CCGRAM_GROUP_ID` or
+`CCGRAM_INSTANCE_NAME` set), the layer further namespaces by group/instance
+so concurrent bots don't share state.
+
+### `projects.toml`
+
+Predefined project list shown by the `/project` picker:
+
+```toml
+[[project]]
+path = "/root/projects/humanprogram/backend"
+label = "HP Backend"
+default_model = "opus"               # Claude CLI alias: opus | sonnet | haiku
+default_reasoning = "extra-high"     # layer label: extra-high | high | medium | low
+default_preamble = """
+Remember our backend conventions. Run pnpm typecheck after edits.
+"""
+
+[[project]]
+path = "/root/projects/personal/ccgram"
+label = "ccgram (this repo)"
+```
+
+### `settings.toml`
+
+Global layer defaults — every key is optional and falls back to the
+baked-in value:
+
+```toml
+[defaults]
+silent_mode = true
+batch_mode = true
+plan_mode_on_new_session = true
+preamble = """
+Remember to follow best practices and our current project rules.
+Production-ready implementation only — no quick changes or hacks.
+"""
+
+[voice]
+transcription_note = "Voice may have transcription errors — interpret intent."
+flush_grace_seconds = 30
+
+[snapshots]
+prune_after_days = 7
+
+[share_tokens]
+default_ttl_seconds = 259200  # 3 days
+```
+
+## Status
+
+Phase 0 (foundation) shipped. Subsequent phases land independently — each
+leaves the bot fully working. See `ccgram-pro doctor` for what's wired up
+in the current install.

--- a/ccgram-pro/pyproject.toml
+++ b/ccgram-pro/pyproject.toml
@@ -1,0 +1,77 @@
+[project]
+name = "ccgram-pro"
+version = "0.1.0"
+description = "Workflow layer on top of ccgram — project picker, batched input, plan/execute mode, web diff viewer, PR review loop."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.14"
+authors = [
+    { name = "Evgenij Dolgov", email = "edolgov@outlook.com" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Communications :: Chat",
+    "Topic :: Software Development",
+    "Typing :: Typed",
+]
+dependencies = [
+    "ccgram",
+    "click>=8.1.0",
+    "structlog>=24.0.0",
+    # PTB JobQueue powers the periodic workspace GC sweep. ccgram itself
+    # does not pull this extra, so the layer asks for it explicitly.
+    "python-telegram-bot[job-queue]>=21.0",
+]
+
+[project.scripts]
+ccgram-pro = "ccgram_pro.cli:main"
+
+[project.entry-points."ccgram.extensions"]
+ccgram-pro = "ccgram_pro.extension:install"
+
+[project.entry-points."ccgram.miniapp_factory"]
+ccgram-pro = "ccgram_pro.miniapp_factory:make_factory"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pyright>=1.1.0",
+    "ruff>=0.8.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ccgram_pro"]
+
+[tool.uv.sources]
+ccgram = { path = "..", editable = true }
+
+[tool.ruff]
+target-version = "py314"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "ARG", "G", "BLE", "SIM", "PLR2004", "C901", "PLR0911", "PLR0912", "PLR0915", "N"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.per-file-ignores]
+# Tests: unused fixture args, magic values in assertions (matches ccgram's
+# own ruff config so test style stays uniform across both packages).
+"tests/**" = ["ARG", "PLR2004"]
+
+[tool.pyright]
+pythonVersion = "3.14"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+timeout = 30

--- a/ccgram-pro/src/ccgram_pro/__init__.py
+++ b/ccgram-pro/src/ccgram_pro/__init__.py
@@ -1,0 +1,19 @@
+"""ccgram-pro — workflow layer on top of ccgram.
+
+Activated via two entry points declared in ``pyproject.toml``:
+
+- ``ccgram.extensions`` → :func:`ccgram_pro.extension.install` runs after the
+  PTB application is bootstrapped and registers handlers, callbacks, and
+  background tasks.
+- ``ccgram.miniapp_factory`` → :func:`ccgram_pro.miniapp_factory.make_factory`
+  wraps the default ``build_app`` so layer-owned aiohttp routes (diff viewer,
+  long summaries, share links) ride the same Mini App server.
+
+Per-window state lives at ``~/.ccgram/layer/state/<window_id>.json``. Global
+defaults at ``~/.ccgram/layer/settings.toml`` and project list at
+``~/.ccgram/layer/projects.toml``.
+"""
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/ccgram-pro/src/ccgram_pro/cli.py
+++ b/ccgram-pro/src/ccgram_pro/cli.py
@@ -1,0 +1,41 @@
+"""``ccgram-pro`` CLI entry — ``doctor`` + ``setup`` subcommands.
+
+Kept deliberately thin: the layer itself runs inside ccgram via entry-point
+dispatch. The CLI exists so users can validate the install and run the
+guided setup wizard without booting the bot.
+"""
+
+from __future__ import annotations
+
+import click
+
+from . import __version__
+from .doctor import run_doctor
+from .wizard import run_wizard
+
+
+@click.group(help="ccgram-pro maintenance commands.")
+@click.version_option(__version__, prog_name="ccgram-pro")
+def cli() -> None:
+    """Top-level Click group — Click dispatches to subcommands."""
+
+
+@cli.command(help="Validate layer configuration and dependencies.")
+def doctor() -> None:
+    rc = run_doctor()
+    raise SystemExit(rc)
+
+
+@cli.command(help="Interactive setup wizard for ccgram + ccgram-pro.")
+def setup() -> None:
+    rc = run_wizard()
+    raise SystemExit(rc)
+
+
+def main() -> None:
+    """Entry-point declared in ``pyproject.toml`` (``ccgram-pro`` script)."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/ccgram-pro/src/ccgram_pro/config.py
+++ b/ccgram-pro/src/ccgram_pro/config.py
@@ -1,0 +1,339 @@
+"""Configuration loader — projects.toml + settings.toml + path resolution.
+
+Layer config lives under ``<ccgram_dir>/layer/`` where ``ccgram_dir`` is
+ccgram's own config directory (default ``~/.ccgram``, overridable with
+``CCGRAM_DIR``). Reusing ccgram's directory keeps a single state root and
+ensures backups/migrations cover both.
+
+Subdirectories created on first run by :func:`ensure_layer_dirs`:
+
+- ``state/``     — per-window sidecar JSONs
+- ``snapshots/`` — per-iteration git diff snapshots
+- ``pr-loop/``   — `/pr-fix` log files
+
+Two TOML files (both optional):
+
+- ``projects.toml``  — predefined project list with per-project defaults
+- ``settings.toml``  — global layer defaults
+
+Missing files yield baked-in defaults so the layer is usable out of the
+box.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import structlog
+from ccgram.utils import ccgram_dir
+
+logger = structlog.get_logger()
+
+
+def _instance_namespace() -> str | None:
+    """Return a namespace string derived from ccgram's multi-instance env vars.
+
+    ccgram supports multiple bot instances against the same machine via
+    ``CCGRAM_GROUP_ID`` (one Telegram group per bot) and
+    ``CCGRAM_INSTANCE_NAME`` (display label). When either is set, the
+    layer scopes its state directory by that value so two bots running
+    concurrently do not stomp on each other's sidecars. ``CCGRAM_GROUP_ID``
+    takes precedence because it's the partition key ccgram itself uses.
+    """
+    group = os.environ.get("CCGRAM_GROUP_ID", "").strip()
+    if group:
+        return f"group-{group}"
+    instance = os.environ.get("CCGRAM_INSTANCE_NAME", "").strip()
+    if instance:
+        return f"instance-{instance}"
+    return None
+
+
+def layer_dir() -> Path:
+    """Layer root directory.
+
+    Default: ``<ccgram_dir>/layer``. When ``CCGRAM_GROUP_ID`` or
+    ``CCGRAM_INSTANCE_NAME`` is set, the path becomes
+    ``<ccgram_dir>/layer/<namespace>`` so multiple ccgram instances on the
+    same host keep their layer state separate.
+    """
+    base = ccgram_dir() / "layer"
+    namespace = _instance_namespace()
+    return base / namespace if namespace else base
+
+
+def state_dir() -> Path:
+    return layer_dir() / "state"
+
+
+def workspaces_dir() -> Path:
+    """Root for per-window project workspaces."""
+    return layer_dir() / "workspaces"
+
+
+def snapshot_dir() -> Path:
+    return layer_dir() / "snapshots"
+
+
+def pr_loop_log_dir() -> Path:
+    return layer_dir() / "pr-loop"
+
+
+def projects_toml_path() -> Path:
+    return layer_dir() / "projects.toml"
+
+
+def settings_toml_path() -> Path:
+    return layer_dir() / "settings.toml"
+
+
+def ensure_layer_dirs() -> None:
+    """Create all layer directories. Safe to call repeatedly."""
+    for d in (
+        layer_dir(),
+        state_dir(),
+        snapshot_dir(),
+        pr_loop_log_dir(),
+        workspaces_dir(),
+    ):
+        d.mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# projects.toml
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Project:
+    """One predefined project the user can pick from the /project keyboard.
+
+    ``default_model`` accepts Claude CLI aliases (``opus``, ``sonnet``,
+    ``haiku``) or full dated model ids; the value is forwarded to
+    ``claude --model <model>`` at window-launch time by Phase 1.
+    ``default_reasoning`` is a layer-level label (``extra-high``,
+    ``high``, ``medium``, ``low``) that Phase 1 maps to a concrete
+    ``--max-thinking-tokens`` value.
+    ``install_command``, when set, overrides the workspace's
+    auto-detected install command (``pnpm install``, ``uv sync``, …).
+    Set to the empty string to skip install entirely.
+    """
+
+    path: Path
+    label: str
+    default_model: str = "opus"
+    default_reasoning: str = "extra-high"
+    default_preamble: str | None = None
+    install_command: str | None = None
+
+
+def load_projects(path: Path | None = None) -> list[Project]:
+    """Load the predefined project list. Returns an empty list if missing."""
+    if path is None:
+        path = projects_toml_path()
+    if not path.exists():
+        return []
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        logger.warning("Failed to parse %s: %s", path, exc)
+        return []
+
+    items = raw.get("project", [])
+    if not isinstance(items, list):
+        logger.warning("projects.toml: expected [[project]] array, got %r", type(items))
+        return []
+
+    projects: list[Project] = []
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            project_path = Path(entry["path"]).expanduser()
+            label = str(entry["label"])
+        except (KeyError, TypeError) as exc:
+            logger.warning("projects.toml: skipping malformed entry: %s", exc)
+            continue
+        install_command_raw = entry.get("install_command")
+        install_command = (
+            str(install_command_raw) if isinstance(install_command_raw, str) else None
+        )
+        projects.append(
+            Project(
+                path=project_path,
+                label=label,
+                default_model=str(entry.get("default_model", "opus")),
+                default_reasoning=str(entry.get("default_reasoning", "extra-high")),
+                default_preamble=entry.get("default_preamble"),
+                install_command=install_command,
+            )
+        )
+    return projects
+
+
+# ---------------------------------------------------------------------------
+# settings.toml
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_PREAMBLE = (
+    "Remember to follow best practices and our current project rules. We need "
+    "a professional and production-ready implementation. No quick changes or "
+    "hacks — proper implementation only."
+)
+_DEFAULT_VOICE_NOTE = (
+    "Voice may have transcription errors — interpret the intent and infer "
+    "what the user meant."
+)
+
+
+@dataclass(frozen=True)
+class VoiceSettings:
+    transcription_note: str = _DEFAULT_VOICE_NOTE
+    flush_grace_seconds: int = 30
+
+
+@dataclass(frozen=True)
+class SnapshotSettings:
+    prune_after_days: int = 7
+
+
+@dataclass(frozen=True)
+class ShareTokenSettings:
+    default_ttl_seconds: int = 259200  # 3 days
+
+
+_WORKSPACE_STRATEGY_CLONE = "clone"
+_WORKSPACE_STRATEGY_COPY = "copy"
+_WORKSPACE_STRATEGIES = frozenset({_WORKSPACE_STRATEGY_CLONE, _WORKSPACE_STRATEGY_COPY})
+
+
+@dataclass(frozen=True)
+class WorkspaceSettings:
+    """Per-session project workspace settings.
+
+    ``strategy`` selects the provisioning strategy:
+
+    - ``"clone"`` (default) — ``git clone --local --no-hardlinks`` from the
+      source repo, then optionally apply uncommitted edits and untracked
+      files. Fast for git projects; falls back to ``"copy"`` for non-git
+      sources.
+    - ``"copy"`` — ``rsync`` with smart excludes
+      (``node_modules``, ``.venv``, ``dist`` …) or ``cp -r`` when ``rsync``
+      is unavailable. Always carries the full working state.
+
+    ``idle_days`` is the GC threshold: workspaces whose
+    ``last_activity_at`` is older than this many days are deleted on the
+    next sweep.
+
+    ``transfer_uncommitted`` controls whether the clone strategy applies
+    the source repo's uncommitted diff and untracked files to the new
+    workspace. Disable when sessions should always start from HEAD.
+
+    ``install_timeout_seconds`` caps how long a ``pnpm install`` /
+    ``uv sync`` / etc. run can take before being killed.
+
+    ``gc_interval_seconds`` is the PTB JobQueue tick for the idle sweep.
+    """
+
+    strategy: str = _WORKSPACE_STRATEGY_CLONE
+    idle_days: int = 5
+    transfer_uncommitted: bool = True
+    install_timeout_seconds: int = 600
+    gc_interval_seconds: int = 3600
+
+
+@dataclass(frozen=True)
+class Defaults:
+    silent_mode: bool = True
+    batch_mode: bool = True
+    plan_mode_on_new_session: bool = True
+    preamble: str = _DEFAULT_PREAMBLE
+
+
+@dataclass(frozen=True)
+class Settings:
+    defaults: Defaults = field(default_factory=Defaults)
+    voice: VoiceSettings = field(default_factory=VoiceSettings)
+    snapshots: SnapshotSettings = field(default_factory=SnapshotSettings)
+    share_tokens: ShareTokenSettings = field(default_factory=ShareTokenSettings)
+    workspaces: WorkspaceSettings = field(default_factory=WorkspaceSettings)
+
+
+def _coerce_bool(value: Any, fallback: bool) -> bool:  # noqa: ANN401 -- TOML scalar boundary
+    return bool(value) if isinstance(value, bool) else fallback
+
+
+def _coerce_int(value: Any, fallback: int) -> int:  # noqa: ANN401 -- TOML scalar boundary
+    # bool is a subclass of int in Python; isinstance(True, int) is True. A
+    # TOML author writing ``flush_grace_seconds = true`` should not silently
+    # get a 1 — that's almost always a typo, so we fall back to the default.
+    if isinstance(value, bool):
+        return fallback
+    return int(value) if isinstance(value, int) else fallback
+
+
+def _coerce_str(value: Any, fallback: str) -> str:  # noqa: ANN401 -- TOML scalar boundary
+    return str(value) if isinstance(value, str) else fallback
+
+
+def load_settings(path: Path | None = None) -> Settings:
+    """Load layer settings. Returns baked-in defaults if file missing or invalid."""
+    if path is None:
+        path = settings_toml_path()
+    if not path.exists():
+        return Settings()
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        logger.warning("Failed to parse %s: %s — using defaults", path, exc)
+        return Settings()
+
+    d = raw.get("defaults", {}) if isinstance(raw.get("defaults"), dict) else {}
+    v = raw.get("voice", {}) if isinstance(raw.get("voice"), dict) else {}
+    s = raw.get("snapshots", {}) if isinstance(raw.get("snapshots"), dict) else {}
+    t = raw.get("share_tokens", {}) if isinstance(raw.get("share_tokens"), dict) else {}
+    w = raw.get("workspaces", {}) if isinstance(raw.get("workspaces"), dict) else {}
+
+    defaults = Defaults(
+        silent_mode=_coerce_bool(d.get("silent_mode"), True),
+        batch_mode=_coerce_bool(d.get("batch_mode"), True),
+        plan_mode_on_new_session=_coerce_bool(d.get("plan_mode_on_new_session"), True),
+        preamble=_coerce_str(d.get("preamble"), _DEFAULT_PREAMBLE),
+    )
+    voice = VoiceSettings(
+        transcription_note=_coerce_str(
+            v.get("transcription_note"), _DEFAULT_VOICE_NOTE
+        ),
+        flush_grace_seconds=_coerce_int(v.get("flush_grace_seconds"), 30),
+    )
+    snapshots = SnapshotSettings(
+        prune_after_days=_coerce_int(s.get("prune_after_days"), 7),
+    )
+    share_tokens = ShareTokenSettings(
+        default_ttl_seconds=_coerce_int(t.get("default_ttl_seconds"), 259200),
+    )
+    strategy_raw = _coerce_str(w.get("strategy"), _WORKSPACE_STRATEGY_CLONE)
+    strategy = (
+        strategy_raw
+        if strategy_raw in _WORKSPACE_STRATEGIES
+        else _WORKSPACE_STRATEGY_CLONE
+    )
+    workspaces = WorkspaceSettings(
+        strategy=strategy,
+        idle_days=_coerce_int(w.get("idle_days"), 5),
+        transfer_uncommitted=_coerce_bool(w.get("transfer_uncommitted"), True),
+        install_timeout_seconds=_coerce_int(w.get("install_timeout_seconds"), 600),
+        gc_interval_seconds=_coerce_int(w.get("gc_interval_seconds"), 3600),
+    )
+    return Settings(
+        defaults=defaults,
+        voice=voice,
+        snapshots=snapshots,
+        share_tokens=share_tokens,
+        workspaces=workspaces,
+    )

--- a/ccgram-pro/src/ccgram_pro/doctor.py
+++ b/ccgram-pro/src/ccgram_pro/doctor.py
@@ -1,0 +1,247 @@
+"""``ccgram-pro doctor`` — validate the layer is installed and ready.
+
+Checks (each printed with a ``[OK]`` / ``[WARN]`` / ``[FAIL]`` tag):
+
+1. ``ccgram.extensions`` entry-point points at ``ccgram_pro.extension:install``.
+2. ``ccgram.miniapp_factory`` entry-point points at
+   ``ccgram_pro.miniapp_factory:make_factory``.
+3. ccgram exposes the dispatch sites (``bootstrap.dispatch_extensions`` and
+   ``main._resolve_miniapp_factory``). Missing means the host bot has not
+   picked up the hook PR yet.
+4. Layer directories under ``<ccgram_dir>/layer/`` are writable.
+5. ``projects.toml`` parses (warn if missing — defaults still work).
+6. ``settings.toml`` parses (warn if missing — defaults still work).
+7. ``gh`` CLI is on ``$PATH`` (needed by Phase 7's PR review loop).
+
+Returns 0 if every check is OK or WARN; 1 if any FAIL.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from importlib.metadata import entry_points
+from pathlib import Path
+from typing import Literal
+
+from . import __version__
+from .config import (
+    ensure_layer_dirs,
+    layer_dir,
+    load_projects,
+    load_settings,
+    projects_toml_path,
+    settings_toml_path,
+    state_dir,
+    workspaces_dir,
+)
+
+Status = Literal["OK", "WARN", "FAIL"]
+
+
+def _use_colors() -> bool:
+    """Match ccgram's NO_COLOR / FORCE_COLOR convention.
+
+    Presence-based per the NO_COLOR / FORCE_COLOR specs: set with any
+    value (including empty) counts. NO_COLOR wins over FORCE_COLOR.
+    """
+    if "NO_COLOR" in os.environ:
+        return False
+    if "FORCE_COLOR" in os.environ:
+        return True
+    return bool(sys.stdout.isatty())
+
+
+def _emit(status: Status, label: str, detail: str = "") -> None:
+    color = {"OK": "\x1b[32m", "WARN": "\x1b[33m", "FAIL": "\x1b[31m"}[status]
+    reset = "\x1b[0m"
+    tag = f"{color}[{status:<4}]{reset}" if _use_colors() else f"[{status:<4}]"
+    line = f"{tag} {label}"
+    if detail:
+        line += f" — {detail}"
+    print(line)
+
+
+def _check_entry_points() -> Status:
+    overall: Status = "OK"
+    expected = {
+        "ccgram.extensions": "ccgram_pro.extension:install",
+        "ccgram.miniapp_factory": "ccgram_pro.miniapp_factory:make_factory",
+    }
+    for group, expected_target in expected.items():
+        eps = list(entry_points(group=group))
+        ours = [ep for ep in eps if ep.value == expected_target]
+        if not ours:
+            _emit(
+                "FAIL",
+                f"Entry point {group} → {expected_target}",
+                "missing — is ccgram-pro installed?",
+            )
+            overall = "FAIL"
+            continue
+        # WARN only when MULTIPLE ours are present (duplicate install of
+        # ccgram-pro itself). Other plugins coexisting in the same group is
+        # by design — Phase 5+ may add additional ccgram extensions that
+        # register here, and the doctor should not nag the operator about it.
+        if len(ours) > 1:
+            _emit(
+                "WARN",
+                f"Entry point {group}",
+                f"ccgram-pro registered {len(ours)}× — duplicate install",
+            )
+            if overall == "OK":
+                overall = "WARN"
+            continue
+        _emit("OK", f"Entry point {group}", expected_target)
+    return overall
+
+
+def _check_dispatch_sites() -> Status:
+    """Confirm ccgram's host has the hook dispatch sites we depend on."""
+    try:
+        # Lazy: ccgram is the host package; importing inside the check lets
+        # us report a usable error if ccgram is uninstalled or partially
+        # installed, instead of failing at module load.
+        from ccgram import bootstrap as _bootstrap, main as _main
+    except ImportError as exc:
+        _emit("FAIL", "Import ccgram", str(exc))
+        return "FAIL"
+
+    overall: Status = "OK"
+    if not hasattr(_bootstrap, "dispatch_extensions"):
+        _emit(
+            "FAIL",
+            "ccgram.bootstrap.dispatch_extensions",
+            "missing — host ccgram lacks the entry-point hook",
+        )
+        overall = "FAIL"
+    else:
+        _emit("OK", "ccgram.bootstrap.dispatch_extensions", "present")
+
+    if not hasattr(_main, "_resolve_miniapp_factory"):
+        _emit(
+            "FAIL",
+            "ccgram.main._resolve_miniapp_factory",
+            "missing — host ccgram lacks the miniapp-factory hook",
+        )
+        overall = "FAIL"
+    else:
+        _emit("OK", "ccgram.main._resolve_miniapp_factory", "present")
+    return overall
+
+
+def _check_layer_dirs() -> Status:
+    remedy = "set CCGRAM_DIR to a writable path or fix permissions"
+    try:
+        ensure_layer_dirs()
+    except OSError as exc:
+        _emit("FAIL", "Layer dirs", f"{layer_dir()}: {exc} — {remedy}")
+        return "FAIL"
+
+    probe = state_dir() / ".doctor-probe"
+    try:
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+    except OSError as exc:
+        _emit("FAIL", f"Writable {state_dir()}", f"{exc} — {remedy}")
+        return "FAIL"
+    _emit("OK", f"Layer dirs under {layer_dir()}", "writable")
+    return "OK"
+
+
+def _check_workspaces() -> Status:
+    root = workspaces_dir()
+    if not root.is_dir():
+        # ensure_layer_dirs() was called by _check_layer_dirs; missing now
+        # would be a real filesystem fault.
+        _emit("FAIL", f"Workspaces dir {root}", "missing after ensure_layer_dirs()")
+        return "FAIL"
+    count = sum(
+        1 for entry in root.iterdir() if entry.is_dir() and ".stage-" not in entry.name
+    )
+    detail = (
+        f"{count} workspace(s) currently provisioned" if count else "no workspaces yet"
+    )
+    _emit("OK", f"Workspaces dir {root}", detail)
+    return "OK"
+
+
+def _check_git() -> Status:
+    """The default workspace strategy needs ``git`` on $PATH."""
+    if shutil.which("git") is None:
+        _emit(
+            "WARN",
+            "git CLI",
+            "absent — workspace strategy will fall back to filesystem copy",
+        )
+        return "WARN"
+    _emit("OK", "git CLI", "present")
+    return "OK"
+
+
+def _check_projects(path: Path) -> Status:
+    if not path.exists():
+        _emit(
+            "WARN", f"projects.toml ({path})", "missing — /project picker will be empty"
+        )
+        return "WARN"
+    projects = load_projects(path)
+    if not projects:
+        _emit("WARN", "projects.toml", "no [[project]] entries parsed")
+        return "WARN"
+    _emit("OK", "projects.toml", f"{len(projects)} project(s)")
+    return "OK"
+
+
+def _check_settings(path: Path) -> Status:
+    if not path.exists():
+        _emit("WARN", f"settings.toml ({path})", "missing — using baked-in defaults")
+        return "WARN"
+    # Loading is permissive; just confirm it doesn't fall back to defaults
+    # unexpectedly.
+    load_settings(path)
+    _emit("OK", "settings.toml", "parsed")
+    return "OK"
+
+
+def _check_gh_cli() -> Status:
+    """Phase 7 dependency. Not required for Phase 0, so report OK either way.
+
+    Once ``/pr-fix`` ships we promote a missing ``gh`` to WARN — for now it
+    is an informational note so operators not on the PR-loop flow don't see
+    a permanent yellow flag.
+    """
+    if shutil.which("gh") is None:
+        _emit("OK", "gh CLI", "absent — only required for Phase 7's /pr-fix")
+        return "OK"
+    _emit("OK", "gh CLI", "present")
+    return "OK"
+
+
+def _worst(*statuses: Status) -> Status:
+    if "FAIL" in statuses:
+        return "FAIL"
+    if "WARN" in statuses:
+        return "WARN"
+    return "OK"
+
+
+def run_doctor() -> int:
+    """Run every check, print results, return shell exit code."""
+    print(f"ccgram-pro {__version__} doctor")
+    print()
+    statuses: list[Status] = [
+        _check_entry_points(),
+        _check_dispatch_sites(),
+        _check_layer_dirs(),
+        _check_workspaces(),
+        _check_git(),
+        _check_projects(projects_toml_path()),
+        _check_settings(settings_toml_path()),
+        _check_gh_cli(),
+    ]
+    print()
+    overall = _worst(*statuses)
+    print(f"Overall: {overall}")
+    return 1 if overall == "FAIL" else 0

--- a/ccgram-pro/src/ccgram_pro/extension.py
+++ b/ccgram-pro/src/ccgram_pro/extension.py
@@ -1,0 +1,52 @@
+"""ccgram.extensions entry-point target — wires the layer into the bot.
+
+Called by :func:`ccgram.bootstrap.dispatch_extensions` after the PTB
+application is bootstrapped. Phase 0 is intentionally a no-op that only
+logs activation and ensures the layer's state directories exist; subsequent
+phases register handlers, intercept inbound and outbound messages, and
+attach periodic tasks.
+
+Contract for extension authors:
+
+- ``install`` is called **once** per process, synchronously, with the live
+  PTB ``Application``. Returning a coroutine is a bug — it will be
+  discarded by :func:`ccgram.bootstrap.dispatch_extensions`.
+- Registrations should be idempotent at the import level: ccgram's
+  ``reset_for_testing`` may trigger a second dispatch, so prefer
+  ``application.add_handler`` (additive) over module-level callback
+  registration that raises on double-register.
+- Faults are caught at the dispatch site; an install failure is logged but
+  does not abort bot startup. Failing loudly inside ``install`` is fine
+  — the bot keeps running with the layer disabled.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+from . import __version__
+from .config import ensure_layer_dirs
+from .workspaces.runtime import schedule_gc
+
+if TYPE_CHECKING:
+    from telegram.ext import Application
+
+logger = structlog.get_logger()
+
+
+def install(application: Application) -> None:
+    """Install ccgram-pro into the running PTB application.
+
+    Phase 0/0.5 setup:
+
+    - Ensure layer directories exist (``state``, ``snapshots``,
+      ``pr-loop``, ``workspaces``).
+    - Schedule the periodic workspace GC sweep on the PTB JobQueue.
+
+    Phase 1+ will add handler registrations and message intercepts here.
+    """
+    ensure_layer_dirs()
+    schedule_gc(application)
+    logger.info("ccgram-pro %s installed", __version__)

--- a/ccgram-pro/src/ccgram_pro/miniapp_factory.py
+++ b/ccgram-pro/src/ccgram_pro/miniapp_factory.py
@@ -1,0 +1,61 @@
+"""ccgram.miniapp_factory entry-point target — wraps build_app.
+
+Called once at startup by :func:`ccgram.main._resolve_miniapp_factory` with
+ccgram's default ``build_app`` callable. Returns a new factory; when invoked
+by ``start_server`` the wrapper builds the base app then registers
+layer-owned routes (diff viewer, long-summary viewer, share links — added
+in Phase 5+).
+
+Phase 0 leaves the wrapper a thin pass-through so the call signature is
+exercised end-to-end. Adding routes in later phases is a non-breaking
+change to this file.
+
+Wrapper limitations:
+
+- New aiohttp routes may be **added** to the returned ``Application`` via
+  ``app.router.add_*``. Mutating or replacing upstream's existing routes
+  is not supported (aiohttp's ``UrlDispatcher`` exposes no clean override
+  API); cross-cutting needs go through ``app.middlewares.append(...)``
+  instead.
+- ``start_server`` currently only forwards ``bot_token`` to ``build_app``
+  (see ``ccgram.miniapp.server.start_server``). The other ``build_app``
+  parameters (``terminal_capture``, ``pane_capture`` etc.) are
+  test-injection points; a production wrapper cannot reach them through
+  the entry-point seam.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+from . import __version__
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from aiohttp import web
+
+logger = structlog.get_logger()
+
+
+def make_factory(
+    default_build_app: Callable[..., web.Application],
+) -> Callable[..., web.Application]:
+    """Return a wrapping factory that delegates to *default_build_app*.
+
+    The returned factory accepts the same keyword arguments as upstream
+    ``build_app`` and forwards them verbatim. A renamed kwarg on the
+    upstream side will surface as a ``TypeError`` from
+    ``default_build_app(**kwargs)`` at startup — caught and logged by
+    :func:`ccgram.main._resolve_miniapp_factory`, so the bot still starts
+    with the un-wrapped factory.
+    """
+
+    def factory(**kwargs: object) -> web.Application:
+        app = default_build_app(**kwargs)
+        logger.debug("ccgram-pro %s miniapp factory built app", __version__)
+        return app
+
+    return factory

--- a/ccgram-pro/src/ccgram_pro/state.py
+++ b/ccgram-pro/src/ccgram_pro/state.py
@@ -1,0 +1,404 @@
+"""Per-window sidecar state — JSON files keyed by tmux window id.
+
+Each live window owns one ``<window_id>.json`` file under
+``<layer_dir>/state/``. Storing layer state in sidecar files rather than
+extending ccgram's ``WindowState`` lets us track upstream cleanly and keeps
+the layer's growing feature set off the ccgram window-state audit.
+
+Stale-file detection: every sidecar carries a ``window_creation_epoch`` —
+the tmux ``window_activity`` (or fallback ``time.time()`` at create) of the
+window when the sidecar was first written. If the live window's creation
+epoch differs (e.g. a tmux restart recycled the id), the sidecar is treated
+as stale and ignored. GC runs lazily at extension startup; window teardown
+also unlinks the file via the ccgram ``topic_state_registry`` hook (wired
+from :mod:`ccgram_pro.extension`).
+
+Atomic writes: a temp file beside the target is written then ``os.replace``-d
+so partial JSON never appears on disk. Concurrent callers should wrap their
+load-modify-save sequence in :func:`transaction` (async context manager
+backed by a per-window ``asyncio.Lock``) to avoid lost-update races.
+
+Filename safety: window ids are routed through
+``ccgram.mailbox.sanitize_dir_name`` (rejects ``..``, ``/``, ``\\``;
+converts ``:`` → ``=``) so a hostile id cannot escape the state directory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import tempfile
+import time
+from contextlib import asynccontextmanager
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import structlog
+from ccgram.mailbox import sanitize_dir_name
+
+from .config import state_dir
+
+logger = structlog.get_logger()
+
+# Module-level lock registry for the transaction() context manager. Locks are
+# created lazily per window_id and never garbage-collected during the bot's
+# lifetime — the population is bounded by the number of live windows, and the
+# Lock objects themselves are tiny. The dict mutation in _lock_for is
+# single-threaded because asyncio runs on one event loop thread.
+_window_locks: dict[str, asyncio.Lock] = {}
+
+
+@dataclass
+class BatchItem:
+    """One queued message in the user's accumulated batch."""
+
+    kind: str  # "text" | "voice"
+    body: str
+    transcribing: bool = False
+    received_at: float = field(default_factory=time.time)
+
+
+@dataclass
+class WindowSidecar:
+    """All layer state for a single tmux window.
+
+    Defaults are chosen so a brand-new sidecar is equivalent to "no
+    customization". Persisted JSON is intentionally permissive on read —
+    unknown keys are ignored, missing keys fall back to defaults — so
+    forward-compatible schema additions don't require migrations.
+    """
+
+    window_id: str
+    window_creation_epoch: float
+    project_path: str | None = None
+    model: str = "opus"
+    reasoning: str = "extra-high"
+    batch_mode: bool = True
+    silent_mode: bool = True
+    current_batch: list[BatchItem] = field(default_factory=list)
+    preamble_sent: bool = False
+    plan_mode: str = "pending"  # "pending" | "entered" | "approved" | "skipped"
+    current_progress_bubble: dict[str, int] | None = (
+        None  # {"thread_id": .., "message_id": ..}
+    )
+    session_anchor_sha: str | None = None
+    last_snapshot_id: str | None = None
+    # Workspace bookkeeping — populated by ``ccgram_pro.workspaces.manager`` when
+    # a per-session clone is created. ``workspace_path`` is the absolute path of
+    # the cloned/copy workspace on disk; ``last_activity_at`` is the wall-clock
+    # epoch of the most recent activity inside it (file touch, message sent),
+    # consulted by the idle GC sweep. Both stay ``None`` when no workspace is
+    # provisioned for the window.
+    workspace_path: str | None = None
+    last_activity_at: float | None = None
+
+
+def _sidecar_path(window_id: str) -> Path:
+    """Resolve the on-disk path for ``window_id``.
+
+    Routes through :func:`ccgram.mailbox.sanitize_dir_name` which raises
+    ``ValueError`` on anything containing ``..``, ``/``, or ``\\`` — so a
+    hostile window id cannot escape ``state_dir()``.
+    """
+    return state_dir() / f"{sanitize_dir_name(window_id)}.json"
+
+
+def _atomic_write(path: Path, payload: str) -> None:
+    """Write *payload* to *path* atomically; clean up temp on failure."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=path.name + ".",
+            suffix=".tmp",
+            delete=False,
+        ) as fh:
+            tmp_name = fh.name
+            fh.write(payload)
+        os.replace(tmp_name, path)
+        tmp_name = None
+    finally:
+        # If we never reached os.replace (write raised or rename failed), the
+        # tempfile is still on disk — clean it up so leaks don't accumulate.
+        if tmp_name is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+
+
+def _serialize(sidecar: WindowSidecar) -> str:
+    return json.dumps(asdict(sidecar), indent=2, sort_keys=True)
+
+
+def _quarantine(path: Path, reason: str) -> None:
+    """Rename a corrupt sidecar to ``.corrupt-<ts>`` so it doesn't get re-tried.
+
+    The original file is kept for debugging; the active path is freed so
+    callers see "no sidecar" rather than crashing on every load.
+    """
+    suffix = f".corrupt-{int(time.time())}"
+    try:
+        path.rename(path.with_name(path.name + suffix))
+        logger.warning("Quarantined sidecar %s: %s", path, reason)
+    except OSError as exc:
+        logger.warning("Failed to quarantine %s: %s", path, exc)
+
+
+def _deserialize(raw: str, window_id: str, path: Path) -> WindowSidecar | None:
+    """Reconstruct a sidecar from JSON. Returns ``None`` on malformed input.
+
+    On corruption the file is moved aside via :func:`_quarantine` so the next
+    call returns ``None`` cleanly instead of hitting the same parse error.
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _quarantine(path, f"JSON decode: {exc}")
+        return None
+    if not isinstance(data, dict):
+        _quarantine(path, f"top-level type {type(data).__name__}, expected dict")
+        return None
+
+    batch_raw = data.get("current_batch", [])
+    items: list[BatchItem] = []
+    if isinstance(batch_raw, list):
+        for it in batch_raw:
+            if not isinstance(it, dict):
+                continue
+            try:
+                items.append(
+                    BatchItem(
+                        kind=str(it.get("kind", "text")),
+                        body=str(it.get("body", "")),
+                        transcribing=bool(it.get("transcribing", False)),
+                        received_at=float(it.get("received_at", time.time())),
+                    )
+                )
+            except TypeError, ValueError:
+                continue
+
+    bubble_raw = data.get("current_progress_bubble")
+    bubble: dict[str, int] | None = None
+    if isinstance(bubble_raw, dict):
+        try:
+            bubble = {
+                "thread_id": int(bubble_raw["thread_id"]),
+                "message_id": int(bubble_raw["message_id"]),
+            }
+        except KeyError, TypeError, ValueError:
+            bubble = None
+
+    try:
+        last_activity_raw = data.get("last_activity_at")
+        last_activity_at = (
+            float(last_activity_raw) if last_activity_raw is not None else None
+        )
+        return WindowSidecar(
+            window_id=str(data.get("window_id", window_id)),
+            window_creation_epoch=float(data.get("window_creation_epoch", 0.0)),
+            project_path=data.get("project_path") or None,
+            model=str(data.get("model", "opus")),
+            reasoning=str(data.get("reasoning", "extra-high")),
+            batch_mode=bool(data.get("batch_mode", True)),
+            silent_mode=bool(data.get("silent_mode", True)),
+            current_batch=items,
+            preamble_sent=bool(data.get("preamble_sent", False)),
+            plan_mode=str(data.get("plan_mode", "pending")),
+            current_progress_bubble=bubble,
+            session_anchor_sha=data.get("session_anchor_sha") or None,
+            last_snapshot_id=data.get("last_snapshot_id") or None,
+            workspace_path=data.get("workspace_path") or None,
+            last_activity_at=last_activity_at,
+        )
+    except (TypeError, ValueError) as exc:
+        _quarantine(path, f"reconstruct failed: {exc}")
+        return None
+
+
+def load(
+    window_id: str, *, live_window_creation_epoch: float | None = None
+) -> WindowSidecar | None:
+    """Return the sidecar for ``window_id`` if it exists and is not stale.
+
+    If ``live_window_creation_epoch`` is provided and differs from the stored
+    epoch, the sidecar is unlinked and ``None`` is returned. This guards
+    against tmux window-id recycling — if the same ``@N`` now points at a
+    different window, prior layer state is dropped. The comparison is exact;
+    callers should pass a stable epoch (e.g. tmux ``window_activity`` or the
+    ``time.time()`` snapshot taken at ``get_or_create`` time).
+    """
+    path = _sidecar_path(window_id)
+    if not path.exists():
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Failed to read sidecar %s: %s", path, exc)
+        return None
+    sidecar = _deserialize(raw, window_id, path)
+    if sidecar is None:
+        return None
+    if (
+        live_window_creation_epoch is not None
+        and sidecar.window_creation_epoch
+        and sidecar.window_creation_epoch != live_window_creation_epoch
+    ):
+        # Transient race — tmux recycled a window id. Discard the stale
+        # sidecar so the caller (get_or_create) writes a fresh one. DEBUG,
+        # not INFO: window recycling is a normal event in long-running
+        # sessions and would otherwise spam steady-state logs.
+        logger.debug(
+            "Sidecar epoch mismatch for %s (stored=%s live=%s); discarding",
+            window_id,
+            sidecar.window_creation_epoch,
+            live_window_creation_epoch,
+        )
+        delete(window_id)
+        return None
+    return sidecar
+
+
+def save(sidecar: WindowSidecar) -> None:
+    """Atomically persist ``sidecar`` to disk."""
+    path = _sidecar_path(sidecar.window_id)
+    _atomic_write(path, _serialize(sidecar))
+
+
+def delete(window_id: str) -> None:
+    """Remove the sidecar for ``window_id`` if present."""
+    path = _sidecar_path(window_id)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.warning("Failed to delete sidecar %s: %s", path, exc)
+
+
+def get_or_create(
+    window_id: str, *, live_window_creation_epoch: float | None = None
+) -> WindowSidecar:
+    """Load the sidecar or create a fresh one with epoch fingerprint.
+
+    Not concurrency-safe on its own — callers that may execute concurrently
+    against the same ``window_id`` should wrap the call in
+    :func:`transaction`. Single-caller use (boot-time setup, doctor) is
+    fine.
+    """
+    existing = load(window_id, live_window_creation_epoch=live_window_creation_epoch)
+    if existing is not None:
+        return existing
+    sidecar = WindowSidecar(
+        window_id=window_id,
+        window_creation_epoch=(
+            live_window_creation_epoch
+            if live_window_creation_epoch is not None
+            else time.time()
+        ),
+    )
+    save(sidecar)
+    return sidecar
+
+
+def all_sidecars() -> list[WindowSidecar]:
+    """Return every readable sidecar on disk. Corrupt files are quarantined."""
+    results: list[WindowSidecar] = []
+    d = state_dir()
+    if not d.exists():
+        return results
+    for path in d.iterdir():
+        if path.suffix != ".json" or not path.is_file():
+            continue
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Skipping unreadable sidecar %s: %s", path, exc)
+            continue
+        sidecar = _deserialize(raw, path.stem, path)
+        if sidecar is not None:
+            results.append(sidecar)
+    return results
+
+
+def gc_stale(live_window_ids: set[str], *, force: bool = False) -> int:
+    """Delete sidecars for windows not in *live_window_ids*. Returns count removed.
+
+    Refuses to run when *live_window_ids* is empty unless ``force=True`` is
+    set — an empty set is almost always the result of a failed ``tmux
+    list-windows`` query, and wiping every sidecar in response would lose
+    real state. Callers that intentionally want to clear all state (test
+    teardown) must opt in explicitly.
+    """
+    if not live_window_ids and not force:
+        logger.debug(
+            "gc_stale: refusing to GC against empty live set without force=True"
+        )
+        return 0
+    removed = 0
+    for sidecar in all_sidecars():
+        if sidecar.window_id not in live_window_ids:
+            delete(sidecar.window_id)
+            removed += 1
+    if removed:
+        logger.info("GC'd %d stale layer sidecars", removed)
+    return removed
+
+
+def update(window_id: str, **changes: Any) -> WindowSidecar | None:  # noqa: ANN401 -- dataclass field setter passthrough
+    """Mutate a sidecar in place and persist. Returns ``None`` if absent.
+
+    Raises ``AttributeError`` if any *changes* key is not a sidecar field —
+    writes are always local code (not user input), so a typo is a bug, not
+    a migration. The race window between load and save is small but real;
+    concurrent callers should wrap in :func:`transaction`.
+    """
+    sidecar = load(window_id)
+    if sidecar is None:
+        return None
+    for key, value in changes.items():
+        if not hasattr(sidecar, key):
+            raise AttributeError(
+                f"WindowSidecar has no field {key!r} (passed to update)"
+            )
+        setattr(sidecar, key, value)
+    save(sidecar)
+    return sidecar
+
+
+def _lock_for(window_id: str) -> asyncio.Lock:
+    """Return the lock for *window_id*, creating one on first use."""
+    lock = _window_locks.get(window_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _window_locks[window_id] = lock
+    return lock
+
+
+@asynccontextmanager
+async def transaction(window_id: str):
+    """Serialize concurrent access to the sidecar for *window_id*.
+
+    Usage::
+
+        async with state.transaction(window_id):
+            sidecar = state.get_or_create(window_id)
+            sidecar.preamble_sent = True
+            state.save(sidecar)
+
+    The lock is held for the entire ``with`` block, so callers must keep
+    work inside it short. The locks live for the bot's lifetime; their
+    memory cost is negligible (one ``asyncio.Lock`` per live window).
+    """
+    lock = _lock_for(window_id)
+    async with lock:
+        yield
+
+
+def _reset_locks_for_testing() -> None:
+    """Drop the lock registry. Tests that mutate event loops need this."""
+    _window_locks.clear()

--- a/ccgram-pro/src/ccgram_pro/wizard/__init__.py
+++ b/ccgram-pro/src/ccgram_pro/wizard/__init__.py
@@ -1,0 +1,22 @@
+"""Interactive setup wizard for ccgram + ccgram-pro.
+
+Public surface is :func:`run_wizard` — invoked by the ``ccgram-pro setup``
+CLI subcommand. The wizard walks the operator through every configuration
+needed to take the bot from a fresh checkout to a working install:
+
+- Telegram bot token + allowed users
+- Claude Code availability
+- Predefined project list
+- Optional LLM (shell mode + completion summaries)
+- Optional voice transcription
+- Optional Mini App
+- Claude Code hook installation
+- Doctor validation
+
+Steps write to ``~/.ccgram/.env`` and ``~/.ccgram/layer/*.toml``
+incrementally so a Ctrl-C mid-wizard preserves the work done so far.
+"""
+
+from .run import run_wizard
+
+__all__ = ["run_wizard"]

--- a/ccgram-pro/src/ccgram_pro/wizard/env.py
+++ b/ccgram-pro/src/ccgram_pro/wizard/env.py
@@ -1,0 +1,144 @@
+"""``.env`` reader/writer that preserves unknown keys and comments.
+
+ccgram's runtime loads ``~/.ccgram/.env`` plus a local ``./.env`` via
+``python-dotenv``, so the wizard's job is to update the keys it knows about
+while leaving every other line (comments, blank lines, third-party keys)
+untouched. The implementation is intentionally minimal — we own line
+ordering for keys we set, append new keys to the end, and keep everything
+else byte-identical.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+import shlex
+import tempfile
+from pathlib import Path
+
+# Matches ``KEY=VALUE`` with whitespace tolerance. Values can be quoted or
+# bare; the wizard only writes bare/double-quoted values, but parses any
+# variant.
+_KEY_RE = re.compile(r"^\s*(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<value>.*?)\s*$")
+
+
+_MIN_QUOTED_LEN = 2  # a paired quote on each end
+
+
+def _strip_quotes(value: str) -> str:
+    if (
+        len(value) >= _MIN_QUOTED_LEN
+        and value[0] == value[-1]
+        and value[0] in ('"', "'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def read_env(path: Path) -> dict[str, str]:
+    """Return ``{KEY: VALUE}`` for every assignment in *path*.
+
+    Comments, blank lines, and malformed lines are ignored. Values lose
+    their surrounding quotes (matching python-dotenv's runtime behaviour).
+    Missing file returns an empty dict.
+    """
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        m = _KEY_RE.match(raw)
+        if not m:
+            continue
+        out[m.group("key")] = _strip_quotes(m.group("value"))
+    return out
+
+
+def _format_value(value: str) -> str:
+    """Render *value* for the .env file.
+
+    Bare assignment when the value is shell-safe (alphanumeric, dash,
+    underscore, slash, dot, colon, comma); double-quoted otherwise, with
+    embedded double-quotes and backslashes escaped. Matches python-dotenv's
+    parse rules so the runtime sees the same string we wrote.
+    """
+    if value == "":
+        return ""
+    if re.fullmatch(r"[A-Za-z0-9_./:,@-]+", value):
+        return value
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def update_env(path: Path, updates: dict[str, str]) -> None:
+    """Merge *updates* into *path*, preserving unknown keys + comments.
+
+    Existing assignments for the keys in *updates* are rewritten in place
+    (preserving the surrounding lines); keys not yet present are appended
+    to the end under a single ``# ccgram-pro setup`` block.
+
+    Empty-string values are written as ``KEY=`` (no quotes) — this matches
+    the convention python-dotenv uses for "set but blank".
+    """
+    if not updates:
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing_lines: list[str] = []
+    if path.exists():
+        existing_lines = path.read_text(encoding="utf-8").splitlines()
+
+    remaining = dict(updates)
+    new_lines: list[str] = []
+    for raw in existing_lines:
+        m = _KEY_RE.match(raw)
+        if m and m.group("key") in remaining:
+            key = m.group("key")
+            new_lines.append(f"{key}={_format_value(remaining.pop(key))}")
+        else:
+            new_lines.append(raw)
+
+    if remaining:
+        # Trailing-newline normalisation: ensure exactly one blank line
+        # separator before our appended block, regardless of how the file
+        # ended before.
+        if new_lines and new_lines[-1].strip():
+            new_lines.append("")
+        new_lines.append("# Added by ccgram-pro setup")
+        for key, value in remaining.items():
+            new_lines.append(f"{key}={_format_value(value)}")
+
+    payload = "\n".join(new_lines)
+    if not payload.endswith("\n"):
+        payload += "\n"
+
+    # Atomic write so a Ctrl-C during the wizard does not corrupt the .env.
+    tmp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=path.name + ".",
+            suffix=".tmp",
+            delete=False,
+        ) as fh:
+            tmp_name = fh.name
+            fh.write(payload)
+        os.replace(tmp_name, path)
+        tmp_name = None
+    finally:
+        # If we never reached os.replace, the staged temp file is still on
+        # disk — best-effort unlink. Swallow OSError so a flaky filesystem
+        # cleanup does not mask the real exception that triggered finally.
+        if tmp_name is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+
+
+def quote_for_shell(value: str) -> str:
+    """Convenience wrapper around ``shlex.quote`` used by wizard output."""
+    return shlex.quote(value)

--- a/ccgram-pro/src/ccgram_pro/wizard/prompts.py
+++ b/ccgram-pro/src/ccgram_pro/wizard/prompts.py
@@ -1,0 +1,64 @@
+"""Validators + thin Click wrappers for the wizard prompts.
+
+Keeping validation in a dedicated module lets the tests exercise the
+regex / parsing logic without booting a Click runtime.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+
+_BOT_TOKEN_RE = re.compile(r"^\d{6,}:[A-Za-z0-9_-]{30,}$")
+
+
+def is_valid_bot_token(value: str) -> bool:
+    """Telegram bot tokens look like ``<numeric_id>:<35+ alphanumeric chars>``.
+
+    @BotFather's real tokens are typically ``\\d{10}:[A-Za-z0-9_-]{35}`` but
+    documenting the exact length is risky — we accept any token Telegram
+    might mint while still rejecting obvious typos (missing colon, empty
+    halves).
+    """
+    return bool(_BOT_TOKEN_RE.match(value.strip()))
+
+
+def parse_user_ids(value: str) -> list[int]:
+    """Parse ``"123, 456"`` into ``[123, 456]``. Raises ValueError on any garbage."""
+    parts = [p.strip() for p in value.replace(";", ",").split(",") if p.strip()]
+    if not parts:
+        msg = "at least one Telegram user id is required"
+        raise ValueError(msg)
+    result: list[int] = []
+    for p in parts:
+        try:
+            result.append(int(p))
+        except ValueError as exc:
+            raise ValueError(f"{p!r} is not an integer user id") from exc
+    return result
+
+
+def is_valid_https_url(value: str) -> bool:
+    """Mini App base URL must be ``https://…`` with a host part.
+
+    HTTP is rejected — Telegram WebApps refuse to load non-HTTPS pages, so
+    accepting it would only produce a broken setup the user discovers later.
+    """
+    try:
+        parsed = urlparse(value.strip())
+    except ValueError:
+        return False
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
+LLM_PROVIDERS: tuple[str, ...] = (
+    "openai",
+    "xai",
+    "deepseek",
+    "anthropic",
+    "groq",
+    "ollama",
+)
+
+WHISPER_PROVIDERS: tuple[str, ...] = ("openai", "groq")

--- a/ccgram-pro/src/ccgram_pro/wizard/run.py
+++ b/ccgram-pro/src/ccgram_pro/wizard/run.py
@@ -1,0 +1,87 @@
+"""Wizard orchestration — drives the step modules in order.
+
+Banner + summary live here so the steps stay focused on a single concern.
+The whole flow takes the operator through about a dozen prompts; every
+step writes its result immediately so a ``Ctrl-C`` mid-wizard preserves
+what's been answered so far.
+"""
+
+from __future__ import annotations
+
+import click
+
+from .. import __version__
+from . import steps
+
+
+_STEP_FUNCTIONS = (
+    steps.step_bot_token,
+    steps.step_allowed_users,
+    steps.step_claude_check,
+    steps.step_projects,
+    steps.step_llm,
+    steps.step_whisper,
+    steps.step_miniapp,
+    steps.step_hooks,
+    steps.step_doctors,
+)
+
+
+def _print_banner() -> None:
+    click.secho(f"ccgram-pro {__version__} setup wizard", fg="cyan", bold=True)
+    click.echo("Walks you through every config needed to run ccgram + ccgram-pro.")
+    click.echo(
+        "Answers are written incrementally to ~/.ccgram/.env and "
+        "~/.ccgram/layer/projects.toml — Ctrl-C is safe."
+    )
+
+
+def _print_summary(state: steps.WizardState) -> None:
+    click.echo()
+    click.secho("━━ Summary ━━", fg="cyan", bold=True)
+    rows = [
+        ("Bot token", state.bot_token_set),
+        ("Allowed users", state.allowed_users_set),
+        ("Claude CLI detected", state.claude_present),
+        ("Projects configured", bool(state.projects)),
+        ("LLM provider", state.llm_configured),
+        ("Voice transcription", state.whisper_configured),
+        ("Mini App dashboard", state.miniapp_configured),
+        ("Hooks installed", state.hooks_installed),
+    ]
+    for label, ok in rows:
+        marker = (
+            click.style("✓", fg="green") if ok else click.style("·", fg="bright_black")
+        )
+        click.echo(f"  {marker} {label}")
+
+    click.echo()
+    click.echo("Next steps:")
+    click.echo(
+        "  - Create a Telegram supergroup, enable Topics, and add the bot as admin."
+    )
+    click.echo(
+        "  - Start the bot with `ccgram` (or your supervisor script);"
+        " open a topic to begin."
+    )
+    if not state.hooks_installed and state.claude_present:
+        click.echo("  - Run `ccgram hook --install` once you're ready (recommended).")
+    if state.miniapp_configured:
+        click.echo(
+            "  - Point your reverse proxy at 127.0.0.1:8765 (or whatever you "
+            "set CCGRAM_MINIAPP_PORT to)."
+        )
+
+
+def run_wizard() -> int:
+    """Run the wizard end to end. Returns a shell-style exit code."""
+    _print_banner()
+    state = steps.initial_state()
+    try:
+        for step in _STEP_FUNCTIONS:
+            step(state)
+    except click.Abort:
+        click.secho("\nWizard cancelled. Partial progress was saved.", fg="yellow")
+        return 130
+    _print_summary(state)
+    return 0

--- a/ccgram-pro/src/ccgram_pro/wizard/steps.py
+++ b/ccgram-pro/src/ccgram_pro/wizard/steps.py
@@ -1,0 +1,373 @@
+"""Wizard steps — each one is a small function the run loop drives.
+
+Steps share these conventions:
+
+- Take ``state: WizardState`` so they can read previous answers and side-
+  effect the .env / TOML files.
+- Use ``click.echo`` for headings and explanations; ``click.prompt`` /
+  ``click.confirm`` for input.
+- Return ``True`` when something was written, ``False`` when the user
+  skipped. The orchestrator uses this for the final summary.
+
+Each step writes immediately so a Ctrl-C mid-wizard preserves prior work.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import click
+from ccgram.utils import ccgram_dir
+
+from ..config import (
+    Project,
+    layer_dir,
+    load_projects,
+    projects_toml_path,
+)
+from .env import update_env
+from .prompts import (
+    LLM_PROVIDERS,
+    WHISPER_PROVIDERS,
+    is_valid_bot_token,
+    is_valid_https_url,
+    parse_user_ids,
+)
+
+
+@dataclass
+class WizardState:
+    """Mutable scratchpad threaded through every step."""
+
+    env_path: Path
+    projects_path: Path
+    projects: list[Project] = field(default_factory=list)
+    bot_token_set: bool = False
+    allowed_users_set: bool = False
+    claude_present: bool = False
+    llm_configured: bool = False
+    whisper_configured: bool = False
+    miniapp_configured: bool = False
+    hooks_installed: bool = False
+
+
+def _heading(title: str) -> None:
+    click.echo()
+    click.secho(f"━━ {title} ━━", fg="cyan", bold=True)
+
+
+def _hint(text: str) -> None:
+    click.secho(text, fg="bright_black")
+
+
+def step_bot_token(state: WizardState) -> None:
+    _heading("Telegram bot token")
+    _hint(
+        "Create a bot via @BotFather on Telegram (send /newbot), then paste\n"
+        "the token it gives you. Tokens look like ``123456789:ABC-DEF…``."
+    )
+    while True:
+        value = click.prompt(
+            "Bot token", hide_input=True, default="", show_default=False
+        ).strip()
+        if not value:
+            click.secho("Bot token is required — aborting wizard.", fg="red")
+            sys.exit(1)
+        if is_valid_bot_token(value):
+            update_env(state.env_path, {"TELEGRAM_BOT_TOKEN": value})
+            state.bot_token_set = True
+            click.secho("✓ Saved", fg="green")
+            return
+        click.secho(
+            "That doesn't look like a Telegram bot token. Expected "
+            "``<numeric id>:<35+ chars>``.",
+            fg="red",
+        )
+
+
+def step_allowed_users(state: WizardState) -> None:
+    _heading("Allowed Telegram users")
+    _hint(
+        "Comma-separated user IDs. Get yours from @userinfobot. The bot\n"
+        "will refuse messages from anyone not on this list."
+    )
+    while True:
+        value = click.prompt("Allowed user IDs", default="").strip()
+        if not value:
+            click.secho("At least one user id is required — aborting wizard.", fg="red")
+            sys.exit(1)
+        try:
+            ids = parse_user_ids(value)
+        except ValueError as exc:
+            click.secho(f"{exc}", fg="red")
+            continue
+        update_env(state.env_path, {"ALLOWED_USERS": ",".join(str(i) for i in ids)})
+        state.allowed_users_set = True
+        click.secho(f"✓ Saved ({len(ids)} user(s))", fg="green")
+        return
+
+
+def step_claude_check(state: WizardState) -> None:
+    _heading("Claude Code availability")
+    claude_path = shutil.which("claude")
+    if claude_path:
+        click.secho(f"✓ claude CLI found at {claude_path}", fg="green")
+        try:
+            version = subprocess.run(
+                ["claude", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            if version.returncode == 0 and version.stdout.strip():
+                _hint(f"  {version.stdout.strip()}")
+        except subprocess.TimeoutExpired, FileNotFoundError:
+            pass
+        state.claude_present = True
+        return
+    click.secho("✗ claude CLI not on $PATH", fg="yellow")
+    _hint(
+        "Install Claude Code from https://docs.anthropic.com/claude-code, or\n"
+        "set CCGRAM_CLAUDE_COMMAND to a wrapper that points at your install."
+    )
+
+
+def step_projects(state: WizardState) -> None:
+    _heading("Predefined project list")
+    _hint(
+        "These appear in the /project picker once Phase 1 lands. Each\n"
+        "session clones one of them into a per-session workspace.\n"
+        "Leave blank when you're done adding projects."
+    )
+    existing = load_projects(state.projects_path)
+    if existing:
+        click.echo(f"Already configured: {len(existing)} project(s)")
+        if not click.confirm("Add more?", default=False):
+            state.projects = existing
+            return
+
+    collected: list[Project] = list(existing)
+    while True:
+        path_str = click.prompt(
+            "Project path (absolute, blank to finish)", default=""
+        ).strip()
+        if not path_str:
+            break
+        path = Path(path_str).expanduser()
+        if not path.is_dir():
+            click.secho(f"  {path} is not a directory; please try again.", fg="red")
+            continue
+        label = click.prompt("Label shown in /project", default=path.name).strip()
+        collected.append(
+            Project(
+                path=path,
+                label=label or path.name,
+                default_model="opus",
+                default_reasoning="extra-high",
+            )
+        )
+
+    if collected:
+        _write_projects_toml(state.projects_path, collected)
+        state.projects = collected
+        click.secho(f"✓ Wrote {state.projects_path}", fg="green")
+    else:
+        _hint("(no projects configured)")
+
+
+def step_llm(state: WizardState) -> None:
+    _heading("Optional: LLM for shell mode + completion summaries")
+    _hint(
+        "ccgram uses an LLM for two things: turning natural-language into\n"
+        "shell commands in shell-provider topics, and writing one-line\n"
+        "Done summaries when an agent finishes. Skip if you don't want\n"
+        "either."
+    )
+    if not click.confirm("Configure an LLM provider?", default=False):
+        return
+    provider = _pick("LLM provider", LLM_PROVIDERS)
+    api_key = click.prompt(
+        f"{provider} API key", hide_input=True, default="", show_default=False
+    ).strip()
+    if not api_key:
+        click.secho("(no key entered — skipping LLM setup)", fg="yellow")
+        return
+    update_env(
+        state.env_path,
+        {"CCGRAM_LLM_PROVIDER": provider, "CCGRAM_LLM_API_KEY": api_key},
+    )
+    if click.confirm("Override default model?", default=False):
+        model = click.prompt("Model name", default="").strip()
+        if model:
+            update_env(state.env_path, {"CCGRAM_LLM_MODEL": model})
+    state.llm_configured = True
+    click.secho("✓ LLM configured", fg="green")
+
+
+def step_whisper(state: WizardState) -> None:
+    _heading("Optional: voice transcription (Whisper)")
+    _hint(
+        "Enables sending voice messages — they get transcribed and queued\n"
+        "with text input. Requires an OpenAI or Groq key (Groq's\n"
+        "whisper-large-v3 endpoint is fast + cheap)."
+    )
+    if not click.confirm("Configure voice transcription?", default=False):
+        return
+    provider = _pick("Whisper provider", WHISPER_PROVIDERS)
+    api_key = click.prompt(
+        f"{provider} API key (blank to reuse OPENAI_API_KEY)",
+        hide_input=True,
+        default="",
+        show_default=False,
+    ).strip()
+    update_env(state.env_path, {"CCGRAM_WHISPER_PROVIDER": provider})
+    if api_key:
+        update_env(state.env_path, {"CCGRAM_WHISPER_API_KEY": api_key})
+    state.whisper_configured = True
+    click.secho("✓ Voice transcription configured", fg="green")
+
+
+def step_miniapp(state: WizardState) -> None:
+    _heading("Optional: Mini App dashboard")
+    _hint(
+        "Enables the in-Telegram WebApp (live terminal, transcript search,\n"
+        "diff viewer once Phase 5 lands). Needs an externally reachable\n"
+        "HTTPS URL — set up cloudflared, caddy, or nginx pointing at\n"
+        "http://127.0.0.1:8765 first."
+    )
+    if not click.confirm("Configure Mini App?", default=False):
+        return
+    while True:
+        url = click.prompt("HTTPS base URL", default="").strip()
+        if not url:
+            click.secho("(no URL entered — skipping)", fg="yellow")
+            return
+        if is_valid_https_url(url):
+            break
+        click.secho("URL must start with https:// and include a host.", fg="red")
+    updates = {"CCGRAM_MINIAPP_BASE_URL": url.rstrip("/")}
+    if click.confirm("Override default host/port?", default=False):
+        host = click.prompt("Host", default="127.0.0.1").strip()
+        port = click.prompt("Port", default="8765").strip()
+        updates["CCGRAM_MINIAPP_HOST"] = host
+        updates["CCGRAM_MINIAPP_PORT"] = port
+    update_env(state.env_path, updates)
+    state.miniapp_configured = True
+    click.secho("✓ Mini App configured", fg="green")
+
+
+def step_hooks(state: WizardState) -> None:
+    _heading("Claude Code hooks")
+    _hint(
+        "Installs the Claude Code hook scripts so ccgram gets instant\n"
+        "events (Stop, Notification, SessionEnd…) instead of polling.\n"
+        "Strongly recommended — most layer features depend on hooks."
+    )
+    if not state.claude_present:
+        click.secho("Skipping (claude CLI not detected).", fg="yellow")
+        return
+    if not click.confirm("Run `ccgram hook --install`?", default=True):
+        return
+    ccgram_bin = shutil.which("ccgram")
+    if ccgram_bin is None:
+        click.secho("Cannot find ccgram on $PATH; install ccgram first.", fg="red")
+        return
+    result = subprocess.run(
+        [ccgram_bin, "hook", "--install"], capture_output=True, text=True, check=False
+    )
+    if result.returncode == 0:
+        click.secho("✓ Hooks installed", fg="green")
+        state.hooks_installed = True
+    else:
+        click.secho(
+            f"Hook install failed: {result.stderr.strip() or result.stdout.strip()}",
+            fg="red",
+        )
+
+
+def step_doctors(_state: WizardState) -> None:
+    """Run both doctors so the operator sees the same view as `ccgram-pro doctor`."""
+    _heading("Verify")
+    ccgram_bin = shutil.which("ccgram")
+    if ccgram_bin is not None:
+        click.echo("Running `ccgram doctor`…")
+        subprocess.run([ccgram_bin, "doctor"], check=False)
+    pro_bin = shutil.which("ccgram-pro")
+    if pro_bin is not None:
+        click.echo("\nRunning `ccgram-pro doctor`…")
+        subprocess.run([pro_bin, "doctor"], check=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pick(label: str, options: tuple[str, ...]) -> str:
+    click.echo(f"{label}:")
+    for idx, name in enumerate(options, 1):
+        click.echo(f"  {idx}) {name}")
+    while True:
+        raw = click.prompt("Choice", default="1").strip()
+        try:
+            choice = int(raw)
+        except ValueError:
+            click.secho("Pick a number.", fg="red")
+            continue
+        if 1 <= choice <= len(options):
+            return options[choice - 1]
+        click.secho(f"Pick a number 1..{len(options)}.", fg="red")
+
+
+def _write_projects_toml(path: Path, projects: list[Project]) -> None:
+    """Write *projects* as a fresh ``projects.toml``.
+
+    Doesn't try to preserve existing content — the wizard owns this file
+    when it runs. The TOML serializer is intentionally hand-rolled to
+    avoid a runtime dependency on ``tomli-w`` and to keep the output
+    diff-friendly (one ``[[project]]`` block per entry, in input order).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# ccgram-pro predefined project list — written by `ccgram-pro setup`.",
+        "# Edit and restart ccgram; new entries appear in the /project keyboard.",
+        "",
+    ]
+    for project in projects:
+        lines.append("[[project]]")
+        lines.append(f'path = "{project.path}"')
+        lines.append(f'label = "{_escape_toml(project.label)}"')
+        lines.append(f'default_model = "{_escape_toml(project.default_model)}"')
+        lines.append(f'default_reasoning = "{_escape_toml(project.default_reasoning)}"')
+        if project.default_preamble:
+            lines.append(
+                f'default_preamble = """{_escape_toml(project.default_preamble)}"""'
+            )
+        if project.install_command is not None:
+            lines.append(f'install_command = "{_escape_toml(project.install_command)}"')
+        lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _escape_toml(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def default_env_path() -> Path:
+    return ccgram_dir() / ".env"
+
+
+def default_projects_path() -> Path:
+    return projects_toml_path()
+
+
+def initial_state() -> WizardState:
+    layer_dir().mkdir(parents=True, exist_ok=True)
+    return WizardState(
+        env_path=default_env_path(), projects_path=default_projects_path()
+    )

--- a/ccgram-pro/src/ccgram_pro/workspaces/__init__.py
+++ b/ccgram-pro/src/ccgram_pro/workspaces/__init__.py
@@ -1,0 +1,35 @@
+"""Per-session project workspaces.
+
+Each tmux window optionally gets its own clone or copy of the chosen project
+under ``<layer_dir>/workspaces/<window_id>/``, so parallel sessions on the
+same source repo cannot stomp on each other (and Claude is free to modify
+files without affecting the developer's main checkout).
+
+Sub-modules:
+
+- :mod:`paths` — directory layout helpers.
+- :mod:`git_clone` — ``git clone --local --no-hardlinks`` + uncommitted /
+  untracked transfer.
+- :mod:`copy_strategy` — ``rsync`` (with smart excludes) / ``cp -r``
+  fallback for non-git sources.
+- :mod:`install` — auto-detect + run the project's package install command.
+- :mod:`manager` — high-level ``create_workspace`` /
+  ``delete_workspace`` orchestration. Writes ``workspace_path`` and
+  ``last_activity_at`` to the sidecar.
+- :mod:`gc` — sweep idle workspaces against the configured threshold.
+- :mod:`runtime` — schedule the GC sweep as a PTB ``JobQueue`` task.
+"""
+
+from .manager import (
+    WorkspaceCreationError,
+    create_workspace,
+    delete_workspace,
+    touch_activity,
+)
+
+__all__ = [
+    "WorkspaceCreationError",
+    "create_workspace",
+    "delete_workspace",
+    "touch_activity",
+]

--- a/ccgram-pro/src/ccgram_pro/workspaces/copy_strategy.py
+++ b/ccgram-pro/src/ccgram_pro/workspaces/copy_strategy.py
@@ -1,0 +1,126 @@
+"""Filesystem-copy provisioning strategy for non-git sources (or opt-in).
+
+Uses ``rsync`` with a built-in exclude list when available — that gives
+predictable performance on large repos and skips dependency caches
+(``node_modules``, ``.venv``, ``dist`` …) by default. Falls back to
+``shutil.copytree`` with the same exclude set when ``rsync`` is missing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+class CopyError(RuntimeError):
+    """Raised when filesystem copy provisioning fails."""
+
+
+# Directories almost certainly safe to skip for a fresh workspace. Lists
+# (rather than wildcard globs) so the same shape works for both rsync's
+# --exclude and shutil.copytree's ignore callback.
+DEFAULT_EXCLUDES: tuple[str, ...] = (
+    "node_modules",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    "dist",
+    "build",
+    "target",
+    ".next",
+    ".turbo",
+    ".cache",
+    ".gradle",
+    ".idea",
+    ".vscode",
+    # We MUST copy .git for git-based projects; the manager picks the
+    # clone strategy for those anyway, so for the copy strategy keep .git
+    # too — the user might want git history available even in a non-clone
+    # workspace.
+)
+
+
+_RSYNC_TIMEOUT_SECONDS = 600  # rsync of large trees can take a while
+
+
+def _rsync_available() -> bool:
+    return shutil.which("rsync") is not None
+
+
+def _rsync_copy(source: Path, dest: Path) -> None:
+    args = ["rsync", "-a", "--delete"]
+    for pattern in DEFAULT_EXCLUDES:
+        args.extend(["--exclude", pattern])
+    # rsync semantics: trailing slash on source means "copy CONTENTS into
+    # dest"; without it, you get dest/<basename>/... — we want the former.
+    args.append(f"{source}/")
+    args.append(f"{dest}/")
+    result = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=_RSYNC_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        msg = f"rsync failed: {result.stderr.strip() or result.stdout.strip()}"
+        raise CopyError(msg)
+
+
+def _shutil_copy(source: Path, dest: Path) -> None:
+    excludes = set(DEFAULT_EXCLUDES)
+
+    def _ignore(_dirname: str, names: list[str]) -> list[str]:
+        return [n for n in names if n in excludes]
+
+    try:
+        shutil.copytree(source, dest, ignore=_ignore, symlinks=True)
+    except (OSError, shutil.Error) as exc:
+        msg = f"copytree failed: {exc}"
+        raise CopyError(msg) from exc
+
+
+async def copy_workspace(source: Path, workspace: Path) -> None:
+    """Mirror *source* into a fresh *workspace*.
+
+    Stages into a sibling tempdir so the workspace path never exists in a
+    half-copied state. Picks ``rsync`` when available, ``shutil`` otherwise.
+    """
+    if workspace.exists():
+        msg = f"Workspace already exists: {workspace}"
+        raise CopyError(msg)
+    if not source.is_dir():
+        msg = f"Source is not a directory: {source}"
+        raise CopyError(msg)
+
+    stage_parent = workspace.parent
+    stage_parent.mkdir(parents=True, exist_ok=True)
+    stage = Path(tempfile.mkdtemp(prefix=workspace.name + ".stage-", dir=stage_parent))
+
+    def _do_work() -> None:
+        # mkdtemp returns an existing empty dir; both rsync (trailing
+        # slash) and copytree (must not exist) need that handled.
+        if _rsync_available():
+            _rsync_copy(source, stage)
+        else:
+            shutil.rmtree(stage)
+            _shutil_copy(source, stage)
+
+    try:
+        await asyncio.to_thread(_do_work)
+        os.replace(stage, workspace)
+    except Exception:
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+        raise

--- a/ccgram-pro/src/ccgram_pro/workspaces/gc.py
+++ b/ccgram-pro/src/ccgram_pro/workspaces/gc.py
@@ -1,0 +1,139 @@
+"""Idle-workspace garbage collection.
+
+Workspaces are deleted on two conditions:
+
+1. **Idle.** The owning sidecar's ``last_activity_at`` is older than
+   ``WorkspaceSettings.idle_days``. The user explicitly designed this as
+   the "session has ended" signal — wall-clock idle is the only reliable
+   proxy when neither tmux nor Telegram emit a clear lifecycle event.
+2. **Orphan.** A workspace directory exists on disk but no sidecar
+   references it. This catches the case where a sidecar was deleted (GC,
+   epoch fingerprint mismatch, manual ``rm``) while the workspace was
+   left behind.
+
+The sweep runs synchronously inside ``asyncio.to_thread`` from the
+runtime job. Each removal is independent — one failure does not block
+the rest of the sweep.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import structlog
+
+from .. import state
+from ..config import WorkspaceSettings, load_settings, workspaces_dir
+from .paths import workspace_for_window
+
+logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class SweepResult:
+    """Counts returned from a single GC pass — surfaced by doctor."""
+
+    idle_removed: int
+    orphans_removed: int
+
+    @property
+    def total(self) -> int:
+        return self.idle_removed + self.orphans_removed
+
+
+def _seconds(days: int) -> int:
+    return days * 24 * 60 * 60
+
+
+def _try_rmtree(path: Path) -> bool:
+    try:
+        shutil.rmtree(path)
+    except OSError as exc:
+        logger.warning("GC could not remove %s: %s", path, exc)
+        return False
+    return True
+
+
+def _sweep_idle(now: float, idle_seconds: int) -> int:
+    """Remove workspaces whose sidecar's last_activity_at is older than the threshold."""
+    removed = 0
+    for sidecar in state.all_sidecars():
+        if sidecar.workspace_path is None:
+            continue
+        if sidecar.last_activity_at is None:
+            # Sidecar references a workspace but never recorded activity —
+            # treat as orphan-ish, but don't aggressively delete since the
+            # workspace may have been created seconds ago. Skip; the next
+            # touch_activity call will populate the timestamp.
+            continue
+        if now - sidecar.last_activity_at <= idle_seconds:
+            continue
+        workspace = Path(sidecar.workspace_path)
+        if workspace.exists() and not _try_rmtree(workspace):
+            continue
+        # Clear sidecar fields whether or not the dir existed — the sidecar
+        # bookkeeping is the source of truth for "we have a workspace".
+        sidecar.workspace_path = None
+        sidecar.last_activity_at = None
+        state.save(sidecar)
+        logger.info(
+            "GC removed idle workspace %s (window=%s)", workspace, sidecar.window_id
+        )
+        removed += 1
+    return removed
+
+
+def _sweep_orphans() -> int:
+    """Remove workspace directories that no sidecar references."""
+    root = workspaces_dir()
+    if not root.is_dir():
+        return 0
+    sidecar_paths = {
+        sidecar.workspace_path
+        for sidecar in state.all_sidecars()
+        if sidecar.workspace_path is not None
+    }
+    removed = 0
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        # Skip staging dirs that strategy modules use during provisioning —
+        # they have a ``.stage-`` suffix and a live writer.
+        if ".stage-" in entry.name:
+            continue
+        # Also defend against the sanitize_dir_name round-trip: an entry
+        # we don't recognise as a known window_id stays UNLESS no sidecar
+        # claims its absolute path.
+        if str(entry) in sidecar_paths:
+            continue
+        if _try_rmtree(entry):
+            logger.info("GC removed orphan workspace %s", entry)
+            removed += 1
+    return removed
+
+
+def sweep(
+    *,
+    now: float | None = None,
+    settings: WorkspaceSettings | None = None,
+) -> SweepResult:
+    """Run one GC pass.
+
+    The two phases are independent — orphan cleanup also runs even when
+    no idle candidates exist, since the most common orphan cause is a
+    sidecar deleted out from under a workspace.
+    """
+    effective_now = time.time() if now is None else now
+    effective_settings = settings or load_settings().workspaces
+    idle_seconds = _seconds(effective_settings.idle_days)
+    idle_removed = _sweep_idle(effective_now, idle_seconds)
+    orphans_removed = _sweep_orphans()
+    return SweepResult(idle_removed=idle_removed, orphans_removed=orphans_removed)
+
+
+def expected_workspace_for(window_id: str) -> Path:
+    """Helper for diagnostics — the path :func:`workspace_for_window` would resolve."""
+    return workspace_for_window(window_id)

--- a/ccgram-pro/src/ccgram_pro/workspaces/git_clone.py
+++ b/ccgram-pro/src/ccgram_pro/workspaces/git_clone.py
@@ -1,0 +1,193 @@
+"""``git`` provisioning strategy — clone a source repo into a workspace.
+
+The clone path uses ``--local --no-hardlinks`` so modifying the workspace's
+``.git`` cannot corrupt the source repository's object DB, while still
+benefiting from the local-file fast path (no network, near-instant for
+typical projects). Uncommitted edits and untracked files in the source can
+optionally be carried over so the workspace mirrors what the developer
+sees in their main checkout.
+
+This module deliberately matches the subprocess style in
+``ccgram.handlers.topics.worktree`` — :class:`GitCloneError` is the
+strategy-level exception; the manager translates it into a user-facing
+:class:`WorkspaceCreationError`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+class GitCloneError(RuntimeError):
+    """Raised when a git provisioning step fails."""
+
+
+_GIT_TIMEOUT_SECONDS = 120
+
+
+def _git(
+    cwd: Path, *args: str, timeout: int = _GIT_TIMEOUT_SECONDS
+) -> subprocess.CompletedProcess[str]:
+    """Run ``git -C <cwd> <args>`` with stdout + stderr captured.
+
+    Returns the ``CompletedProcess``; callers decide whether non-zero exit
+    is fatal (some probes legitimately fail and the caller handles that).
+    """
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def is_git_repo(path: Path) -> bool:
+    """Return True if *path* is inside a git work tree (not a bare repo)."""
+    if not path.is_dir():
+        return False
+    try:
+        result = _git(path, "rev-parse", "--is-inside-work-tree")
+    except subprocess.TimeoutExpired, FileNotFoundError:
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _clone(source: Path, dest: Path) -> None:
+    """Clone *source* into *dest* via ``git clone --local --no-hardlinks``.
+
+    ``--no-hardlinks`` copies pack files instead of hardlinking them so a
+    later GC inside the workspace cannot reach into the source's object
+    database. Slightly slower on cold cache; the safety is worth it.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        [
+            "git",
+            "clone",
+            "--local",
+            "--no-hardlinks",
+            str(source),
+            str(dest),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        msg = f"git clone failed: {result.stderr.strip() or result.stdout.strip()}"
+        raise GitCloneError(msg)
+
+
+def _apply_uncommitted_diff(source: Path, workspace: Path) -> None:
+    """Carry the source repo's uncommitted edits into the new workspace.
+
+    Uses ``git diff HEAD --binary`` so binary blobs survive intact. The
+    diff is piped to ``git apply --whitespace=nowarn --3way`` inside the
+    workspace; an empty diff (clean source) is a no-op. Failure to apply
+    is logged but non-fatal — the workspace is still usable, just at HEAD.
+    """
+    diff_result = _git(source, "diff", "HEAD", "--binary")
+    if diff_result.returncode != 0:
+        logger.warning(
+            "Failed to read source diff for transfer: %s",
+            diff_result.stderr.strip(),
+        )
+        return
+    if not diff_result.stdout:
+        return  # clean working tree, nothing to apply
+    apply_result = subprocess.run(
+        ["git", "-C", str(workspace), "apply", "--whitespace=nowarn", "--3way"],
+        input=diff_result.stdout,
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if apply_result.returncode != 0:
+        logger.warning(
+            "Could not apply source uncommitted diff to %s (workspace stays at HEAD): %s",
+            workspace,
+            apply_result.stderr.strip(),
+        )
+
+
+def _copy_untracked_files(source: Path, workspace: Path) -> int:
+    """Copy untracked-but-not-ignored files from *source* into *workspace*.
+
+    Uses ``git ls-files --others --exclude-standard`` so .gitignore is
+    respected. Returns the number of files copied. Failure to copy any
+    single file is logged but does not abort — partial transfer is better
+    than no transfer.
+    """
+    listing = _git(source, "ls-files", "--others", "--exclude-standard", "-z")
+    if listing.returncode != 0 or not listing.stdout:
+        return 0
+    paths = [p for p in listing.stdout.split("\x00") if p]
+    copied = 0
+    for rel in paths:
+        src = source / rel
+        if not src.is_file():
+            continue
+        dst = workspace / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.copy2(src, dst)
+            copied += 1
+        except OSError as exc:
+            logger.warning("Failed to copy untracked %s: %s", rel, exc)
+    return copied
+
+
+async def clone_workspace(
+    source: Path, workspace: Path, *, transfer_uncommitted: bool
+) -> None:
+    """Provision *workspace* from the git repository at *source*.
+
+    Runs the (synchronous) subprocess work in a worker thread so the
+    asyncio event loop stays responsive. If anything before the final move
+    fails, the partial workspace is removed so the caller sees a clean
+    "not created" state rather than a half-populated directory.
+    """
+    if workspace.exists():
+        msg = f"Workspace already exists: {workspace}"
+        raise GitCloneError(msg)
+
+    # Stage into a sibling tempdir, then rename — this keeps a half-cloned
+    # workspace from appearing under its final name (where GC could see it).
+    stage_parent = workspace.parent
+    stage_parent.mkdir(parents=True, exist_ok=True)
+    stage = Path(tempfile.mkdtemp(prefix=workspace.name + ".stage-", dir=stage_parent))
+
+    def _do_work() -> None:
+        # mkdtemp produced an empty dir; git clone insists on a non-existent
+        # target, so remove it and let clone recreate.
+        shutil.rmtree(stage)
+        _clone(source, stage)
+        if transfer_uncommitted:
+            _apply_uncommitted_diff(source, stage)
+            copied = _copy_untracked_files(source, stage)
+            if copied:
+                logger.debug(
+                    "Copied %d untracked file(s) from %s to %s", copied, source, stage
+                )
+
+    try:
+        await asyncio.to_thread(_do_work)
+        os.replace(stage, workspace)
+    except Exception:
+        # Best-effort cleanup of the stage directory; the workspace itself
+        # was never created (rename never reached), so callers see nothing.
+        if stage.exists():
+            shutil.rmtree(stage, ignore_errors=True)
+        raise

--- a/ccgram-pro/src/ccgram_pro/workspaces/install.py
+++ b/ccgram-pro/src/ccgram_pro/workspaces/install.py
@@ -1,0 +1,162 @@
+"""Auto-detect and run the workspace's package install command.
+
+Detection looks at the lock/manifest files present in the workspace root.
+Order matters — pnpm-lock beats package-lock so a hybrid repo picks the
+faster tool, ``uv.lock`` beats bare ``pyproject.toml`` so we prefer uv
+when the project committed an explicit lock.
+
+A user-supplied ``install_command`` on the matching :class:`Project`
+overrides the auto-detection. The empty string ``""`` is a sentinel
+meaning "skip install entirely" — useful when the workspace ships
+vendored deps or the user wants to wire up their own bootstrap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+import structlog
+
+from .paths import install_log_path
+
+logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    """Outcome of an install run. Captured for the manager + doctor."""
+
+    command: str
+    returncode: int
+    duration_seconds: float
+    log_path: Path
+
+    @property
+    def succeeded(self) -> bool:
+        return self.returncode == 0
+
+
+# Detection rules: ordered list of (filename, default command). First hit wins.
+# Tuples are tried in declaration order, so favor lockfiles over manifests.
+_DETECT_RULES: tuple[tuple[str, str], ...] = (
+    ("pnpm-lock.yaml", "pnpm install --frozen-lockfile"),
+    ("yarn.lock", "yarn install --frozen-lockfile"),
+    ("package-lock.json", "npm ci"),
+    ("uv.lock", "uv sync"),
+    ("poetry.lock", "poetry install --no-root"),
+    ("Pipfile.lock", "pipenv install --deploy"),
+    ("Cargo.lock", "cargo fetch"),
+    ("go.sum", "go mod download"),
+    # Manifest-only fallbacks. Lockfile rules above already covered the
+    # paired case; these handle repos that intentionally don't commit a lock.
+    ("package.json", "npm install"),
+    ("pyproject.toml", "uv sync"),
+    ("requirements.txt", "pip install -r requirements.txt"),
+    ("Cargo.toml", "cargo fetch"),
+    ("go.mod", "go mod download"),
+)
+
+
+def detect_install_command(workspace: Path) -> str | None:
+    """Return the inferred install command for *workspace*, or ``None``.
+
+    No fancy heuristics — just inspects the workspace root for known
+    lock/manifest files. Returns ``None`` when none match, which the
+    manager treats as "no install needed".
+    """
+    for filename, command in _DETECT_RULES:
+        if (workspace / filename).is_file():
+            return command
+    return None
+
+
+def resolve_install_command(workspace: Path, *, configured: str | None) -> str | None:
+    """Pick the effective install command for *workspace*.
+
+    Resolution order:
+
+    1. ``configured == ""`` — explicit skip; return ``None``.
+    2. ``configured is not None`` — use the user-supplied string verbatim.
+    3. fall back to :func:`detect_install_command`.
+    """
+    if configured == "":
+        return None
+    if configured is not None:
+        return configured
+    return detect_install_command(workspace)
+
+
+async def run_install(
+    workspace: Path, command: str, *, timeout_seconds: int
+) -> InstallResult:
+    """Run *command* inside *workspace*; capture stdout+stderr to a log.
+
+    The command is parsed with :func:`shlex.split` and executed without a
+    shell, so shell injection from a misconfigured project entry is not a
+    risk. Output is streamed to ``workspace/.ccgram-install.log`` for the
+    operator to inspect after the fact — this is where ``doctor`` will
+    point if an install fails.
+    """
+    log = install_log_path(workspace)
+    log.write_text(f"$ {command}\n", encoding="utf-8")
+
+    argv = shlex.split(command)
+    if not argv:
+        msg = "install command resolved to empty argv"
+        raise ValueError(msg)
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=str(workspace),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+    except FileNotFoundError as exc:
+        with log.open("a", encoding="utf-8") as fh:
+            fh.write(f"\n[ccgram-pro] command not found: {exc}\n")
+        return InstallResult(
+            command=command,
+            returncode=127,
+            duration_seconds=0.0,
+            log_path=log,
+        )
+
+    async def _drain() -> None:
+        assert proc.stdout is not None
+        with log.open("a", encoding="utf-8") as fh:
+            while True:
+                chunk = await proc.stdout.readline()
+                if not chunk:
+                    break
+                fh.write(chunk.decode("utf-8", errors="replace"))
+                fh.flush()
+
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(_drain(), proc.wait()), timeout=timeout_seconds
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        with log.open("a", encoding="utf-8") as fh:
+            fh.write(f"\n[ccgram-pro] install killed after {timeout_seconds}s\n")
+        return InstallResult(
+            command=command,
+            returncode=124,
+            duration_seconds=timeout_seconds,
+            log_path=log,
+        )
+
+    duration = loop.time() - start
+    return InstallResult(
+        command=command,
+        returncode=proc.returncode or 0,
+        duration_seconds=duration,
+        log_path=log,
+    )

--- a/ccgram-pro/src/ccgram_pro/workspaces/manager.py
+++ b/ccgram-pro/src/ccgram_pro/workspaces/manager.py
@@ -1,0 +1,191 @@
+"""High-level workspace lifecycle — orchestrates clone/copy + install + sidecar bookkeeping.
+
+This is the only module callers outside :mod:`ccgram_pro.workspaces`
+should depend on; the strategy modules and install runner are
+implementation details. Public surface:
+
+- :func:`create_workspace` — provision a fresh workspace for a window.
+- :func:`delete_workspace` — remove the workspace directory and clear the
+  sidecar fields.
+- :func:`touch_activity` — bump ``last_activity_at`` on the sidecar so
+  the next idle GC sweep skips this window.
+
+Sidecar mutation goes through :func:`ccgram_pro.state.transaction` so
+concurrent callers serialize per-window.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import structlog
+
+from .. import state
+from ..config import WorkspaceSettings, load_settings
+from .copy_strategy import CopyError, copy_workspace
+from .git_clone import GitCloneError, clone_workspace, is_git_repo
+from .install import InstallResult, resolve_install_command, run_install
+from .paths import workspace_for_window
+
+logger = structlog.get_logger()
+
+
+class WorkspaceCreationError(RuntimeError):
+    """Raised when workspace provisioning fails before the sidecar is written."""
+
+
+@dataclass(frozen=True)
+class WorkspaceCreated:
+    """Result returned to the caller of :func:`create_workspace`."""
+
+    path: Path
+    install: InstallResult | None
+
+
+async def create_workspace(
+    window_id: str,
+    source: Path,
+    *,
+    install_command: str | None = None,
+    settings: WorkspaceSettings | None = None,
+) -> WorkspaceCreated:
+    """Provision a per-window workspace from *source*.
+
+    Strategy is taken from *settings* (defaults loaded from
+    ``settings.toml``) — ``"clone"`` for git sources, falling back to
+    ``"copy"`` when the source isn't a git work-tree. On success, the
+    sidecar for *window_id* is updated with ``workspace_path`` and
+    ``last_activity_at`` inside a per-window transaction.
+
+    Failure modes:
+
+    - source missing / wrong shape → :class:`WorkspaceCreationError`.
+    - clone / copy step fails → :class:`WorkspaceCreationError` (and the
+      partial workspace is cleaned up by the strategy module).
+    - install step fails → the workspace is kept; the failure is logged
+      and surfaced via :attr:`WorkspaceCreated.install`. The caller
+      decides what to do (Phase 1 surfaces it to Telegram).
+    """
+    if not source.is_dir():
+        msg = f"Source project path does not exist or is not a directory: {source}"
+        raise WorkspaceCreationError(msg)
+
+    workspace = workspace_for_window(window_id)
+    if workspace.exists():
+        msg = f"Workspace already exists for window {window_id}: {workspace}"
+        raise WorkspaceCreationError(msg)
+
+    ws_settings = settings or load_settings().workspaces
+    strategy = ws_settings.strategy
+    # Auto-downgrade: clone strategy on a non-git source falls back to copy
+    # rather than failing. Most user projects are git but ad-hoc directories
+    # should still work.
+    if strategy == "clone" and not is_git_repo(source):
+        logger.debug(
+            "Source %s is not a git repo; using copy strategy instead of clone",
+            source,
+        )
+        strategy = "copy"
+
+    try:
+        if strategy == "clone":
+            await clone_workspace(
+                source,
+                workspace,
+                transfer_uncommitted=ws_settings.transfer_uncommitted,
+            )
+        else:
+            await copy_workspace(source, workspace)
+    except (GitCloneError, CopyError) as exc:
+        raise WorkspaceCreationError(str(exc)) from exc
+
+    install_result: InstallResult | None = None
+    command = resolve_install_command(workspace, configured=install_command)
+    if command is not None:
+        try:
+            install_result = await run_install(
+                workspace,
+                command,
+                timeout_seconds=ws_settings.install_timeout_seconds,
+            )
+        except (ValueError, OSError) as exc:
+            logger.warning("Install run failed to start for %s: %s", workspace, exc)
+
+    now = time.time()
+    async with state.transaction(window_id):
+        sidecar = state.get_or_create(window_id)
+        sidecar.workspace_path = str(workspace)
+        sidecar.last_activity_at = now
+        # Recording the resolved project path even when the picker hasn't
+        # run yet keeps the sidecar self-describing for GC + doctor.
+        if sidecar.project_path is None:
+            sidecar.project_path = str(source)
+        state.save(sidecar)
+
+    if install_result is not None and not install_result.succeeded:
+        logger.warning(
+            "Install for %s exited %d in %.1fs; see %s",
+            workspace,
+            install_result.returncode,
+            install_result.duration_seconds,
+            install_result.log_path,
+        )
+
+    logger.info(
+        "Provisioned workspace for window %s at %s (strategy=%s)",
+        window_id,
+        workspace,
+        strategy,
+    )
+    return WorkspaceCreated(path=workspace, install=install_result)
+
+
+async def delete_workspace(window_id: str) -> bool:
+    """Remove the workspace for *window_id* and clear the sidecar fields.
+
+    Returns ``True`` when a workspace was actually removed, ``False`` when
+    none existed. The directory removal is best-effort — read-only files
+    inside a node_modules tree have been known to defeat ``rmtree``, so
+    failures are logged and the function still clears the sidecar bookkeeping
+    so the orphan is visible to the GC sweep.
+    """
+    workspace = workspace_for_window(window_id)
+    removed = False
+    if workspace.exists():
+        try:
+            shutil.rmtree(workspace)
+            removed = True
+        except OSError as exc:
+            logger.warning("Failed to remove workspace %s: %s", workspace, exc)
+
+    async with state.transaction(window_id):
+        sidecar = state.load(window_id)
+        if sidecar is not None and (
+            sidecar.workspace_path is not None or sidecar.last_activity_at is not None
+        ):
+            sidecar.workspace_path = None
+            sidecar.last_activity_at = None
+            state.save(sidecar)
+
+    if removed:
+        logger.info("Removed workspace for window %s", window_id)
+    return removed
+
+
+async def touch_activity(window_id: str) -> None:
+    """Refresh the sidecar's ``last_activity_at`` to now.
+
+    Called whenever the layer registers user-visible activity for the
+    window (Phase 1+ will hook this into message forwarding). Safe to
+    call on a window with no workspace — it just records that the
+    sidecar saw activity.
+    """
+    async with state.transaction(window_id):
+        sidecar = state.load(window_id)
+        if sidecar is None:
+            return
+        sidecar.last_activity_at = time.time()
+        state.save(sidecar)

--- a/ccgram-pro/src/ccgram_pro/workspaces/paths.py
+++ b/ccgram-pro/src/ccgram_pro/workspaces/paths.py
@@ -1,0 +1,29 @@
+"""Path helpers for per-window workspaces.
+
+Mirrors :mod:`ccgram_pro.state` — window ids are routed through
+``ccgram.mailbox.sanitize_dir_name`` so a hostile id (``..``, ``/``) is
+rejected before it can produce a path outside :func:`workspaces_dir`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ccgram.mailbox import sanitize_dir_name
+
+from ..config import workspaces_dir
+
+
+def workspace_for_window(window_id: str) -> Path:
+    """Resolve the workspace directory path for *window_id*.
+
+    Does not create the directory — that is the manager's job. Raises
+    ``ValueError`` via :func:`sanitize_dir_name` if the id contains path
+    traversal sequences.
+    """
+    return workspaces_dir() / sanitize_dir_name(window_id)
+
+
+def install_log_path(workspace: Path) -> Path:
+    """Where :mod:`install` writes the captured install output."""
+    return workspace / ".ccgram-install.log"

--- a/ccgram-pro/src/ccgram_pro/workspaces/runtime.py
+++ b/ccgram-pro/src/ccgram_pro/workspaces/runtime.py
@@ -1,0 +1,64 @@
+"""PTB JobQueue integration — schedule the workspace GC sweep.
+
+The sweep itself is synchronous file I/O wrapped in ``asyncio.to_thread``
+so the event loop stays responsive. Scheduling lives here so the
+extension's ``install`` callback can wire it without depending on
+``ccgram_pro.workspaces.gc`` types directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import structlog
+
+from ..config import load_settings
+from . import gc as gc_module
+
+if TYPE_CHECKING:
+    from telegram.ext import Application, ContextTypes
+
+logger = structlog.get_logger()
+
+
+_JOB_NAME = "ccgram_pro_workspace_gc"
+
+
+async def _gc_job(_context: "ContextTypes.DEFAULT_TYPE") -> None:
+    """JobQueue callback — runs one :func:`gc.sweep` pass off the event loop."""
+    result = await asyncio.to_thread(gc_module.sweep)
+    if result.total:
+        logger.info(
+            "Workspace GC: removed %d idle, %d orphan",
+            result.idle_removed,
+            result.orphans_removed,
+        )
+
+
+def schedule_gc(application: "Application") -> None:
+    """Register the periodic GC job on *application*'s ``JobQueue``.
+
+    No-ops gracefully when the application has no ``job_queue``
+    (extensions can register their own scheduling on hosts that opted
+    out of PTB's job-queue extra). Idempotent — re-registering schedules
+    the next tick from now without removing the previous job, which
+    matches PTB's standard pattern.
+    """
+    job_queue = getattr(application, "job_queue", None)
+    if job_queue is None:
+        logger.warning(
+            "PTB JobQueue not available; ccgram-pro workspace GC will not run automatically"
+        )
+        return
+
+    settings = load_settings().workspaces
+    interval = settings.gc_interval_seconds
+    # Stagger the first run by 60s so multiple GC tasks across extensions
+    # don't all fire at startup.
+    job_queue.run_repeating(_gc_job, interval=interval, first=60, name=_JOB_NAME)
+    logger.info(
+        "Workspace GC scheduled (interval=%ds, idle_days=%d)",
+        interval,
+        settings.idle_days,
+    )

--- a/ccgram-pro/tests/conftest.py
+++ b/ccgram-pro/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures for ccgram-pro tests.
+
+Every test gets an isolated ``CCGRAM_DIR`` pointing at a tmp_path subdir,
+so the layer's state directory never touches the developer's real
+``~/.ccgram/``. The layer dirs are created on demand by code under test
+(via ``ensure_layer_dirs``) so fixtures stay minimal.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_ccgram_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[Path]:
+    """Point CCGRAM_DIR at a per-test tmp dir so state never leaks.
+
+    Also strips multi-instance env vars so :func:`layer_dir` doesn't
+    namespace into a sub-sub-dir tests don't expect. Tests that want to
+    exercise instance-name behaviour set those vars themselves.
+    """
+    monkeypatch.setenv("CCGRAM_DIR", str(tmp_path))
+    monkeypatch.delenv("CCGRAM_GROUP_ID", raising=False)
+    monkeypatch.delenv("CCGRAM_INSTANCE_NAME", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    # state.py holds a module-level lock registry — drop it between tests so
+    # an event-loop-per-test pytest setup doesn't reuse stale Locks.
+    from ccgram_pro import state as _state
+
+    _state._reset_locks_for_testing()
+    yield tmp_path

--- a/ccgram-pro/tests/test_config.py
+++ b/ccgram-pro/tests/test_config.py
@@ -1,0 +1,175 @@
+"""Tests for ``ccgram_pro.config`` — TOML loading edge cases + defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ccgram_pro.config import (
+    Defaults,
+    Project,
+    Settings,
+    _coerce_bool,
+    _coerce_int,
+    _coerce_str,
+    ensure_layer_dirs,
+    layer_dir,
+    load_projects,
+    load_settings,
+)
+
+
+def test_layer_dir_default(tmp_path: Path) -> None:
+    assert layer_dir() == tmp_path / "layer"
+
+
+def test_layer_dir_namespaces_on_group_id(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("CCGRAM_GROUP_ID", "humans")
+    assert layer_dir() == tmp_path / "layer" / "group-humans"
+
+
+def test_layer_dir_namespaces_on_instance_name_when_group_unset(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("CCGRAM_INSTANCE_NAME", "bot-a")
+    assert layer_dir() == tmp_path / "layer" / "instance-bot-a"
+
+
+def test_layer_dir_prefers_group_over_instance(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("CCGRAM_GROUP_ID", "g1")
+    monkeypatch.setenv("CCGRAM_INSTANCE_NAME", "i1")
+    assert layer_dir() == tmp_path / "layer" / "group-g1"
+
+
+def test_ensure_layer_dirs_creates_all(tmp_path: Path) -> None:
+    ensure_layer_dirs()
+    base = tmp_path / "layer"
+    assert (base / "state").is_dir()
+    assert (base / "snapshots").is_dir()
+    assert (base / "pr-loop").is_dir()
+
+
+def test_load_projects_missing_returns_empty(tmp_path: Path) -> None:
+    assert load_projects(tmp_path / "absent.toml") == []
+
+
+def test_load_projects_happy(tmp_path: Path) -> None:
+    f = tmp_path / "projects.toml"
+    f.write_text(
+        """
+[[project]]
+path = "/tmp/a"
+label = "A"
+
+[[project]]
+path = "/tmp/b"
+label = "B"
+default_model = "sonnet"
+default_reasoning = "high"
+default_preamble = "be careful"
+"""
+    )
+    projects = load_projects(f)
+    assert len(projects) == 2
+    assert projects[0] == Project(path=Path("/tmp/a"), label="A")
+    assert projects[1].default_model == "sonnet"
+    assert projects[1].default_reasoning == "high"
+    assert projects[1].default_preamble == "be careful"
+
+
+def test_load_projects_expands_user(tmp_path: Path) -> None:
+    f = tmp_path / "projects.toml"
+    f.write_text('[[project]]\npath = "~/foo"\nlabel = "F"\n')
+    projects = load_projects(f)
+    assert projects[0].path == Path.home() / "foo"
+
+
+def test_load_projects_skips_malformed(tmp_path: Path) -> None:
+    f = tmp_path / "projects.toml"
+    f.write_text(
+        """
+[[project]]
+label = "no path"
+
+[[project]]
+path = "/tmp/ok"
+label = "ok"
+"""
+    )
+    projects = load_projects(f)
+    assert len(projects) == 1
+    assert projects[0].label == "ok"
+
+
+def test_load_projects_handles_toml_decode_error(tmp_path: Path) -> None:
+    f = tmp_path / "projects.toml"
+    f.write_text("[[ malformed toml")
+    assert load_projects(f) == []
+
+
+def test_load_projects_handles_non_array_project_key(tmp_path: Path) -> None:
+    f = tmp_path / "projects.toml"
+    f.write_text('project = "not an array"\n')
+    assert load_projects(f) == []
+
+
+def test_load_settings_missing_returns_defaults(tmp_path: Path) -> None:
+    s = load_settings(tmp_path / "absent.toml")
+    assert s == Settings()
+    assert s.defaults.silent_mode is True
+    assert s.defaults.batch_mode is True
+    assert s.voice.flush_grace_seconds == 30
+
+
+def test_load_settings_partial_overrides(tmp_path: Path) -> None:
+    f = tmp_path / "settings.toml"
+    f.write_text(
+        """
+[defaults]
+silent_mode = false
+
+[voice]
+flush_grace_seconds = 5
+"""
+    )
+    s = load_settings(f)
+    assert s.defaults.silent_mode is False
+    assert s.defaults.batch_mode is True  # still default
+    assert s.voice.flush_grace_seconds == 5
+    assert s.voice.transcription_note == Settings().voice.transcription_note
+
+
+def test_load_settings_malformed_section_falls_back(tmp_path: Path) -> None:
+    f = tmp_path / "settings.toml"
+    f.write_text('defaults = "not a table"\n')
+    s = load_settings(f)
+    assert s.defaults == Defaults()
+
+
+def test_load_settings_invalid_toml_returns_defaults(tmp_path: Path) -> None:
+    f = tmp_path / "settings.toml"
+    f.write_text(":::not toml at all")
+    assert load_settings(f) == Settings()
+
+
+def test_coerce_bool_only_accepts_real_booleans() -> None:
+    assert _coerce_bool(True, False) is True
+    assert _coerce_bool(False, True) is False
+    assert _coerce_bool("yes", False) is False  # truthy string falls back
+    assert _coerce_bool(1, False) is False  # ints fall back
+    assert _coerce_bool(None, True) is True
+
+
+def test_coerce_int_rejects_booleans() -> None:
+    # isinstance(True, int) is True in Python; we MUST reject so a TOML
+    # author writing ``flush_grace_seconds = true`` doesn't silently get 1.
+    assert _coerce_int(True, 30) == 30
+    assert _coerce_int(False, 30) == 30
+    assert _coerce_int(5, 30) == 5
+    assert _coerce_int("5", 30) == 30
+    assert _coerce_int(None, 30) == 30
+
+
+def test_coerce_str_only_accepts_strings() -> None:
+    assert _coerce_str("hello", "x") == "hello"
+    assert _coerce_str(5, "x") == "x"
+    assert _coerce_str(None, "x") == "x"

--- a/ccgram-pro/tests/test_doctor.py
+++ b/ccgram-pro/tests/test_doctor.py
@@ -1,0 +1,108 @@
+"""Tests for ``ccgram_pro.doctor`` — smoke + worst-status helpers."""
+
+from __future__ import annotations
+
+import pytest
+from ccgram_pro import doctor
+
+
+def test_use_colors_honors_no_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "")
+    assert doctor._use_colors() is False
+
+
+def test_use_colors_honors_force_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert doctor._use_colors() is True
+
+
+def test_use_colors_no_color_wins_over_force(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "")
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert doctor._use_colors() is False
+
+
+def test_worst_precedence() -> None:
+    assert doctor._worst("OK", "OK", "OK") == "OK"
+    assert doctor._worst("OK", "WARN", "OK") == "WARN"
+    assert doctor._worst("WARN", "FAIL", "OK") == "FAIL"
+    assert doctor._worst("FAIL") == "FAIL"
+
+
+def test_run_doctor_returns_zero_when_everything_ok(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Phase 0 doctor only fails on missing entry points; everything else is OK/WARN."""
+    rc = doctor.run_doctor()
+    out = capsys.readouterr().out
+    assert "ccgram-pro" in out
+    assert "Overall:" in out
+    assert rc == 0
+
+
+def test_run_doctor_returns_one_when_entry_point_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If entry_points returns nothing, the doctor must FAIL."""
+
+    def stub_entry_points(*_args, **kwargs):  # noqa: ANN001, ANN003
+        # importlib.metadata.entry_points(group=...) returns an EntryPoints
+        # which is iterable; an empty list satisfies the interface.
+        del kwargs
+        return []
+
+    monkeypatch.setattr(doctor, "entry_points", stub_entry_points)
+    rc = doctor.run_doctor()
+    out = capsys.readouterr().out
+    assert "FAIL" in out
+    assert "missing" in out
+    assert rc == 1
+
+
+def test_check_dispatch_sites_detects_present(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    status = doctor._check_dispatch_sites()
+    assert status == "OK"
+    out = capsys.readouterr().out
+    assert "dispatch_extensions" in out
+    assert "_resolve_miniapp_factory" in out
+
+
+def test_check_layer_dirs_succeeds(capsys: pytest.CaptureFixture[str]) -> None:
+    status = doctor._check_layer_dirs()
+    assert status == "OK"
+    out = capsys.readouterr().out
+    assert "writable" in out
+
+
+def test_check_projects_warns_when_missing(
+    tmp_path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    status = doctor._check_projects(tmp_path / "nope.toml")
+    assert status == "WARN"
+    out = capsys.readouterr().out
+    assert "missing" in out
+
+
+def test_check_projects_ok_when_populated(
+    tmp_path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    f = tmp_path / "projects.toml"
+    f.write_text('[[project]]\npath = "/tmp/x"\nlabel = "X"\n')
+    status = doctor._check_projects(f)
+    assert status == "OK"
+    out = capsys.readouterr().out
+    assert "1 project" in out
+
+
+def test_check_gh_cli_does_not_fail_when_absent(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """gh is a Phase 7 dependency; Phase 0 doctor reports OK either way."""
+    monkeypatch.setattr(doctor.shutil, "which", lambda _name: None)
+    status = doctor._check_gh_cli()
+    assert status == "OK"
+    out = capsys.readouterr().out
+    assert "Phase 7" in out

--- a/ccgram-pro/tests/test_extension.py
+++ b/ccgram-pro/tests/test_extension.py
@@ -1,0 +1,54 @@
+"""Tests for ``ccgram_pro.extension`` and ``miniapp_factory`` entry-point targets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from ccgram_pro import extension, miniapp_factory
+
+
+def test_install_is_idempotent_and_creates_layer_dirs(tmp_path: Path) -> None:
+    extension.install(None)  # type: ignore[arg-type]
+    extension.install(None)  # second call must not raise
+    assert (tmp_path / "layer" / "state").is_dir()
+    assert (tmp_path / "layer" / "snapshots").is_dir()
+    assert (tmp_path / "layer" / "pr-loop").is_dir()
+
+
+def test_make_factory_passes_through_kwargs() -> None:
+    captured: dict[str, Any] = {}
+
+    def stub_build_app(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return "fake-app"
+
+    factory = miniapp_factory.make_factory(stub_build_app)
+    result = factory(bot_token="abc")
+    assert result == "fake-app"
+    assert captured == {"bot_token": "abc"}
+
+
+def test_make_factory_forwards_arbitrary_keywords() -> None:
+    """Future build_app params (terminal_capture etc.) must flow through."""
+    captured: dict[str, Any] = {}
+
+    def stub_build_app(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return "ok"
+
+    factory = miniapp_factory.make_factory(stub_build_app)
+    factory(bot_token="x", terminal_capture="cap", pane_list="pl")
+    assert captured == {"bot_token": "x", "terminal_capture": "cap", "pane_list": "pl"}
+
+
+def test_make_factory_surfaces_upstream_typeerror() -> None:
+    """A renamed kwarg in upstream build_app must propagate as TypeError."""
+
+    def picky_build_app(*, bot_token: str) -> object:  # noqa: ARG001
+        return "ok"
+
+    factory = miniapp_factory.make_factory(picky_build_app)
+    with pytest.raises(TypeError):
+        factory(unknown_kw="oops")

--- a/ccgram-pro/tests/test_host_contract.py
+++ b/ccgram-pro/tests/test_host_contract.py
@@ -1,0 +1,87 @@
+"""Contract tests: ccgram's host symbols must exist and have stable shapes.
+
+These are the upstream-pull canaries. If a future ccgram refactor renames
+or restructures the entry-point dispatch sites, the layer breaks at
+runtime. Catching it as a unit-test failure on `git pull` is much cheaper
+than discovering it in production.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_bootstrap_dispatch_extensions_signature() -> None:
+    from ccgram import bootstrap
+
+    fn = getattr(bootstrap, "dispatch_extensions", None)
+    assert fn is not None, "ccgram.bootstrap.dispatch_extensions missing"
+    sig = inspect.signature(fn)
+    # One positional arg (the PTB Application). Subsequent additions of
+    # keyword-only params are forward-compatible.
+    positional = [
+        p
+        for p in sig.parameters.values()
+        if p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    assert len(positional) == 1
+
+
+def test_bootstrap_application_calls_dispatch_extensions() -> None:
+    """Sanity: the dispatch site exists inside bootstrap_application's body."""
+    from ccgram import bootstrap
+
+    source = inspect.getsource(bootstrap.bootstrap_application)
+    assert "dispatch_extensions" in source
+
+
+def test_bootstrap_reset_for_testing_resets_extensions_flag() -> None:
+    """reset_for_testing must clear the _extensions_dispatched guard."""
+    from ccgram import bootstrap
+
+    source = inspect.getsource(bootstrap.reset_for_testing)
+    assert "_extensions_dispatched" in source
+
+
+def test_main_resolve_miniapp_factory_signature() -> None:
+    from ccgram import main
+
+    fn = getattr(main, "_resolve_miniapp_factory", None)
+    assert fn is not None, "ccgram.main._resolve_miniapp_factory missing"
+    sig = inspect.signature(fn)
+    # No required parameters.
+    required = [
+        p
+        for p in sig.parameters.values()
+        if p.default is inspect.Parameter.empty
+        and p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    ]
+    assert required == []
+
+
+def test_main_start_miniapp_forwards_factory() -> None:
+    """start_miniapp_if_enabled must thread the resolved factory into start_server."""
+    from ccgram import main
+
+    source = inspect.getsource(main.start_miniapp_if_enabled)
+    assert "_resolve_miniapp_factory" in source
+    assert "app_factory" in source
+
+
+def test_miniapp_build_app_accepts_bot_token() -> None:
+    """Our wrapper assumes build_app takes a keyword-only bot_token."""
+    from ccgram.miniapp.server import build_app
+
+    sig = inspect.signature(build_app)
+    bot_token = sig.parameters.get("bot_token")
+    assert bot_token is not None
+    assert bot_token.kind == inspect.Parameter.KEYWORD_ONLY

--- a/ccgram-pro/tests/test_state.py
+++ b/ccgram-pro/tests/test_state.py
@@ -1,0 +1,243 @@
+"""Tests for ``ccgram_pro.state`` — sidecar round-trip + epoch + GC + locks."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+from ccgram_pro import state
+from ccgram_pro.config import ensure_layer_dirs, state_dir
+
+
+def _sidecar_file(tmp_path: Path, window_id: str) -> Path:
+    """Resolve the on-disk path the same way state._sidecar_path does."""
+    return state._sidecar_path(window_id)
+
+
+def test_save_and_load_round_trip() -> None:
+    ensure_layer_dirs()
+    sidecar = state.WindowSidecar(window_id="@1", window_creation_epoch=100.0)
+    sidecar.model = "sonnet"
+    sidecar.preamble_sent = True
+    state.save(sidecar)
+    loaded = state.load("@1")
+    assert loaded is not None
+    assert loaded.model == "sonnet"
+    assert loaded.preamble_sent is True
+    assert loaded.window_creation_epoch == 100.0
+
+
+def test_get_or_create_creates_when_missing() -> None:
+    sidecar = state.get_or_create("@2", live_window_creation_epoch=200.0)
+    assert sidecar.window_id == "@2"
+    assert sidecar.window_creation_epoch == 200.0
+    again = state.get_or_create("@2", live_window_creation_epoch=200.0)
+    assert again.window_creation_epoch == 200.0  # no rewrite
+
+
+def test_load_with_matching_epoch_returns_sidecar() -> None:
+    state.save(state.WindowSidecar(window_id="@3", window_creation_epoch=300.0))
+    loaded = state.load("@3", live_window_creation_epoch=300.0)
+    assert loaded is not None
+
+
+def test_load_with_mismatched_epoch_discards() -> None:
+    state.save(state.WindowSidecar(window_id="@4", window_creation_epoch=400.0))
+    loaded = state.load("@4", live_window_creation_epoch=500.0)
+    assert loaded is None
+    assert not _sidecar_file(state_dir(), "@4").exists()
+
+
+def test_load_with_zero_stored_epoch_does_not_discard() -> None:
+    """A stored epoch of 0 (legacy / migrated) must not trigger mismatch."""
+    state.save(state.WindowSidecar(window_id="@5", window_creation_epoch=0.0))
+    loaded = state.load("@5", live_window_creation_epoch=999.0)
+    assert loaded is not None
+
+
+def test_load_corrupt_json_quarantines() -> None:
+    ensure_layer_dirs()
+    path = _sidecar_file(state_dir(), "@6")
+    path.write_text("{not json")
+    assert state.load("@6") is None
+    assert not path.exists()
+    # Quarantined sibling created.
+    siblings = list(state_dir().glob("*.corrupt-*"))
+    assert len(siblings) == 1
+
+
+def test_load_top_level_non_dict_quarantines() -> None:
+    ensure_layer_dirs()
+    path = _sidecar_file(state_dir(), "@7")
+    path.write_text(json.dumps(["a", "list"]))
+    assert state.load("@7") is None
+    siblings = list(state_dir().glob("*.corrupt-*"))
+    assert len(siblings) == 1
+
+
+def test_delete_idempotent() -> None:
+    state.delete("@missing")  # must not raise
+
+
+def test_safe_window_id_rejects_path_traversal() -> None:
+    """ccgram.mailbox.sanitize_dir_name raises on '..', '/', '\\\\'."""
+    with pytest.raises(ValueError):
+        state.save(
+            state.WindowSidecar(window_id="../escape", window_creation_epoch=0.0)
+        )
+
+
+def test_safe_window_id_handles_qualified_id() -> None:
+    """Qualified ids like ``ccgram:@0`` should round-trip through the filename."""
+    state.save(state.WindowSidecar(window_id="ccgram:@0", window_creation_epoch=0.0))
+    loaded = state.load("ccgram:@0")
+    assert loaded is not None
+
+
+def test_all_sidecars_skips_non_json() -> None:
+    ensure_layer_dirs()
+    (state_dir() / "noise.txt").write_text("not json")
+    state.save(state.WindowSidecar(window_id="@8", window_creation_epoch=0.0))
+    sidecars = state.all_sidecars()
+    assert len(sidecars) == 1
+    assert sidecars[0].window_id == "@8"
+
+
+def test_gc_stale_refuses_empty_set_by_default() -> None:
+    state.save(state.WindowSidecar(window_id="@9", window_creation_epoch=0.0))
+    removed = state.gc_stale(set())
+    assert removed == 0
+    assert state.load("@9") is not None  # survived
+
+
+def test_gc_stale_force_wipes_everything() -> None:
+    state.save(state.WindowSidecar(window_id="@10", window_creation_epoch=0.0))
+    removed = state.gc_stale(set(), force=True)
+    assert removed == 1
+
+
+def test_gc_stale_removes_only_missing() -> None:
+    state.save(state.WindowSidecar(window_id="@a", window_creation_epoch=0.0))
+    state.save(state.WindowSidecar(window_id="@b", window_creation_epoch=0.0))
+    removed = state.gc_stale({"@a"})
+    assert removed == 1
+    assert state.load("@a") is not None
+    assert state.load("@b") is None
+
+
+def test_update_returns_none_when_absent() -> None:
+    assert state.update("@nonexistent", model="haiku") is None
+
+
+def test_update_applies_changes() -> None:
+    state.save(state.WindowSidecar(window_id="@u", window_creation_epoch=0.0))
+    updated = state.update("@u", model="haiku", preamble_sent=True)
+    assert updated is not None
+    assert updated.model == "haiku"
+    assert updated.preamble_sent is True
+    # Persisted, not just in memory.
+    again = state.load("@u")
+    assert again is not None
+    assert again.model == "haiku"
+
+
+def test_update_raises_on_unknown_field() -> None:
+    state.save(state.WindowSidecar(window_id="@bad", window_creation_epoch=0.0))
+    with pytest.raises(AttributeError, match="no field 'nope'"):
+        state.update("@bad", nope="oops")
+
+
+def test_batch_items_round_trip() -> None:
+    sidecar = state.WindowSidecar(window_id="@batch", window_creation_epoch=0.0)
+    sidecar.current_batch = [
+        state.BatchItem(kind="text", body="hello"),
+        state.BatchItem(kind="voice", body="hi", transcribing=True),
+    ]
+    state.save(sidecar)
+    loaded = state.load("@batch")
+    assert loaded is not None
+    assert len(loaded.current_batch) == 2
+    assert loaded.current_batch[0].body == "hello"
+    assert loaded.current_batch[1].transcribing is True
+
+
+def test_progress_bubble_round_trip() -> None:
+    sidecar = state.WindowSidecar(window_id="@bubble", window_creation_epoch=0.0)
+    sidecar.current_progress_bubble = {"thread_id": 42, "message_id": 999}
+    state.save(sidecar)
+    loaded = state.load("@bubble")
+    assert loaded is not None
+    assert loaded.current_progress_bubble == {"thread_id": 42, "message_id": 999}
+
+
+def test_atomic_write_cleans_up_temp_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If os.replace raises, the temp file must be removed."""
+    ensure_layer_dirs()
+    target = state_dir() / "doomed.json"
+
+    def boom(_src: str, _dst) -> None:  # noqa: ANN001 -- match os.replace signature loosely
+        raise OSError("simulated rename failure")
+
+    monkeypatch.setattr(state.os, "replace", boom)
+    with pytest.raises(OSError, match="simulated"):
+        state._atomic_write(target, "payload")
+    assert list(state_dir().glob("doomed.json.*.tmp")) == []
+
+
+async def test_transaction_serializes_concurrent_writers() -> None:
+    """Two concurrent transactions on the same window_id must serialize."""
+    state.save(state.WindowSidecar(window_id="@tx", window_creation_epoch=0.0))
+    order: list[str] = []
+
+    async def worker(name: str, delay: float) -> None:
+        async with state.transaction("@tx"):
+            order.append(f"{name}-enter")
+            await asyncio.sleep(delay)
+            order.append(f"{name}-exit")
+
+    # Start a slow worker first so the fast one must wait.
+    await asyncio.gather(worker("a", 0.05), worker("b", 0.0))
+    # Expected: a-enter, a-exit, b-enter, b-exit (or b before a — but never
+    # interleaved). Detect interleave: every -exit must come right after its
+    # own -enter without the other in between.
+    assert order[0].endswith("-enter")
+    assert order[1] == order[0].replace("-enter", "-exit")
+    assert order[2].endswith("-enter")
+    assert order[3] == order[2].replace("-enter", "-exit")
+
+
+async def test_transaction_lock_is_per_window() -> None:
+    """Different window_ids must not block each other."""
+    order: list[str] = []
+
+    async def worker(window_id: str, delay: float) -> None:
+        async with state.transaction(window_id):
+            order.append(f"{window_id}-enter")
+            await asyncio.sleep(delay)
+            order.append(f"{window_id}-exit")
+
+    await asyncio.gather(worker("@one", 0.05), worker("@two", 0.0))
+    # @two has no delay; it should enter and exit before @one exits.
+    assert "@two-exit" in order[: order.index("@one-exit")]
+
+
+def test_window_sidecar_defaults_model_is_opus() -> None:
+    """Phase 1 will resolve this to a Claude CLI --model arg; must be valid."""
+    sidecar = state.WindowSidecar(window_id="@d", window_creation_epoch=0.0)
+    assert sidecar.model == "opus"
+    assert sidecar.reasoning == "extra-high"
+    assert sidecar.batch_mode is True
+    assert sidecar.silent_mode is True
+
+
+def test_window_creation_epoch_fallback_to_time(tmp_path: Path) -> None:
+    """When live epoch not supplied, get_or_create uses time.time()."""
+    before = time.time()
+    sidecar = state.get_or_create("@time")
+    after = time.time()
+    assert before - 1.0 <= sidecar.window_creation_epoch <= after + 1.0

--- a/ccgram-pro/tests/test_wizard_env.py
+++ b/ccgram-pro/tests/test_wizard_env.py
@@ -1,0 +1,103 @@
+"""Tests for ``ccgram_pro.wizard.env`` — .env reader/writer round-trip."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ccgram_pro.wizard.env import read_env, update_env
+
+
+def test_read_env_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert read_env(tmp_path / "nope.env") == {}
+
+
+def test_read_env_parses_simple_assignments(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    f.write_text("FOO=bar\nBAZ=qux\n")
+    assert read_env(f) == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_read_env_ignores_comments_and_blank_lines(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    f.write_text("# header\n\nKEY=value\n# trailing\n")
+    assert read_env(f) == {"KEY": "value"}
+
+
+def test_read_env_strips_surrounding_quotes(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    f.write_text("KEY=\"quoted value\"\nOTHER='single'\n")
+    assert read_env(f) == {"KEY": "quoted value", "OTHER": "single"}
+
+
+def test_update_env_creates_file_when_missing(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    update_env(f, {"TELEGRAM_BOT_TOKEN": "1:abc"})
+    assert "TELEGRAM_BOT_TOKEN=1:abc" in f.read_text()
+
+
+def test_update_env_preserves_unknown_keys_and_comments(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    original = (
+        "# my notes\n"
+        "EXTERNAL_KEY=keepme\n"
+        "TELEGRAM_BOT_TOKEN=oldtoken\n"
+        "# trailing comment\n"
+    )
+    f.write_text(original)
+    update_env(f, {"TELEGRAM_BOT_TOKEN": "newtoken"})
+    out = f.read_text()
+    assert "# my notes" in out
+    assert "EXTERNAL_KEY=keepme" in out
+    assert "TELEGRAM_BOT_TOKEN=newtoken" in out
+    assert "TELEGRAM_BOT_TOKEN=oldtoken" not in out
+    assert "# trailing comment" in out
+
+
+def test_update_env_appends_new_keys_with_section_header(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    f.write_text("EXISTING=1\n")
+    update_env(f, {"NEW_KEY": "value"})
+    out = f.read_text()
+    assert "EXISTING=1" in out
+    assert "# Added by ccgram-pro setup" in out
+    assert "NEW_KEY=value" in out
+
+
+def test_update_env_quotes_values_with_spaces(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    update_env(f, {"PREAMBLE": "hello world"})
+    assert 'PREAMBLE="hello world"' in f.read_text()
+
+
+def test_update_env_bare_format_for_safe_values(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    update_env(f, {"TOKEN": "1234:Abc-Def_123"})
+    assert "TOKEN=1234:Abc-Def_123" in f.read_text()
+
+
+def test_update_env_escapes_embedded_quotes_and_backslashes(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    update_env(f, {"WEIRD": 'one "two" \\three'})
+    raw = f.read_text()
+    # The format_value escapes \ → \\ and " → \"
+    assert 'WEIRD="one \\"two\\" \\\\three"' in raw
+
+
+def test_update_env_empty_string_value(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    update_env(f, {"BLANK": ""})
+    assert "BLANK=" in f.read_text()
+
+
+def test_update_env_atomic_no_temp_files_left(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    update_env(f, {"K": "v"})
+    siblings = [p for p in tmp_path.iterdir() if p.name != ".env"]
+    assert siblings == []
+
+
+def test_update_env_round_trip(tmp_path: Path) -> None:
+    f = tmp_path / ".env"
+    update_env(f, {"A": "1", "B": "two words", "C": "x"})
+    parsed = read_env(f)
+    assert parsed == {"A": "1", "B": "two words", "C": "x"}

--- a/ccgram-pro/tests/test_wizard_validators.py
+++ b/ccgram-pro/tests/test_wizard_validators.py
@@ -1,0 +1,83 @@
+"""Tests for ``ccgram_pro.wizard.prompts`` validators."""
+
+from __future__ import annotations
+
+import pytest
+from ccgram_pro.wizard.prompts import (
+    is_valid_bot_token,
+    is_valid_https_url,
+    parse_user_ids,
+)
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi",
+        "987654321:A" + "x" * 34,
+        "100000:" + "0" * 35,
+    ],
+)
+def test_valid_bot_tokens(token: str) -> None:
+    assert is_valid_bot_token(token)
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "",
+        "no-colon",
+        "short:abc",
+        "12345:notlongenoughbyfar",
+        "abc:" + "x" * 35,  # numeric id missing
+        ":" + "x" * 35,  # empty id
+    ],
+)
+def test_invalid_bot_tokens(token: str) -> None:
+    assert not is_valid_bot_token(token)
+
+
+def test_parse_user_ids_single() -> None:
+    assert parse_user_ids("12345") == [12345]
+
+
+def test_parse_user_ids_multiple() -> None:
+    assert parse_user_ids("1, 2, 3") == [1, 2, 3]
+
+
+def test_parse_user_ids_accepts_semicolons() -> None:
+    assert parse_user_ids("1; 2; 3") == [1, 2, 3]
+
+
+def test_parse_user_ids_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        parse_user_ids("")
+
+
+def test_parse_user_ids_rejects_non_numeric() -> None:
+    with pytest.raises(ValueError, match="not an integer"):
+        parse_user_ids("1, abc, 3")
+
+
+def test_parse_user_ids_strips_whitespace_only_entries() -> None:
+    assert parse_user_ids("1,,2") == [1, 2]
+
+
+def test_https_url_accepts_real_urls() -> None:
+    assert is_valid_https_url("https://example.com")
+    assert is_valid_https_url("https://example.com/path?q=1")
+    assert is_valid_https_url("https://tunnel-abc.example.dev")
+
+
+def test_https_url_rejects_http() -> None:
+    assert not is_valid_https_url("http://example.com")
+
+
+def test_https_url_rejects_no_host() -> None:
+    assert not is_valid_https_url("https://")
+
+
+def test_https_url_rejects_garbage() -> None:
+    assert not is_valid_https_url("")
+    assert not is_valid_https_url("not a url")
+    assert not is_valid_https_url("ftp://example.com")

--- a/ccgram-pro/tests/test_workspaces.py
+++ b/ccgram-pro/tests/test_workspaces.py
@@ -1,0 +1,273 @@
+"""Tests for ``ccgram_pro.workspaces`` — clone, copy, install detect, manager."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+from ccgram_pro import state
+from ccgram_pro.config import (
+    WorkspaceSettings,
+    ensure_layer_dirs,
+    workspaces_dir,
+)
+from ccgram_pro.workspaces import manager
+from ccgram_pro.workspaces.copy_strategy import copy_workspace
+from ccgram_pro.workspaces.git_clone import (
+    clone_workspace,
+    is_git_repo,
+)
+from ccgram_pro.workspaces.install import (
+    detect_install_command,
+    resolve_install_command,
+    run_install,
+)
+from ccgram_pro.workspaces.paths import workspace_for_window
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)
+
+
+def _make_git_repo(root: Path, *, name: str = "src") -> Path:
+    """Create a tiny git repo with one commit and an uncommitted edit + untracked file."""
+    src = root / name
+    src.mkdir(parents=True, exist_ok=True)
+    _git(src, "init", "-q", "-b", "main")
+    _git(src, "config", "user.email", "test@example.com")
+    _git(src, "config", "user.name", "Test")
+    (src / "README.md").write_text("# initial\n", encoding="utf-8")
+    (src / "package.json").write_text('{"name":"t"}\n', encoding="utf-8")
+    _git(src, "add", ".")
+    _git(src, "commit", "-q", "-m", "initial")
+    # Uncommitted edit + untracked file the clone should optionally carry over.
+    (src / "README.md").write_text("# initial\n\nuncommitted\n", encoding="utf-8")
+    (src / "scratch.txt").write_text("untracked\n", encoding="utf-8")
+    return src
+
+
+def test_is_git_repo_detects_repo(tmp_path: Path) -> None:
+    src = _make_git_repo(tmp_path)
+    assert is_git_repo(src) is True
+
+
+def test_is_git_repo_false_for_plain_dir(tmp_path: Path) -> None:
+    (tmp_path / "plain").mkdir()
+    assert is_git_repo(tmp_path / "plain") is False
+
+
+def test_is_git_repo_false_for_missing_path(tmp_path: Path) -> None:
+    assert is_git_repo(tmp_path / "absent") is False
+
+
+async def test_clone_workspace_carries_head(tmp_path: Path) -> None:
+    src = _make_git_repo(tmp_path)
+    dest = workspaces_dir() / "@w1"
+    ensure_layer_dirs()
+    await clone_workspace(src, dest, transfer_uncommitted=False)
+    assert (dest / "README.md").read_text() == "# initial\n"
+    assert not (dest / "scratch.txt").exists()  # untracked, didn't transfer
+
+
+async def test_clone_workspace_carries_uncommitted_and_untracked(
+    tmp_path: Path,
+) -> None:
+    src = _make_git_repo(tmp_path)
+    dest = workspaces_dir() / "@w2"
+    ensure_layer_dirs()
+    await clone_workspace(src, dest, transfer_uncommitted=True)
+    assert "uncommitted" in (dest / "README.md").read_text()
+    assert (dest / "scratch.txt").read_text() == "untracked\n"
+
+
+async def test_clone_workspace_refuses_existing_destination(tmp_path: Path) -> None:
+    src = _make_git_repo(tmp_path)
+    dest = workspaces_dir() / "@w3"
+    ensure_layer_dirs()
+    dest.mkdir(parents=True)
+    from ccgram_pro.workspaces.git_clone import GitCloneError
+
+    with pytest.raises(GitCloneError):
+        await clone_workspace(src, dest, transfer_uncommitted=False)
+
+
+async def test_copy_workspace_uses_excludes(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "keep.txt").write_text("k\n", encoding="utf-8")
+    (src / "node_modules").mkdir()
+    (src / "node_modules" / "x").write_text("noise\n", encoding="utf-8")
+    dest = workspaces_dir() / "@w4"
+    ensure_layer_dirs()
+    await copy_workspace(src, dest)
+    assert (dest / "keep.txt").exists()
+    assert not (dest / "node_modules").exists()
+
+
+async def test_copy_workspace_refuses_missing_source(tmp_path: Path) -> None:
+    dest = workspaces_dir() / "@w5"
+    ensure_layer_dirs()
+    from ccgram_pro.workspaces.copy_strategy import CopyError
+
+    with pytest.raises(CopyError):
+        await copy_workspace(tmp_path / "nope", dest)
+
+
+def test_detect_install_command_pnpm(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text('{"name":"t"}', encoding="utf-8")
+    (tmp_path / "pnpm-lock.yaml").write_text("", encoding="utf-8")
+    assert detect_install_command(tmp_path) == "pnpm install --frozen-lockfile"
+
+
+def test_detect_install_command_uv(tmp_path: Path) -> None:
+    (tmp_path / "uv.lock").write_text("", encoding="utf-8")
+    assert detect_install_command(tmp_path) == "uv sync"
+
+
+def test_detect_install_command_npm_no_lock(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text('{"name":"t"}', encoding="utf-8")
+    assert detect_install_command(tmp_path) == "npm install"
+
+
+def test_detect_install_command_none_when_unknown(tmp_path: Path) -> None:
+    (tmp_path / "main.rs").write_text("fn main() {}", encoding="utf-8")
+    assert detect_install_command(tmp_path) is None
+
+
+def test_resolve_install_command_skip_on_empty_string(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text('{"name":"t"}', encoding="utf-8")
+    assert resolve_install_command(tmp_path, configured="") is None
+
+
+def test_resolve_install_command_user_override(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text('{"name":"t"}', encoding="utf-8")
+    assert resolve_install_command(tmp_path, configured="echo custom") == "echo custom"
+
+
+def test_resolve_install_command_autodetect_when_not_configured(tmp_path: Path) -> None:
+    (tmp_path / "uv.lock").write_text("", encoding="utf-8")
+    assert resolve_install_command(tmp_path, configured=None) == "uv sync"
+
+
+async def test_run_install_captures_output_and_succeeds(tmp_path: Path) -> None:
+    ensure_layer_dirs()
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    result = await run_install(workspace, "echo hi", timeout_seconds=10)
+    assert result.succeeded
+    log = (workspace / ".ccgram-install.log").read_text()
+    assert "hi" in log
+    assert "$ echo hi" in log
+
+
+async def test_run_install_records_nonzero_exit(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    result = await run_install(workspace, "sh -c 'exit 5'", timeout_seconds=10)
+    assert result.returncode == 5
+    assert not result.succeeded
+
+
+async def test_run_install_command_not_found(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    result = await run_install(
+        workspace, "definitely-not-a-real-cmd-xyz", timeout_seconds=10
+    )
+    assert result.returncode == 127
+    log = (workspace / ".ccgram-install.log").read_text()
+    assert "command not found" in log
+
+
+async def test_run_install_times_out(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    result = await run_install(workspace, "sleep 10", timeout_seconds=1)
+    assert result.returncode == 124
+    log = (workspace / ".ccgram-install.log").read_text()
+    assert "killed after" in log
+
+
+async def test_create_workspace_clones_and_writes_sidecar(tmp_path: Path) -> None:
+    src = _make_git_repo(tmp_path)
+    created = await manager.create_workspace(
+        "@m1",
+        src,
+        install_command="",  # skip install
+        settings=WorkspaceSettings(strategy="clone", transfer_uncommitted=True),
+    )
+    assert created.path == workspace_for_window("@m1")
+    assert created.path.exists()
+    assert (created.path / "scratch.txt").read_text() == "untracked\n"
+    sidecar = state.load("@m1")
+    assert sidecar is not None
+    assert sidecar.workspace_path == str(created.path)
+    assert sidecar.last_activity_at is not None
+    assert sidecar.project_path == str(src)
+
+
+async def test_create_workspace_falls_back_to_copy_for_non_git(tmp_path: Path) -> None:
+    src = tmp_path / "plain"
+    src.mkdir()
+    (src / "a.txt").write_text("hi", encoding="utf-8")
+    created = await manager.create_workspace(
+        "@m2",
+        src,
+        install_command="",
+        settings=WorkspaceSettings(strategy="clone"),  # auto-downgrades
+    )
+    assert (created.path / "a.txt").read_text() == "hi"
+
+
+async def test_create_workspace_refuses_missing_source(tmp_path: Path) -> None:
+    with pytest.raises(manager.WorkspaceCreationError):
+        await manager.create_workspace("@m3", tmp_path / "absent")
+
+
+async def test_create_workspace_refuses_existing_workspace(tmp_path: Path) -> None:
+    src = _make_git_repo(tmp_path)
+    workspace = workspace_for_window("@m4")
+    workspace.parent.mkdir(parents=True, exist_ok=True)
+    workspace.mkdir()
+    with pytest.raises(manager.WorkspaceCreationError):
+        await manager.create_workspace("@m4", src, install_command="")
+
+
+async def test_delete_workspace_removes_dir_and_clears_sidecar(tmp_path: Path) -> None:
+    src = _make_git_repo(tmp_path)
+    await manager.create_workspace(
+        "@m5", src, install_command="", settings=WorkspaceSettings()
+    )
+    sidecar_before = state.load("@m5")
+    assert sidecar_before is not None
+    assert sidecar_before.workspace_path is not None
+    removed = await manager.delete_workspace("@m5")
+    assert removed is True
+    assert not workspace_for_window("@m5").exists()
+    sidecar_after = state.load("@m5")
+    assert sidecar_after is not None
+    assert sidecar_after.workspace_path is None
+    assert sidecar_after.last_activity_at is None
+
+
+async def test_delete_workspace_returns_false_when_missing(tmp_path: Path) -> None:
+    assert await manager.delete_workspace("@never-existed") is False
+
+
+async def test_touch_activity_updates_sidecar(tmp_path: Path) -> None:
+    state.save(state.WindowSidecar(window_id="@touch", window_creation_epoch=0.0))
+    before = time.time()
+    await asyncio.sleep(0.01)
+    await manager.touch_activity("@touch")
+    sidecar = state.load("@touch")
+    assert sidecar is not None
+    assert sidecar.last_activity_at is not None
+    assert sidecar.last_activity_at >= before
+
+
+async def test_touch_activity_no_op_when_sidecar_missing() -> None:
+    # Should NOT raise.
+    await manager.touch_activity("@no-sidecar")

--- a/ccgram-pro/tests/test_workspaces_gc.py
+++ b/ccgram-pro/tests/test_workspaces_gc.py
@@ -1,0 +1,119 @@
+"""Tests for ``ccgram_pro.workspaces.gc`` — idle + orphan sweep."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from ccgram_pro import state
+from ccgram_pro.config import (
+    WorkspaceSettings,
+    ensure_layer_dirs,
+    workspaces_dir,
+)
+from ccgram_pro.workspaces import gc
+from ccgram_pro.workspaces.paths import workspace_for_window
+
+
+def _make_sidecar_with_workspace(window_id: str, *, age_days: int) -> Path:
+    ensure_layer_dirs()
+    ws = workspace_for_window(window_id)
+    ws.mkdir(parents=True)
+    (ws / "marker").write_text("x", encoding="utf-8")
+    sidecar = state.WindowSidecar(
+        window_id=window_id,
+        window_creation_epoch=0.0,
+        workspace_path=str(ws),
+        last_activity_at=time.time() - age_days * 86400,
+    )
+    state.save(sidecar)
+    return ws
+
+
+def test_sweep_removes_idle_workspaces(tmp_path: Path) -> None:
+    old = _make_sidecar_with_workspace("@old", age_days=10)
+    young = _make_sidecar_with_workspace("@young", age_days=1)
+    result = gc.sweep(settings=WorkspaceSettings(idle_days=5))
+    assert result.idle_removed == 1
+    assert not old.exists()
+    assert young.exists()
+    # Sidecar fields cleared on the idle one.
+    cleared = state.load("@old")
+    assert cleared is not None
+    assert cleared.workspace_path is None
+    assert cleared.last_activity_at is None
+    # Untouched on the live one.
+    survivor = state.load("@young")
+    assert survivor is not None
+    assert survivor.workspace_path is not None
+
+
+def test_sweep_idle_skips_sidecar_with_no_workspace(tmp_path: Path) -> None:
+    sidecar = state.WindowSidecar(window_id="@no-ws", window_creation_epoch=0.0)
+    state.save(sidecar)
+    result = gc.sweep(settings=WorkspaceSettings(idle_days=5))
+    assert result.idle_removed == 0
+
+
+def test_sweep_idle_skips_sidecar_with_no_activity_timestamp(tmp_path: Path) -> None:
+    """A workspace without last_activity_at is treated as "just created", not orphan."""
+    ensure_layer_dirs()
+    ws = workspace_for_window("@just-made")
+    ws.mkdir(parents=True)
+    sidecar = state.WindowSidecar(
+        window_id="@just-made",
+        window_creation_epoch=0.0,
+        workspace_path=str(ws),
+        last_activity_at=None,
+    )
+    state.save(sidecar)
+    result = gc.sweep(settings=WorkspaceSettings(idle_days=5))
+    assert result.idle_removed == 0
+    assert ws.exists()
+
+
+def test_sweep_removes_orphan_workspace_directories(tmp_path: Path) -> None:
+    """Workspaces on disk without an owning sidecar should be cleaned up."""
+    ensure_layer_dirs()
+    orphan = workspaces_dir() / "orphan-window"
+    orphan.mkdir(parents=True)
+    (orphan / "stuff").write_text("noise", encoding="utf-8")
+    result = gc.sweep(settings=WorkspaceSettings())
+    assert result.orphans_removed == 1
+    assert not orphan.exists()
+
+
+def test_sweep_does_not_remove_stage_dirs(tmp_path: Path) -> None:
+    """Active staging dirs from a concurrent provisioning must survive sweep."""
+    ensure_layer_dirs()
+    stage = workspaces_dir() / "@x.stage-abc"
+    stage.mkdir(parents=True)
+    result = gc.sweep(settings=WorkspaceSettings())
+    assert stage.exists()
+    assert result.orphans_removed == 0
+
+
+def test_sweep_total_combines_idle_and_orphans(tmp_path: Path) -> None:
+    _make_sidecar_with_workspace("@old1", age_days=10)
+    _make_sidecar_with_workspace("@old2", age_days=12)
+    ensure_layer_dirs()
+    (workspaces_dir() / "orphan").mkdir(parents=True)
+    result = gc.sweep(settings=WorkspaceSettings(idle_days=5))
+    assert result.idle_removed == 2
+    assert result.orphans_removed == 1
+    assert result.total == 3
+
+
+def test_sweep_handles_missing_workspaces_dir(tmp_path: Path, monkeypatch) -> None:
+    """A fresh layout with no workspaces_dir() yet must not crash the GC."""
+    # Don't call ensure_layer_dirs — leave workspaces_dir absent.
+    result = gc.sweep(settings=WorkspaceSettings())
+    assert result.total == 0
+
+
+def test_sweep_now_override_is_respected(tmp_path: Path) -> None:
+    _make_sidecar_with_workspace("@frozen", age_days=0)
+    # Force "now" to be 100 days in the future; sidecar becomes very stale.
+    far_future = time.time() + 100 * 86400
+    result = gc.sweep(now=far_future, settings=WorkspaceSettings(idle_days=5))
+    assert result.idle_removed == 1

--- a/ccgram-pro/uv.lock
+++ b/ccgram-pro/uv.lock
@@ -1,0 +1,762 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
+    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
+    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+]
+
+[[package]]
+name = "aiolimiter"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/23/b52debf471f7a1e42e362d959a3982bdcb4fe13a5d46e63d28868807a79c/aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9", size = 7185, upload-time = "2024-12-08T15:31:51.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/ba/df6e8e1045aebc4778d19b8a3a9bc1808adb1619ba94ca354d9ba17d86c3/aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7", size = 6711, upload-time = "2024-12-08T15:31:49.874Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "ccgram"
+source = { editable = "../" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "httpx" },
+    { name = "libtmux" },
+    { name = "pathspec" },
+    { name = "pillow" },
+    { name = "pyte" },
+    { name = "python-dotenv" },
+    { name = "python-telegram-bot", extra = ["rate-limiter", "socks"] },
+    { name = "structlog" },
+    { name = "telegramify-markdown" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiofiles", specifier = ">=24.0.0" },
+    { name = "aiohttp", specifier = ">=3.10" },
+    { name = "click", specifier = ">=8.1.0" },
+    { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "edge-tts", marker = "extra == 'tts'", specifier = ">=7.2.8" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "libtmux", specifier = ">=0.50.0" },
+    { name = "pathspec", specifier = ">=0.12" },
+    { name = "pillow", specifier = ">=10.0.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
+    { name = "pyte", specifier = ">=0.8.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-telegram-bot", extras = ["rate-limiter", "socks"], specifier = ">=21.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "structlog", specifier = ">=24.0.0" },
+    { name = "telegramify-markdown", specifier = ">=1.0.0" },
+]
+provides-extras = ["dev", "tts"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-xdist", specifier = ">=3.8.0" }]
+
+[[package]]
+name = "ccgram-pro"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "ccgram" },
+    { name = "click" },
+    { name = "structlog" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "ccgram", editable = "../" },
+    { name = "click", specifier = ">=8.1.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "structlog", specifier = ">=24.0.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
+    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
+    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
+    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
+    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
+    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
+]
+
+[[package]]
+name = "idna"
+version = "3.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "libtmux"
+version = "0.58.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/4e/daccd4fd72ad3f17b8fb97f69403774d6c510b5d513521b454fdaedb0561/libtmux-0.58.0.tar.gz", hash = "sha256:abbe330bec2c45687a4bf417ee436373b37046afe123ba547495ee0448e1145a", size = 522080, upload-time = "2026-05-23T16:03:38.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d5/1cee7c13865d0d55ddb54709aaf85e0dc645e2998ce85ffce2c36d3bf08d/libtmux-0.58.0-py3-none-any.whl", hash = "sha256:1aec9875983a8eb121a8de7be7dffa6b97d9754c013ce960944d058764e47ec3", size = 113680, upload-time = "2026-05-23T16:03:37.049Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/ea/23ee535d90ce8bcc465a3028eb3cc0ce3bd1005f4bb27710b30587de798d/propcache-0.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:46088abff4cba581dea21ae0467a480526cb25aa5f3c269e909f800328bc3999", size = 94662, upload-time = "2026-05-08T21:01:22.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fc88b26f08d634f7bc819a7852e5214f5802641ab8d9fd5326892292eee1993e", size = 53928, upload-time = "2026-05-08T21:01:23.986Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b1/4260d67d6bd85e58a66b72d54ce15d5de789b6f3870cc6bedf8ff9667401/propcache-0.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97797ebb098e670a2f92dd66f32897e30d7615b14e7f59711de23e30a9072539", size = 54650, upload-time = "2026-05-08T21:01:25.305Z" },
+    { url = "https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba57fffe4ac99c5d30076161b5866336d97600769bad35cc68f7774b15298a4e", size = 59912, upload-time = "2026-05-08T21:01:26.545Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/29/fe1aebec2ce57ab985a9c382bded1124431f85078113aa222c5d278430d4/propcache-0.5.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:583c19759d9eec1e5b69e2fbef36a7d9c326041be9746cb822d335c8cedc2979", size = 63300, upload-time = "2026-05-08T21:01:27.937Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/18/2334b26768b6c82be8c69e83671b767d5ef426aa09b0cba6c2ea47816774/propcache-0.5.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d0326e2e5e1f3163fa306c834e48e8d490e5fae607a097a40c0648109b47ba80", size = 64208, upload-time = "2026-05-08T21:01:29.484Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/76/7f1bfd6afff4c5e38e36a3c6d68eb5f4b7311ea80baf693db78d95b603c4/propcache-0.5.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e00820e192c8dbebcafb383ebbf99030895f09905e7a0eb2e0340a0bcc2bc825", size = 61633, upload-time = "2026-05-08T21:01:31.068Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/46/b3ff8aba2b4953a3e50de2cf72f1b5748b8eca93b15f3dc2c84339084c09/propcache-0.5.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c66afea89b1e43725731d2004732a046fe6fe955d51f952c3e95a7314a284a39", size = 61724, upload-time = "2026-05-08T21:01:32.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/01/814cfcafbcff954f94c01cf30e097ddc88a076b5440fbcf4570753437d40/propcache-0.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d4dc37dec6c6cdad0b57881a5658fd14fbf53e333b1a86cf86559f190e1d9ec4", size = 60069, upload-time = "2026-05-08T21:01:33.67Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/5c6f7622d510cc666a300687e06fd060c1a43361c0c9b20d284f06d8096a/propcache-0.5.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5570dbcc97571c15f68068e529c92715a12f8d54030e272d264b377e22bd17a5", size = 57099, upload-time = "2026-05-08T21:01:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/55/27/9cb0b4c679124085327957d42521c99dba04c88c90c3e55a6f0b633ebccc/propcache-0.5.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f814362777a9f841adddb200ecdf8f5cb1e5a3c4b7a86378edbd6ccb26edd702", size = 63391, upload-time = "2026-05-08T21:01:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9d/7258aaa5bdf60fc6f27591eef6fe52768cb0beda7140be477c8b12c9794a/propcache-0.5.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:196913dea116aeb5a2ba95af4ddcb7ea85559ae07d8eee8751688310d09168c3", size = 61626, upload-time = "2026-05-08T21:01:37.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/41c602003e8a9b16fe1e7eadf62c7bfba9d5474370b24200bf48b315f45f/propcache-0.5.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6e7b8719005dd1175be4ab1cd25e9b98659a5e0347331506ec6760d2773a7fb5", size = 64781, upload-time = "2026-05-08T21:01:38.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f3/38e66b1856e9bd079deea015bc4a55f7767c0e4db2f7dcf69e7e680ba4ce/propcache-0.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:51f96d685ab16e88cab128cd37a52c5da540809c8b879fa047731bfcb4ad35a4", size = 62570, upload-time = "2026-05-08T21:01:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ca/bbfe9b910ce57dde8bb4876b4520fc02a4e89497c10de26be936758a3aaa/propcache-0.5.2-cp314-cp314-win32.whl", hash = "sha256:cc6fc3cc62e8501d3ed62894425040d2728ecddb1ed072737a5c70bd537aa9f0", size = 39436, upload-time = "2026-05-08T21:01:41.654Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:81e3a30b0bb60caa22033dd0f8a3618d1d67356212514f62c57db75cb0ef410c", size = 42373, upload-time = "2026-05-08T21:01:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/44/68/9ea5103f41d5217d7d6ec24db90018e23aebec070c3f9a6e54d12b841fd8/propcache-0.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:0d2c9bf8528f135dbb805ce027567e09164f7efa51a2be07458a2c0420f292d0", size = 38554, upload-time = "2026-05-08T21:01:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/81/fadf555f42d3b762eea8a53950b0489fdc0aa9da5f8ed9e10ce0a4e01b48/propcache-0.5.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4bc8ff1feffc6a61c7002ffe84634c41b822e104990ae009f44a0834430070bb", size = 99395, upload-time = "2026-05-08T21:01:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c9/c61e134a686949cf7971af3a390148b1156f7be81c73bc0cd12c873e2d48/propcache-0.5.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:79aa3ff0a9b566633b642fa9caf7e21ed1c13d6feca718187873f199e1514078", size = 56653, upload-time = "2026-05-08T21:01:47.307Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/daf935ea7048ddd7ec8eec5345b4a40b619d2d178b3c0a0900796bc3c794/propcache-0.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1b31822f4474c4036bae62de9402710051d431a606d6a0f907fec79935a071aa", size = 56914, upload-time = "2026-05-08T21:01:48.573Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9f/aba959b435ea18617edd7cf0a7ad0b9c574b8fc7e3d2cd55fb59cb255d33/propcache-0.5.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fef48778b5a2a756523fdb781326b028ca75e32858b04f2cdd19f394564917", size = 62567, upload-time = "2026-05-08T21:01:49.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a1/859942de9a791ff42f6141736f5b37749b8f53e65edfa49638c67dd67e6a/propcache-0.5.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8b73ab70f1a3351fbc71f663b3e645af6dd0329100c353081cf69c37433fc6fe", size = 65542, upload-time = "2026-05-08T21:01:51.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/61/315bc0fd6c0fc7f80a528b8afd209e5fc4a875ea79571b91b8f50f442907/propcache-0.5.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5538d2c13d93e4698af7e092b57bc7298fd35d1d58e656ae18f23ee0d0378e03", size = 66845, upload-time = "2026-05-08T21:01:52.539Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f7/9f8122e3132e8e354ac41975ef8f1099be7d5a16bc7ae562734e993665c0/propcache-0.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd645f03898405cabe694fb8bc35241e3a9c332ec85627584fe3de201452b335", size = 63985, upload-time = "2026-05-08T21:01:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/54/c317819ec157cbf6f35df9df9657a6f82daf34d5faf15948b2f639c2192e/propcache-0.5.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a473b3440261e0c60706e732b2ed2f517857344fc21bf48fdfe211e2d98eb285", size = 63999, upload-time = "2026-05-08T21:01:55.179Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/387e3f7dfce0a9233df41fb888aa1c30222cb4bbbf09537c02dd9bd85fe2/propcache-0.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7afa37062e6650640e932e4cc9297d81f9f42d9944029cc386b8247dea4da837", size = 62779, upload-time = "2026-05-08T21:01:57.489Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9c/596784cb5824ed61ee960d3f8655a3f0993e107c6e98ab6c818b7fb92ccb/propcache-0.5.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8a90efd5777e996e42d568db9ac740b944d691e565cbfd31b2f7832f9184b2b8", size = 59796, upload-time = "2026-05-08T21:01:58.736Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/3d/1a6cfa1726a48542c1e8784a0761421476a5b68e09b7f36bf95eb954aaba/propcache-0.5.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:f19bb891234d72535764d703bfed1153cc34f4214d5bd7150aee1eec9e8f4366", size = 66023, upload-time = "2026-05-08T21:02:00.228Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0e/05fd6990369477076e4e280bcb970de760fddf0161a46e988bc95f7940ec/propcache-0.5.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:32775082acd2d807ee3db715c7770d38767b817870acfa08c29e057f3c4d5b56", size = 64448, upload-time = "2026-05-08T21:02:01.888Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/86/5f8da315a4309c62c10c0b2516b17492d5d3bbe1bb862b96604db67e2a37/propcache-0.5.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9282fb1a3bccd038da9f768b927b24a0c753e466c086b7c4f3c6982851eefb2d", size = 67329, upload-time = "2026-05-08T21:02:03.484Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d3/3368efe79ab21f0cdf86ef49895811c9cc933131d4cde1f28a624e22e712/propcache-0.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc49723e2f60d6b32a0f0b08a3fd6d13203c07f1cd9566cfce0f12a917c967a2", size = 65172, upload-time = "2026-05-08T21:02:04.745Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/07/127e8b0bacfb325396196f9d976a22453049b89b9b2b08477cc3145faa44/propcache-0.5.2-cp314-cp314t-win32.whl", hash = "sha256:2d7aa89ebca5acc98cba9d1472d976e394782f587bad6661003602a619fd1821", size = 43813, upload-time = "2026-05-08T21:02:06.025Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+]
+
+[[package]]
+name = "pyromark"
+version = "0.9.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/a3/b46d6253b3a07d1116080864ecf00fc6d3456b1978d4b5b7df3c0022903e/pyromark-0.9.11.tar.gz", hash = "sha256:cef5de337efc14544a3bdc27fd67a1e84096209c8ba28153202bf1f471b0dcec", size = 9090, upload-time = "2026-05-24T22:19:28.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/a4/e6e0995fa79d3fb05a71f1aa2c587e988247c04e58c3d905c309c05b6b0a/pyromark-0.9.11-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4ab000c6507b3b7e5c44f86d6ac9087f9fe2037bf76c18ea94fe9b0fc00bfeb1", size = 347141, upload-time = "2026-05-24T22:22:58.002Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b1/35229efeb45136581b5d2e03220cfa969b87d32df520d2318ebad84a6c67/pyromark-0.9.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:edacbabfced967c2752e826af36b0f335163c212154f682de40c25dfb9634e10", size = 329689, upload-time = "2026-05-24T22:21:52.142Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/05/fe95ecf4a2e29654e93ce44ae48a63efee08ac667cd570094dad6a26de9b/pyromark-0.9.11-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2044ccd2ceff6b3bdd1b2049359e80f85d50e10bca74cbf6e0ec15702e88fbb0", size = 362984, upload-time = "2026-05-24T22:23:06.392Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/eea6a4a86468242990175e5c42e5870cd5b809e85f5ce79d5cb3f8db841b/pyromark-0.9.11-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7b58b29fd60ff4e96f902cb77a3a1d23845770174f502c3287f76c7ee7f7d088", size = 361240, upload-time = "2026-05-24T22:19:30.21Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1b/13906bcdbd05f10746ac0e87a6c6391728b2a4c3bda8995c8d8a1b7b021a/pyromark-0.9.11-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:77212a23f21bd4ac2ba935fa7a81e237e90c3157f738bfb37884e939809d570a", size = 387018, upload-time = "2026-05-24T22:19:12.272Z" },
+    { url = "https://files.pythonhosted.org/packages/91/07/c2c3ecc3a387c9e880b9a47db6cc68021fd4c2456c6eef4cc6132b49fdaf/pyromark-0.9.11-cp314-cp314-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e04fba581cfc1304a65447e85990ed0bd3c27d3ee55de93397f6fc3d01f9ab57", size = 417669, upload-time = "2026-05-24T22:20:58.161Z" },
+    { url = "https://files.pythonhosted.org/packages/72/45/5c6bc54688c77bc22f5e9918601a13007b5dbef45cc89b5e582657d25368/pyromark-0.9.11-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6143a312a783144979c69a6ec180f4d148fc41d063a7d2cd938cc7edfb5aac0d", size = 409519, upload-time = "2026-05-24T22:19:58.001Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b2/8b572ee152c0d6b461132e4c408cdc7833fb1ab6f18721622ccbecf2f357/pyromark-0.9.11-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5c751e1a269007ccefe177316b08dcfc09efc7debc549450d98a9563878c7b8c", size = 448060, upload-time = "2026-05-24T22:20:28.137Z" },
+    { url = "https://files.pythonhosted.org/packages/77/33/ed6eaccf2c692da8987f5efa70c4d70b1750fba2102ab2a6b83e107ea80d/pyromark-0.9.11-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d6b38603efb313ded143a3836082c0a2cdf3b92dc314795ed43d72c0d818304", size = 371338, upload-time = "2026-05-24T22:18:38.359Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/91dc78be20a481f727da6887f3477a4b5f7388a768966a2f3524870d5bc8/pyromark-0.9.11-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:faf026af5c90c73f18d05ab267b073aba8a145c954af5894fbb42d7287d742ff", size = 363598, upload-time = "2026-05-24T22:19:44.354Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/a9/963f92bd732c1fb889896730d6ae54ea02ed95bec9207f48741467330902/pyromark-0.9.11-cp314-cp314-manylinux_2_28_armv7l.whl", hash = "sha256:83564a870f4a081e90e13deb5ab483e2c48130d3ef7e34afda2d74db8111ce02", size = 361231, upload-time = "2026-05-24T22:19:25.219Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cf/3a3ab3915314062762730baf13a6085fef69df55b8bef98c93b1af22bb5b/pyromark-0.9.11-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:337f0e57aeeda6993ed4d2695437ca6c2821a60df794b0de89fa22950f7d5aa5", size = 387300, upload-time = "2026-05-24T22:22:26.876Z" },
+    { url = "https://files.pythonhosted.org/packages/99/dc/4c497732a5c9f5e7abff266b3ac9b85d50513ec6c685ad3d6323b283ff93/pyromark-0.9.11-cp314-cp314-manylinux_2_28_ppc64le.whl", hash = "sha256:9739c4ac35926bec56abd112f208845e94cd440f757a3dacfb11dbd29ec9cf1e", size = 409636, upload-time = "2026-05-24T22:19:17.832Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a6/05a9b913f3393082d90a5db1e928c6790a374b98c1c7fede32aa25f577ba/pyromark-0.9.11-cp314-cp314-manylinux_2_28_s390x.whl", hash = "sha256:ff024a8d19d792d1728c9bc1f03f697fb4dbe14ae02854b23d74909c42c134d1", size = 447742, upload-time = "2026-05-24T22:19:23.755Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/43/011b930f0c5d0288aba1b9de6a947f2e71e2bdfc90b56ae70d6fdd81c572/pyromark-0.9.11-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:2d88478728353f95582a594f734b6a2c85ba31c3dc6af7f9122055ed8d3e88b5", size = 371594, upload-time = "2026-05-24T22:21:37.504Z" },
+    { url = "https://files.pythonhosted.org/packages/00/80/049d0a3c74cd1c436824ced55d136c339496337ae5a68614d31f1c177042/pyromark-0.9.11-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:26d52ebce02df169d2de1cf17b8db07eb4f2c5a543c651f6e15caf8ae6ecd783", size = 372069, upload-time = "2026-05-24T22:21:22.936Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f6/d7197ea8aaf9bee0d1ef88c9e4bd48bb59560fde767f0003b0adcfc5014c/pyromark-0.9.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb789d2d1f13d0efabf9ae2ef85d2fb483440653f54260198477a32a66a0fae0", size = 540529, upload-time = "2026-05-24T22:19:33.992Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/47/b403cf8f75aa5a854352ae1b8eb98923ac4089f8d1fcb77771921e72512a/pyromark-0.9.11-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0837914b0c335ba2ea7285c4a44535506bc68b0dc08ebc54bfe1a9b016b7fbde", size = 637913, upload-time = "2026-05-24T22:19:41.757Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/6ba2aa1364c0b8c46999dfbec8648df22043dbb416500fa95ab3b410abdd/pyromark-0.9.11-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:3923bfa9cfdde43b78c3c7abdedd353b17c245cc4a7de9147e451cfe093c21c7", size = 604815, upload-time = "2026-05-24T22:20:32.717Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b2/0b66636e267a5a469854fcb99b868c8d5f822893919d6bab5b0e9beb626e/pyromark-0.9.11-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:49ef7e711e0b62259878b38e7dd2eb6823cce1da237728e9c2117dfef667df93", size = 540311, upload-time = "2026-05-24T22:19:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/86/a04b45c16a009e3027be2c2d107ed1d09015637718860430d08633448630/pyromark-0.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:634cb7a2cd473d93e1d244d7527f3e215b2c1670fd664d1532e29b3d043f98b0", size = 546082, upload-time = "2026-05-24T22:18:36.206Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/6e/64a8ce53f9abd4f8c7ef1c892efe52dd32440b149b6d51c68761b3773cf4/pyromark-0.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cad96a7b37a386bbcbac01d350cf6d55b78f69a4dbff812d895a6e584fe35e1f", size = 590821, upload-time = "2026-05-24T22:22:25.246Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4c/d8d2267317a8edfd29a25395ca11f0204ec59fb3ffbd75599c7fa7ef1507/pyromark-0.9.11-cp314-cp314-win32.whl", hash = "sha256:fcc29565e1d251d588d7f91dae83cb32770d758f81212a680ceea555aaef3a99", size = 260937, upload-time = "2026-05-24T22:19:16.802Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/97/0b5082e24276909df1d70299ad3c1b6353bbfcfae3c4887303ca0248fb20/pyromark-0.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:0c13f278d03b0f4b321fd78fef25d3b72e5d19bed8e3464c71318265f0d2f04d", size = 273222, upload-time = "2026-05-24T22:18:48.08Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1a/20f3178384dfdc0d126f9d91cc05b7970f83867f5eb78f8a77a06188d282/pyromark-0.9.11-cp314-cp314-win_arm64.whl", hash = "sha256:0b90ab42108f479d6de4508e65edab4b1c904217ed77919eacb2bbe0817fa3fb", size = 258753, upload-time = "2026-05-24T22:21:53.429Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/aeff3c7ba70aeff34c6b28bf012575b33490c42bac99f2b69f5a4f9fde5b/pyromark-0.9.11-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:6d21c4c7cd823a39d79d6140b4f2b23e1d3fac53e202d729781e349bb7ec85cf", size = 345678, upload-time = "2026-05-24T22:19:35.354Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b4/c570e14e75ad752f1575065657fd9c300b1c2ae0fd6c93d2a38ab153fa1a/pyromark-0.9.11-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:15e989f24275834873bc6968b77dd214497fcc4d6f4f562e2703469b453ed99f", size = 328498, upload-time = "2026-05-24T22:19:45.533Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ea/5f07fc67f4f0af5a6c0ec2f2f2557bc426ef55f509c00a1cc0c2ff5ed241/pyromark-0.9.11-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:581dd4a29754a7fa007f3ea67142fbe59e7a2f86f0d4402ce8bc6af66f82cad0", size = 361320, upload-time = "2026-05-24T22:20:59.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/ba6de85c6e2f952e83624ca162a8a51740175750dc02eb17b0305285d271/pyromark-0.9.11-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e036669d6990258331a7bc303cf5dc5c001783f15d53b769a34ea7ba7ff5d1dc", size = 359148, upload-time = "2026-05-24T22:22:40.48Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/8c/39ad5a4fad0a46f4b0fbb76c33703ea38a903858b36c528c14c9d7512e46/pyromark-0.9.11-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:439181484e0eb660b68962fcd5868adc92db32ce1503948546ac9e96fc26b287", size = 385059, upload-time = "2026-05-24T22:19:40.149Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e2/65cc812aece6cc4880f9909ae71eb2e14f655eb116418d82b97c5d60ebd0/pyromark-0.9.11-cp314-cp314t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:051f9af79107b024488a423c0ac1563eb55f946700dd10ffe72db1a6e2bc675b", size = 416203, upload-time = "2026-05-24T22:20:35.711Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/3b/cd470a8c9188c8159729c9ce7de1c47dabbf35ae5cbfcd77fc9fe2b27e1f/pyromark-0.9.11-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3ea9568d17b1ef94d1e951d1e8cb351614ea078dd8bb46bca5d5ab6541266583", size = 407225, upload-time = "2026-05-24T22:18:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/1f/35b911f1b66401da26ed46b8b4fce99b04ee1382532a7188f30b3b2ed44b/pyromark-0.9.11-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d9745842b06509c4f425fc31cbb97a80c1754135f396672cd142a84c216a1668", size = 445917, upload-time = "2026-05-24T22:20:44.409Z" },
+    { url = "https://files.pythonhosted.org/packages/34/da/0e9d205b6fc4947c8280c89d9816dd68918a877096d583570682e1290676/pyromark-0.9.11-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6efca2fb6022011b501454b8a09ac280db94dbd840fe0f83bd4d5688dc044944", size = 369625, upload-time = "2026-05-24T22:18:49.027Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d4/f4fd5c9db786345eb1d0a84798fac4601e34dbff21f4852bd522a192407a/pyromark-0.9.11-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fe125b76e53994adc8bb14a59f582a912adee2d7f3614875729dd1e0fe23187b", size = 362002, upload-time = "2026-05-24T22:21:02.274Z" },
+    { url = "https://files.pythonhosted.org/packages/28/11/cf271b215d98531a8c24ecce7baae9003d3b5a726ef828b72790921fbc89/pyromark-0.9.11-cp314-cp314t-manylinux_2_28_armv7l.whl", hash = "sha256:48adb71a94530f29cb0f0de2b9aa6ca039d81345bec77d6059066352609bcdb1", size = 359172, upload-time = "2026-05-24T22:21:18.123Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/57/a5705bdd1e3687df643aba383a4971d2aca240080d997d746eecaed9b382/pyromark-0.9.11-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:0ed5ca997d906eb954235c61aef3b95ec5193cf54916fcda16a46e76814b9aed", size = 385505, upload-time = "2026-05-24T22:20:12.488Z" },
+    { url = "https://files.pythonhosted.org/packages/48/23/0aa20e8c9e974dd93057ec3d4283e945ed181fd917cbafe2f685c475d290/pyromark-0.9.11-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:174b20eab1bef372735c8eb6398f66eec93b5e7e0316a0952730785b83750011", size = 407332, upload-time = "2026-05-24T22:19:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/94/ed1dedaae23143173dc29ea1349409568b929a133c8474a9b1e195b5f5f8/pyromark-0.9.11-cp314-cp314t-manylinux_2_28_s390x.whl", hash = "sha256:9e7af952342e7394bee512cea64aebc8cd8e1e3ac989cddbc47128e3e411e8b5", size = 445708, upload-time = "2026-05-24T22:21:01.024Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f6/2e146609876e90eac22e75d0391b23e30eb6ddc64f5463edf5422e1429eb/pyromark-0.9.11-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:63589190815986e5c6f5bf66aa336bcaa9ee5e90796dff66b480001ca2eda12b", size = 369988, upload-time = "2026-05-24T22:20:14.844Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3c/c53ebcd8d0bb3e605155ce90474a34b8384ca6abcb0d711ddf25e4852806/pyromark-0.9.11-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b9ac6dc765604a47b7268e78910344980cc2fd0a137c02cf217e4e1072fc355d", size = 370582, upload-time = "2026-05-24T22:21:47.277Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/72/313075d5fc4a78a59ec5259ed75ba3274a7c11786ab3080d801b9ab8bad4/pyromark-0.9.11-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f1459db160281d6e6cf1ac234207bcc781c46ea4de6c1dc2c467023944950d13", size = 539038, upload-time = "2026-05-24T22:19:50.302Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4b/0674c8bff3cc038eb0b33da13ae42129310da078410ec78fa6608ca0b9f6/pyromark-0.9.11-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:156cb4db0911fd6037768e7d31b3571f2309955c9fa29a193d24ce4f26b0e4ed", size = 635924, upload-time = "2026-05-24T22:21:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1b/03271177d632ef73132110215261886869a8cfdc1028fd520a78029596aa/pyromark-0.9.11-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:599fd85d8be2ab6d602b36b3f52b92a959738344e6c1ce569457aa3dae96e8f5", size = 603053, upload-time = "2026-05-24T22:22:00.338Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/62/b10c4aa0903c49cc6b227df3bc18322dfeb4f6d6594e02986284e98a2069/pyromark-0.9.11-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a9797732d5bb2555474f0fbfdb6e29eb5431159f2abbfd8a52b2ed5755ab7206", size = 538467, upload-time = "2026-05-24T22:21:50.464Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/7f/d04c700b7b0b24cc54c6692222f0fe29efed6fc92c655a7c026847923218/pyromark-0.9.11-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:18102dc1d634f2094f5b8723f51049edf7e6c335110640bdc745c7a2126b21ac", size = 544009, upload-time = "2026-05-24T22:20:04.458Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8e/d0abe1f991286b86e1c4074207675913a7c36fb7bcf9d56fb60711ab92b1/pyromark-0.9.11-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5d17ca83164862fc478f26b0ae643628f4a30d6971dcd0663dc13a73fa5c7151", size = 589315, upload-time = "2026-05-24T22:20:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/58/1f5a33d9854a4614ac555de4d3c12294005f12e0d2621f240a8310e2e390/pyromark-0.9.11-cp314-cp314t-win32.whl", hash = "sha256:134de0516db2ea8bb570a608383c4be443f48ec2a185b58935f053369971d94d", size = 260520, upload-time = "2026-05-24T22:23:08.187Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/59f011062c40670a98136180e6def19cb3a3f4e283ac3936520e8c091ff7/pyromark-0.9.11-cp314-cp314t-win_amd64.whl", hash = "sha256:d710e0577de792280df4b5fc05a90cc615b2226980a2db3ba0f3b428d78c09c1", size = 273172, upload-time = "2026-05-24T22:21:09.624Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/da0a369bfb2910bf905b5a3687c7f4d7c4bd263a26b1d1d1055e67a7ad2b/pyromark-0.9.11-cp314-cp314t-win_arm64.whl", hash = "sha256:3c93e10dc4dc751e363494c75bf98ff3fbfdf2c5753bf49c04cc2339e512258f", size = 257990, upload-time = "2026-05-24T22:22:30.145Z" },
+]
+
+[[package]]
+name = "pyte"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ab/b599762933eba04de7dc5b31ae083112a6c9a9db15b01d3109ad797559d9/pyte-0.8.2.tar.gz", hash = "sha256:5af970e843fa96a97149d64e170c984721f20e52227a2f57f0a54207f08f083f", size = 92301, upload-time = "2023-11-12T09:33:43.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/d0/bb522283b90853afbf506cd5b71c650cf708829914efd0003d615cf426cd/pyte-0.8.2-py3-none-any.whl", hash = "sha256:85db42a35798a5aafa96ac4d8da78b090b2c933248819157fc0e6f78876a0135", size = 31627, upload-time = "2023-11-12T09:33:41.096Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-telegram-bot"
+version = "22.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpcore" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/25/2258161b1069e66d6c39c0a602dbe57461d4767dc0012539970ea40bc9d6/python_telegram_bot-22.7.tar.gz", hash = "sha256:784b59ea3852fe4616ad63b4a0264c755637f5d725e87755ecdee28300febf61", size = 1516454, upload-time = "2026-03-16T09:36:03.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/f7/0e2f89dd62f45d46d4ea0d8aec5893ce5b37389638db010c117f46f11450/python_telegram_bot-22.7-py3-none-any.whl", hash = "sha256:d72eed532cf763758cd9331b57a6d790aff0bb4d37d8f4e92149436fe21c6475", size = 745365, upload-time = "2026-03-16T09:36:01.498Z" },
+]
+
+[package.optional-dependencies]
+rate-limiter = [
+    { name = "aiolimiter" },
+]
+socks = [
+    { name = "httpx", extra = ["socks"] },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "telegramify-markdown"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyromark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/db/198bda5ba14b83b714fe5b632992684fac8fa2c07bbc7b14508e8f67e9a9/telegramify_markdown-1.1.5.tar.gz", hash = "sha256:56da17648849f86a351eb712eef4461f8c11aecc7fd27a293f5d9a0a6333b22d", size = 61782, upload-time = "2026-05-10T08:49:40.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/3e/5a68e10227008a820bad5e5b75cc71cbde03db1c4093d6026279463ccb65/telegramify_markdown-1.1.5-py3-none-any.whl", hash = "sha256:9742d56993be3db2cf9c2a61cbb257f8b34b6013a9ff27af5a569509df6673c0", size = 43329, upload-time = "2026-05-10T08:49:38.847Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/0e/e08087695fc12789263821c5dc0f8dc52b5b17efd0887cacf419f8a43ba3/yarl-1.24.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f9312b3c02d9b3d23840f67952913c9c8721d7f1b7db305289faefa878f364c2", size = 129670, upload-time = "2026-05-19T21:29:56.631Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/98/ab4b5ed1b1b5cd973c8a3eb994c3a6aefb6ce6d399e21bb5f0316c33815c/yarl-1.24.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a4f4d6cd615823bfc7fb7e9b5987c3f41666371d870d51058f77e2680fbe9630", size = 91916, upload-time = "2026-05-19T21:29:58.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b1/5297bb6a7df4782f7605bffc43b31f5044070935fbbcaa6c705a07e6ac65/yarl-1.24.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0c3063e5c0a8e8e62fae6c2596fa01da1561e4cd1da6fec5789f5cf99a8aefd8", size = 91625, upload-time = "2026-05-19T21:30:00.412Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a7/45baabfff76829264e623b185cff0c340d7e11bf3e1cd9ea37e7d17934bd/yarl-1.24.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fecd17873a096036c1c87ab3486f1aef7f269ada7f23f7f856f93b1cc7744f14", size = 104574, upload-time = "2026-05-19T21:30:02.544Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/40/3a5ab144d3d650ca37d4f4b57e56169be8af3ca34c448793e064b30baaed/yarl-1.24.2-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a46d1ab4ba4d32e6dc80daf8a28ce0bd83d08df52fbc32f3e288663427734535", size = 97534, upload-time = "2026-05-19T21:30:04.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b5/5658fef3681fb5776b4513b052bec750009f47b3a592251c705d75375798/yarl-1.24.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73e68edf6dfd5f73f9ca127d84e2a6f9213c65bdffb736bda19524c0564fcd14", size = 111481, upload-time = "2026-05-19T21:30:05.988Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/06/fdcd7dde037f00866dce123ed4ba23dba94beb56fc4cf561668d27be37f2/yarl-1.24.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a296ca617f2d25fbceafb962b88750d627e5984e75732c712154d058ae8d79a3", size = 111529, upload-time = "2026-05-19T21:30:07.738Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/53/d81269aaafccea0d33396c03035de997b743f11e648e6e27a0df99c72980/yarl-1.24.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e51b2cf5ec89a8b8470177641ed62a3ba22d74e1e898e06ad53aa77972487208", size = 107338, upload-time = "2026-05-19T21:30:09.713Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/04/23049463f729bd899df203a7960505a75333edd499cda8aa1d5a82b64df5/yarl-1.24.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:310fc687f7b2044ec54e372c8cbe923bb88f5c37bded0d3079e5791c2fc3cf50", size = 106147, upload-time = "2026-05-19T21:30:11.365Z" },
+    { url = "https://files.pythonhosted.org/packages/14/18/04a4b5830b43ed5e4c5015b40e9f6241ad91487d71611061b4e111d6ac80/yarl-1.24.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:297a2fe352ecf858b30a98f87948746ec16f001d279f84aebdbd3bd965e2f1bd", size = 104272, upload-time = "2026-05-19T21:30:12.978Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f7/8cffdf319aee7a7c1dbd07b61d91c3e3fda460c7a93b5f93e445f3806c4c/yarl-1.24.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2a263e76b97bc42bdcd7c5f4953dec1f7cd62a1112fa7f869e57255229390d67", size = 99962, upload-time = "2026-05-19T21:30:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/39/b3cce3b7dbef64ac700ad4cea156a207d01bede0f507587616c364b5468e/yarl-1.24.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:822519b64cf0b474f1a0aaef1dc621438ea46bb77c94df97a5b4d213a7d8a8b1", size = 111063, upload-time = "2026-05-19T21:30:16.683Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ea/100818505e7ebf165c7242ff17fdf7d9fee79e27234aeca871c1082920d7/yarl-1.24.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b6067060d9dc594899ba83e6db6c48c68d1e494a6dab158156ed86977ca7bcb1", size = 105438, upload-time = "2026-05-19T21:30:18.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d2/e075a0b32aa6625087de9e653087df0759fed5de4a435fef594181102a77/yarl-1.24.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:0063adad533e57171b79db3943b229d40dfafeeee579767f96541f106bac5f1b", size = 111458, upload-time = "2026-05-19T21:30:21.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5c/ceea7ba98b65c8eb8d947fdc52f9bedfcd43c6a57c9e3c90c17be8f324a3/yarl-1.24.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee8e3fb34513e8dc082b586ef4910c98335d43a6fab688cd44d4851bacfce3e8", size = 107589, upload-time = "2026-05-19T21:30:23.412Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d9/5582d57e2b2db9b85eb6663a22efdd78e08805f3f5389566e9fcad254d1b/yarl-1.24.2-cp314-cp314-win_amd64.whl", hash = "sha256:afb00d7fd8e0f285ca29a44cc50df2d622ff2f7a6d933fa641577b5f9d5f3db0", size = 94424, upload-time = "2026-05-19T21:30:25.425Z" },
+    { url = "https://files.pythonhosted.org/packages/92/10/7dc07a0e22806a9280f42a57361395506e800c64e22737cd7b0886feab42/yarl-1.24.2-cp314-cp314-win_arm64.whl", hash = "sha256:68cf6eacd6028ef1142bc4b48376b81566385ca6f9e7dde3b0fa91be08ffcb57", size = 88690, upload-time = "2026-05-19T21:30:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/13/d5b8e2c8667db955bcb3de233f18798fefe7edf1d7429c2c9d4f9c401114/yarl-1.24.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:221ce1dd921ac4f603957f17d7c18c5cc0797fbb52f156941f92e04605d1d67b", size = 136248, upload-time = "2026-05-19T21:30:29.297Z" },
+    { url = "https://files.pythonhosted.org/packages/de/46/a4a97c05c9c9b8fd266bb2a0df12992c7fbd02391eb9640583411b6dab32/yarl-1.24.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5f3224db28173a00d7afacdee07045cc4673dfab2b15492c7ae10deddbece761", size = 95084, upload-time = "2026-05-19T21:30:31.031Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b2/845cf2074a015e6fe0d0808cf1a2d9e868386c4220d657ebd8302b199043/yarl-1.24.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c557165320d6244ebe3a02431b2a201a20080e02f41f0cfa0ccc47a183765da8", size = 95272, upload-time = "2026-05-19T21:30:33.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/16/e69d4aa244aef45235ddfebc0e04036a6829842bc5a6a795aedc6c998d23/yarl-1.24.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:904065e6e85b1fa54d0d87438bd58c14c0bad97aad654ad1077fd9d87e8478ed", size = 101497, upload-time = "2026-05-19T21:30:34.842Z" },
+    { url = "https://files.pythonhosted.org/packages/15/94/c07107715d621076863ee88b3ddf183fa5e9d4aba5769623c9979828410a/yarl-1.24.2-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8cec2a38d70edc10e0e856ceda886af5327a017ccbde8e1de1bd44d300357543", size = 94002, upload-time = "2026-05-19T21:30:37.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/35/fc1bbdd895b5e4010b8fdd037f7ed3aa289d3863e08231b30231ca9a0815/yarl-1.24.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e7484b9361ed222ee1ca5b4337aa4cbdcc4618ce5aff57d9ef1582fd95893fc0", size = 106524, upload-time = "2026-05-19T21:30:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/32b66d0a4ba47c296cf86d03e2c67bff58399fe6d6d84d5205c04c66cc6d/yarl-1.24.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:84f9670b89f34db07f81e53aee83e0b938a3412329d51c8f922488be7fcc4024", size = 106165, upload-time = "2026-05-19T21:30:41.888Z" },
+    { url = "https://files.pythonhosted.org/packages/95/47/37cb5ff50c5e825d4d38e81bb04d1b7e96bf960f7ab89f9850b162f3f114/yarl-1.24.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:abb2759733d63a28b4956500a5dd57140f26486c92b2caedfb964ab7d9b79dbf", size = 103010, upload-time = "2026-05-19T21:30:43.985Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d2/4597912315096f7bb359e46e13bf8b60994fcbb2db29b804c0902ef4eff5/yarl-1.24.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:081c2bf54efe03774d0311172bc04fedf9ca01e644d4cd8c805688e527209bdc", size = 101128, upload-time = "2026-05-19T21:30:46.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/c8e86e120521e646013d02a8e3b8884392e28494be8f392366e50d208efc/yarl-1.24.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:86746bef442aa479107fe28132e1277237f9c24c2f00b0b0cf22b3ee0904f2bb", size = 101382, upload-time = "2026-05-19T21:30:48.085Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/98/70b229236118f89dbeb739b76f10225bbf53b5497725502594c9a01d699a/yarl-1.24.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:2d07d21d0bc4b17558e8de0b02fbfdf1e347d3bb3699edd00bb92e7c57925420", size = 95964, upload-time = "2026-05-19T21:30:49.785Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f8/56c386981e3c8648d279fdef2397ffec577e8320fd5649745e34d54faeb7/yarl-1.24.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:4fb1ac3fc5fecd8ae7453ea237e4d22b49befa70266dfe1629924245c21a0c7f", size = 106204, upload-time = "2026-05-19T21:30:51.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1e/765afe97811ca35933e2a7de70ac57b1997ea2e4ee895719ee7a231fb7e5/yarl-1.24.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4da31a5512ed1729ca8d8aacde3f7faeb8843cde3165d6bcf7f88f74f17bb8aa", size = 101510, upload-time = "2026-05-19T21:30:53.62Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/78/393913f4b9039e1edd09ae8a9bbb9d539be909a8abf6d8a2084585bed4b7/yarl-1.24.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:533ded4dceb5f1f3da7906244f4e82cf46cfd40d84c69a1faf5ac506aa65ecbe", size = 105584, upload-time = "2026-05-19T21:30:55.962Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/deb17b7049bbe74ea11a713b86f8f27800cc1c8648b0b797243ebb4830ba/yarl-1.24.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7b3a85525f6e7eeabcfdd372862b21ee1915db1b498a04e8bf0e389b607ff0bd", size = 103410, upload-time = "2026-05-19T21:30:57.962Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/be/f9f7594e23b5b93affff0318e4593c1920331bcaefda326cabcad94296a1/yarl-1.24.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a7624b1ca46ca5d7b864ef0d2f8efe3091454085ee1855b4e992314529972215", size = 102980, upload-time = "2026-05-19T21:30:59.735Z" },
+    { url = "https://files.pythonhosted.org/packages/65/a4/ba80dccd3593ff1f01051a818694d07b58cb8232677ee9a22a5a1f93a9fc/yarl-1.24.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e434a45ce2e7a947f951fc5a8944c8cc080b7e59f9c50ae80fd39107cf88126d", size = 91219, upload-time = "2026-05-19T21:31:01.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]

--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -62,6 +62,7 @@ logger = structlog.get_logger()
 session_monitor: SessionMonitor | None = None
 _status_poll_task: asyncio.Task[None] | None = None
 _callbacks_wired = False
+_extensions_dispatched = False
 
 
 def install_global_exception_handler() -> None:
@@ -215,6 +216,50 @@ def start_status_polling(application: Application) -> asyncio.Task[None]:
     return _status_poll_task
 
 
+def dispatch_extensions(application: Application) -> None:
+    """Load and run any registered ``ccgram.extensions`` entry points.
+
+    External packages register a callable in the ``ccgram.extensions``
+    entry-point group; each is invoked **synchronously** with the PTB
+    ``Application`` after the runtime callbacks are wired and before the
+    mini-app starts. Returning a coroutine is undefined — the dispatcher
+    does not await.
+
+    Entry points are sorted by ``name`` so the load order is deterministic
+    across installs. Both load failures (broad ``Exception`` so a module-
+    init crash in the extension cannot abort the bot) and install errors
+    are logged and skipped. The plugin boundary intentionally absorbs
+    faults — a misconfigured extension must not take the bot down.
+
+    Idempotent: a second invocation in the same process is a no-op, so
+    ``reset_for_testing`` does not double-register extensions whose
+    install paths call into ``register_*_callback`` (which raises on
+    double-register).
+    """
+    global _extensions_dispatched
+
+    if _extensions_dispatched:
+        return
+
+    # Lazy: importlib.metadata is only consulted at startup once.
+    from importlib.metadata import entry_points
+
+    eps = sorted(entry_points(group="ccgram.extensions"), key=lambda ep: ep.name)
+    for ep in eps:
+        try:
+            install = ep.load()
+        except Exception:  # noqa: BLE001 -- plugin boundary
+            logger.exception("Failed to load ccgram extension %s", ep.name)
+            continue
+        try:
+            install(application)
+        except Exception:  # noqa: BLE001 -- plugin boundary, see docstring
+            logger.exception("ccgram extension %s install raised", ep.name)
+            continue
+        logger.info("Loaded ccgram extension: %s", ep.name)
+    _extensions_dispatched = True
+
+
 async def bootstrap_application(application: Application) -> None:
     """Run the full post_init sequence in the prescribed order."""
     install_global_exception_handler()
@@ -225,6 +270,7 @@ async def bootstrap_application(application: Application) -> None:
     wire_runtime_callbacks()
     await start_session_monitor(application)
     start_status_polling(application)
+    dispatch_extensions(application)
 
     # Lazy: main imports bot at top, bot imports bootstrap; hoisting forms
     # main → bot → bootstrap → main on cold import.
@@ -276,7 +322,7 @@ def reset_for_testing() -> None:
     loud on double registration, and bootstrap caches its own
     ``_callbacks_wired`` flag too.
     """
-    global _callbacks_wired, session_monitor, _status_poll_task
+    global _callbacks_wired, _extensions_dispatched, session_monitor, _status_poll_task
 
     # Lazy: each module's _reset_*_for_testing hook is only needed by the
     # test harness; production callers never reach reset_for_testing().
@@ -287,6 +333,7 @@ def reset_for_testing() -> None:
     shell_capture._reset_approval_callback_for_testing()
 
     _callbacks_wired = False
+    _extensions_dispatched = False
     session_monitor = None
     _status_poll_task = None
     clear_active_monitor()

--- a/src/ccgram/main.py
+++ b/src/ccgram/main.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING
 import structlog
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from aiohttp import web
 
 # Set by the upgrade handler to trigger os.execv() after run_polling() returns
@@ -302,6 +304,64 @@ def run_bot() -> None:
     _reraise_shutdown_signal()
 
 
+def _resolve_miniapp_factory() -> "Callable[..., web.Application] | None":
+    """Resolve a wrapping ``app_factory`` from registered entry points.
+
+    Each entry in the ``ccgram.miniapp_factory`` group is a callable that
+    receives the default ``build_app`` and returns a wrapping factory with
+    the same keyword signature. The wrapper typically calls the default
+    factory, registers additional aiohttp routes on the returned app, and
+    returns it.
+
+    Returns ``None`` when no entry point is registered or every load
+    attempt fails. The plugin boundary intentionally swallows faults so a
+    misconfigured extension cannot disable the mini-app entirely — the
+    bot keeps running with the un-wrapped factory.
+
+    When more than one entry point is registered, the lexicographically
+    smallest ``name`` wins (sorted, deterministic across installs). A
+    WARNING is logged so operators notice the conflict.
+
+    Wrappers may **add** routes and middlewares to the returned
+    ``Application`` but should not assume route mutation is supported —
+    aiohttp's ``UrlDispatcher`` exposes no clean override API.
+    """
+    # Lazy: importlib.metadata is only consulted at startup once.
+    from importlib.metadata import entry_points
+
+    eps = sorted(entry_points(group="ccgram.miniapp_factory"), key=lambda ep: ep.name)
+    if not eps:
+        return None
+
+    logger = structlog.get_logger()
+    if len(eps) > 1:
+        logger.warning(
+            "Multiple ccgram.miniapp_factory entry points; using %s (lowest name)",
+            eps[0].name,
+        )
+
+    ep = eps[0]
+    try:
+        wrapper = ep.load()
+    except Exception:  # noqa: BLE001 -- plugin boundary
+        logger.exception("Failed to load miniapp factory %s", ep.name)
+        return None
+
+    # Lazy: miniapp depends on aiohttp; importing build_app at module top
+    # would pay the aiohttp cost on every ccgram invocation, but
+    # _resolve_miniapp_factory only runs when an entry point is registered.
+    from .miniapp.server import build_app
+
+    try:
+        factory = wrapper(build_app)
+    except Exception:  # noqa: BLE001 -- plugin boundary, see docstring
+        logger.exception("miniapp factory %s raised", ep.name)
+        return None
+
+    logger.info("Loaded miniapp factory: %s", ep.name)
+    return factory
+
+
 async def start_miniapp_if_enabled() -> None:
     """Start the Mini App HTTP server when ``CCGRAM_MINIAPP_BASE_URL`` is set.
 
@@ -321,6 +381,7 @@ async def start_miniapp_if_enabled() -> None:
         return
 
     logger = structlog.get_logger()
+    app_factory = _resolve_miniapp_factory()
     try:
         # Lazy: miniapp depends on aiohttp; loading at module level would
         # break deployments that disable the dashboard via miniapp_base_url=None.
@@ -330,6 +391,7 @@ async def start_miniapp_if_enabled() -> None:
             bot_token=config.telegram_bot_token,
             host=config.miniapp_host,
             port=config.miniapp_port,
+            app_factory=app_factory,
         )
         logger.info(
             "Mini App server started: base_url=%s host=%s port=%d",

--- a/tests/ccgram/test_bootstrap.py
+++ b/tests/ccgram/test_bootstrap.py
@@ -102,6 +102,10 @@ class TestBootstrapApplication:
                 side_effect=lambda _app: order.append("polling"),
             ),
             patch(
+                "ccgram.bootstrap.dispatch_extensions",
+                side_effect=lambda _app: order.append("extensions"),
+            ),
+            patch(
                 "ccgram.main.start_miniapp_if_enabled",
                 new=AsyncMock(side_effect=lambda: order.append("miniapp")),
             ),
@@ -120,6 +124,7 @@ class TestBootstrapApplication:
             "wire",
             "monitor",
             "polling",
+            "extensions",
             "miniapp",
         ]
 


### PR DESCRIPTION
Introduces ``ccgram-pro``, a sibling package that hooks into ccgram via two new entry-point groups so the upstream codebase stays untouched beyond ~15 lines of dispatch sites:

- ``ccgram.extensions`` (bootstrap.py): post-init plugin dispatch with idempotent guard against re-dispatch under reset_for_testing.
- ``ccgram.miniapp_factory`` (main.py): app_factory wrapper resolver so layers can register additional aiohttp routes.

The layer ships these subsystems:

- Sidecar per-window state (``~/.ccgram/layer/state/<window_id>.json``) with epoch fingerprinting, atomic writes, per-window asyncio lock for transactional updates, and corrupt-sidecar quarantine. Filename safety reuses ``ccgram.mailbox.sanitize_dir_name``.
- TOML configuration: ``projects.toml`` (predefined project list) + ``settings.toml`` (defaults, voice, snapshots, share-tokens, workspaces). Layer directory namespaces by CCGRAM_GROUP_ID / CCGRAM_INSTANCE_NAME so multi-instance bots do not share state.
- Per-session project workspaces: ``git clone --local --no-hardlinks`` (with optional uncommitted + untracked transfer) or rsync/copy fallback for non-git sources. Install command auto-detection covers pnpm, yarn, npm, uv, poetry, pipenv, cargo, go. Background GC sweeps idle and orphan workspaces on a PTB JobQueue tick.
- Interactive ``ccgram-pro setup`` wizard: walks the operator through bot token, allowed users, Claude Code check, predefined projects, optional LLM provider, optional whisper provider, optional Mini App (HTTPS URL), and ``ccgram hook --install``. Writes ``~/.ccgram/.env``
  + ``projects.toml`` incrementally so Ctrl-C preserves progress.
- ``ccgram-pro doctor`` validates entry-point registration, host dispatch sites, layer directories, workspaces dir, git/gh CLIs, and TOML parsing. Honors NO_COLOR/FORCE_COLOR.

Tested with 130 layer-side pytest cases plus a host-contract test that asserts ``inspect.signature`` on the upstream hook points so a future ccgram refactor surfaces as a red test rather than a runtime failure. make check-layer wired into the parent ``check`` recipe; ccgram's own 5239-test suite is unaffected.