### PR TITLE
fix: rediscover transcript after session reset

### DIFF
--- a/src/ccgram/window_state_store.py
+++ b/src/ccgram/window_state_store.py
@@ -322,9 +322,18 @@ class WindowStateStore:
             self._schedule_save()
 
     def clear_window_session(self, window_id: str) -> None:
-        """Clear session association for a window (e.g., after /clear command)."""
+        """Clear session association for a window (e.g., after /clear command).
+
+        Session-reset commands such as Codex ``/clear`` can move the active
+        conversation to a new transcript while the tmux window stays alive. If
+        the old transcript path remains cached, transcript discovery treats the
+        hook-backed session as already resolved and the monitor keeps tailing the
+        stale file. Clear both fields so the next polling tick can discover and
+        register the new active transcript for the same topic.
+        """
         state = self.get_window_state(window_id)
         state.session_id = ""
+        state.transcript_path = ""
         self._schedule_save()
         logger.debug("Cleared session for window_id %s", window_id)
 

--- a/tests/ccgram/test_window_state_store.py
+++ b/tests/ccgram/test_window_state_store.py
@@ -214,6 +214,25 @@ class TestStoreCRUD:
         store.from_dict(legacy)
         assert store.window_states["@1"].panes == {}
 
+    def test_clear_window_session_clears_transcript_path_for_rediscovery(
+        self, store: WindowStateStore
+    ) -> None:
+        store.window_states["@1"] = WindowState(
+            session_id="old-session",
+            cwd="/proj",
+            window_name="proj",
+            transcript_path="/home/user/.codex/sessions/old.jsonl",
+            provider_name="codex",
+        )
+
+        store.clear_window_session("@1")
+
+        state = store.window_states["@1"]
+        assert state.session_id == ""
+        assert state.transcript_path == ""
+        assert state.cwd == "/proj"
+        assert state.provider_name == "codex"
+
 
 class TestPaneLifecycleNotify:
     def test_window_state_default_is_none(self) -> None:


### PR DESCRIPTION
## Summary
Fixes #111.

Codex `/clear` can leave a topic bound to a stale transcript path even though the active tmux window has moved to a new session. The polling recovery path then considers the hook-backed transcript resolved and does not rediscover the new Codex transcript.

## Changes
- Clear the cached transcript path together with the session id when a session-reset command is forwarded.
- Preserve cwd/provider metadata so the next polling tick can rediscover and register the new active Codex transcript for the same topic.
- Add a regression test for clearing transcript path during session reset.

## Test Plan
- `uv run --extra dev pytest tests/ccgram/test_window_state_store.py -q`
- `uv run ruff check src/ccgram/window_state_store.py tests/ccgram/test_window_state_store.py`
- `uv run --extra dev pyright src/ccgram/window_state_store.py tests/ccgram/test_window_state_store.py`