### PR TITLE
Fix: honor configured log level (CCGRAM_LOG_LEVEL/--log-level/-v were ignored)

### DIFF
--- a/src/ccgram/main.py
+++ b/src/ccgram/main.py
@@ -172,7 +172,7 @@ def setup_logging(log_level: str) -> None:
                 level_styles=level_styles if stdout_colors else None,
             ),
         ],
-        wrapper_class=structlog.stdlib.BoundLogger,
+        wrapper_class=structlog.make_filtering_bound_logger(numeric_level),
         context_class=dict,
         logger_factory=structlog.PrintLoggerFactory(),
         cache_logger_on_first_use=True,


### PR DESCRIPTION
## Problem
`setup_logging()` configures structlog with `wrapper_class=structlog.stdlib.BoundLogger` over a `PrintLoggerFactory`. PrintLogger bypasses stdlib level gating, so `logging.getLogger("ccgram").setLevel(numeric_level)` has no effect and **debug lines are always emitted** regardless of `CCGRAM_LOG_LEVEL`, `--log-level`, or `-v`.

## Fix
Use `structlog.make_filtering_bound_logger(numeric_level)` (numeric_level is already computed at the top of `setup_logging`). One-line change; the level is now honored.

## Test
With `--log-level warning` / `-v` the output now matches the requested level (debug suppressed at info+).