### PR TITLE
Fix: topic-existence probe spams/suspends when bot lacks can_pin_messages

### DIFF
--- a/src/ccgram/handlers/topics/topic_lifecycle.py
+++ b/src/ccgram/handlers/topics/topic_lifecycle.py
@@ -191,9 +191,14 @@ async def prune_stale_state(live_windows: "list[TmuxWindow]") -> None:
 # ── Topic existence probing ───────────────────────────────────────────────
 
 
+_probe_pin_disabled: set = set()
+
+
 async def probe_topic_existence(client: TelegramClient) -> None:
     """Probe all bound topics via Telegram API; detect deleted topics."""
     for user_id, thread_id, wid in list(thread_router.iter_thread_bindings()):
+        if wid in _probe_pin_disabled:
+            continue
         if lifecycle_strategy.should_skip_probe(wid):
             continue
         try:
@@ -224,6 +229,10 @@ async def probe_topic_existence(client: TelegramClient) -> None:
                     thread_id,
                     user_id,
                 )
+            elif isinstance(e, BadRequest) and "Not enough rights" in e.message:
+                if wid not in _probe_pin_disabled:
+                    _probe_pin_disabled.add(wid)
+                    logger.info("Topic probe disabled for %s: bot lacks pin rights", wid)
             else:
                 lifecycle_strategy.record_probe_failure(wid)
                 if not lifecycle_strategy.should_skip_probe(wid):


### PR DESCRIPTION
## Problem
`probe_topic_existence()` calls `unpin_all_forum_topic_messages()` as a cheap existence check. If the bot admin **lacks `can_pin_messages`**, every tick raises `BadRequest("not enough rights to manage pinned messages")`. That falls into the generic `else` branch, is counted as a probe failure, and after `MAX_PROBE_FAILURES` the probe is **suspended** — and the failure re-logs on every inbound message (clear_probe_failures resets the counter). Result: log spam + deleted-topic cleanup silently stops.

## Fix
Treat the permission error as a **permanent per-window skip**: log once, add the window to a module-level `_probe_pin_disabled` set, and skip it on subsequent ticks. A process restart resets the set, so re-granting pin resumes probing. Mirrors the existing graceful handling in `topic_emoji.py` for the same permission case.

## Test
With a bot admin that has no pin right, the probe logs "Topic probe disabled … bot lacks pin rights" exactly once per window and stops, instead of suspending + re-logging.