### PR TITLE
fix: Claude provider misdetection + topic-probe pin-rights handling

### DIFF
--- a/src/ccgram/handlers/topics/topic_lifecycle.py
+++ b/src/ccgram/handlers/topics/topic_lifecycle.py
@@ -192,10 +192,18 @@ async def prune_stale_state(live_windows: "list[TmuxWindow]") -> None:
 # ── Topic existence probing ───────────────────────────────────────────────
 
 
+# Windows whose chat lacks can_pin_messages: the unpin-based probe can never
+# succeed there, so disable it permanently (per process) instead of counting it
+# as a probe failure (which would suspend deleted-topic detection and re-arm on
+# every inbound message). Reset on restart; mirrors _disabled_chats in
+# handlers/status/topic_emoji.py.
+_probe_pin_disabled: set[str] = set()
+
+
 async def probe_topic_existence(client: TelegramClient) -> None:
     """Probe all bound topics via Telegram API; detect deleted topics."""
     for user_id, thread_id, wid in list(thread_router.iter_thread_bindings()):
-        if lifecycle_strategy.should_skip_probe(wid):
+        if wid in _probe_pin_disabled or lifecycle_strategy.should_skip_probe(wid):
             continue
         try:
             await client.unpin_all_forum_topic_messages(
@@ -224,6 +232,12 @@ async def probe_topic_existence(client: TelegramClient) -> None:
                     wid,
                     thread_id,
                     user_id,
+                )
+            elif isinstance(e, BadRequest) and "not enough rights" in e.message.lower():
+                _probe_pin_disabled.add(wid)
+                logger.info(
+                    "Topic probe disabled for window_id '%s': bot lacks pin rights",
+                    wid,
                 )
             else:
                 lifecycle_strategy.record_probe_failure(wid)

--- a/src/ccgram/hooks/adapters.py
+++ b/src/ccgram/hooks/adapters.py
@@ -355,7 +355,13 @@ def detect_provider_from_payload(payload: dict[str, object]) -> ProviderName | N
         provider = "pi"
     elif event_name in _GEMINI_ONLY_EVENT_TYPES:
         provider = "gemini"
-    elif _str_field(payload, "permission_mode") or _str_field(payload, "model"):
+    elif (
+        _str_field(payload, "permission_mode") or _str_field(payload, "model")
+    ) and "/.claude/" not in transcript_path:
+        # ``model``/``permission_mode`` are weak codex signals: Claude's Stop and
+        # Notification payloads now also carry ``model``, so without this guard a
+        # Claude session (transcript under ~/.claude/) installed with no
+        # --provider flag is misdetected as codex.
         provider = "codex"
     elif _str_field(payload, "end_reason") or (
         session_id and not UUID_RE.match(session_id)

--- a/tests/ccgram/handlers/topics/test_topic_lifecycle.py
+++ b/tests/ccgram/handlers/topics/test_topic_lifecycle.py
@@ -291,3 +291,35 @@ class TestProbeTopicExistence:
             mock_router.iter_thread_bindings.return_value = [(1, 100, "@0")]
             await probe_topic_existence(bot)
         bot.unpin_all_forum_topic_messages.assert_not_called()
+
+    async def test_missing_pin_rights_disables_probe_without_suspending(self):
+        from ccgram.handlers.topics import topic_lifecycle as tl
+
+        bot = AsyncMock(spec=Bot)
+        # Real Telegram error for unpin without can_pin_messages is lowercase.
+        bot.unpin_all_forum_topic_messages = AsyncMock(
+            side_effect=BadRequest("not enough rights to manage pinned messages")
+        )
+        wid = "@probe-pin"
+        tl._probe_pin_disabled.discard(wid)
+        try:
+            with (
+                patch.object(tl, "thread_router") as mock_router,
+                patch.object(tl, "lifecycle_strategy") as mock_strategy,
+            ):
+                mock_router.iter_thread_bindings.return_value = [(1, 100, wid)]
+                mock_router.resolve_chat_id.return_value = 42
+                mock_strategy.should_skip_probe.return_value = False
+
+                await probe_topic_existence(bot)
+
+                # Permission error must not count as a probe failure (no suspend).
+                mock_strategy.record_probe_failure.assert_not_called()
+                assert wid in tl._probe_pin_disabled
+
+                # Next tick skips the window entirely — no further API call.
+                bot.unpin_all_forum_topic_messages.reset_mock()
+                await probe_topic_existence(bot)
+                bot.unpin_all_forum_topic_messages.assert_not_called()
+        finally:
+            tl._probe_pin_disabled.discard(wid)

--- a/tests/ccgram/test_hook_provider_events.py
+++ b/tests/ccgram/test_hook_provider_events.py
@@ -358,6 +358,28 @@ def test_detect_provider_from_payload_uses_gemini_only_event_name() -> None:
     assert detect_provider_from_payload({"hook_event_name": "AfterAgent"}) == "gemini"
 
 
+def test_detect_provider_from_payload_claude_model_field_not_codex() -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    # Claude Stop/Notification payloads now carry a ``model`` field; a Claude
+    # transcript path must not be misdetected as codex.
+    payload: dict[str, object] = {
+        "session_id": "550e8400-e29b-41d4-a716-446655440000",
+        "hook_event_name": "Stop",
+        "transcript_path": "/home/u/.claude/projects/proj/sess.jsonl",
+        "model": "claude-opus-4-8",
+        "permission_mode": "default",
+    }
+    assert detect_provider_from_payload(payload) is None
+
+
+def test_detect_provider_from_payload_codex_model_field_still_codex() -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    # A model-bearing payload that is not a Claude transcript still infers codex.
+    assert detect_provider_from_payload({"model": "gpt-5-codex"}) == "codex"
+
+
 def test_gemini_install_adds_provider_specific_hooks(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
Two confirmed bugs from the open-issue/PR triage, fixed in-repo with regression tests.

### 1. Claude misdetected as codex (`hooks/adapters.py`)
Claude Stop/Notification payloads now carry `model`/`permission_mode`; `detect_provider_from_payload` treated either as a codex signal, so a Claude session installed without `--provider` (transcript under `~/.claude/`) was misclassified as codex and poisoned the session_map entry. Guarded the weak heuristic against Claude transcript paths. This is the contributing factor flagged in #107.

### 2. Topic-existence probe suspends on missing pin rights (`handlers/topics/topic_lifecycle.py`)
`unpin_all_forum_topic_messages` raises `BadRequest('not enough rights to manage pinned messages')` when the bot lacks `can_pin_messages`; it was counted as a probe failure and after 3 it suspended deleted-topic detection (re-arming on every inbound message). Now a permanent per-window skip with a **case-insensitive** match (the real Telegram error is lowercase) — mirrors `_disabled_chats` in `topic_emoji.py`. Supersedes #109.

Tests: 220 pass across hook/provider, status-polling, and topic-lifecycle suites; ruff + pyright clean.