### PR TITLE
Preserve transcript offsets across tmux rename refreshes

### DIFF
--- a/src/ccgram/session_lifecycle.py
+++ b/src/ccgram/session_lifecycle.py
@@ -32,6 +32,15 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 
+def _same_transcript_path(
+    old_details: dict[str, Any],
+    new_details: dict[str, Any],
+) -> bool:
+    old_path = old_details.get("transcript_path", "")
+    new_path = new_details.get("transcript_path", "")
+    return bool(old_path and new_path and old_path == new_path)
+
+
 @dataclass
 class ReconcileResult:
     """Result of a session_map reconciliation pass."""
@@ -79,6 +88,14 @@ class SessionLifecycle:
         for window_id, old_details in self._last_session_map.items():
             new_details = current_map.get(window_id)
             if new_details and new_details["session_id"] != old_details["session_id"]:
+                if _same_transcript_path(old_details, new_details):
+                    logger.debug(
+                        "Window '%s' session metadata refreshed for same transcript: %s -> %s",
+                        window_id,
+                        old_details["session_id"],
+                        new_details["session_id"],
+                    )
+                    continue
                 logger.info(
                     "Window '%s' session changed: %s -> %s",
                     window_id,

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -101,6 +101,48 @@ class TranscriptReader:
         self._pending_tools.pop(session_id, None)
         log_throttle_reset(f"partial-jsonl:{session_id}")
 
+    def _adopt_tracking_for_file(
+        self, session_id: str, file_path: Path
+    ) -> TrackedSession | None:
+        """Move offset state when the same transcript appears under a refreshed id."""
+        try:
+            target = file_path.resolve()
+        except _PathResolveError:
+            target = file_path
+
+        for old_session_id, old_session in list(self._state.tracked_sessions.items()):
+            if old_session_id == session_id:
+                continue
+            try:
+                existing = Path(old_session.file_path).resolve()
+            except _PathResolveError:
+                existing = Path(old_session.file_path)
+            if existing != target:
+                continue
+
+            tracked = TrackedSession(
+                session_id=session_id,
+                file_path=str(file_path),
+                last_byte_offset=old_session.last_byte_offset,
+            )
+            self._state.remove_session(old_session_id)
+            self._state.update_session(tracked)
+            if old_session_id in self._file_mtimes:
+                self._file_mtimes[session_id] = self._file_mtimes.pop(old_session_id)
+            if old_session_id in self._pending_tools:
+                self._pending_tools[session_id] = self._pending_tools.pop(
+                    old_session_id
+                )
+            log_throttle_reset(f"partial-jsonl:{old_session_id}")
+            logger.debug(
+                "Adopted transcript offset for refreshed session: %s -> %s (%s)",
+                old_session_id,
+                session_id,
+                str(file_path),
+            )
+            return tracked
+        return None
+
     async def _process_session_file(
         self,
         session_id: str,
@@ -112,6 +154,9 @@ class TranscriptReader:
         """Process a single session file for new messages."""
         tracked = self._state.get_session(session_id)
         provider = _resolve_provider_for_file(window_id, file_path)
+
+        if tracked is None:
+            tracked = self._adopt_tracking_for_file(session_id, file_path)
 
         if tracked is None:
             try:

--- a/tests/ccgram/test_session_lifecycle.py
+++ b/tests/ccgram/test_session_lifecycle.py
@@ -1,0 +1,33 @@
+"""Tests for session-map reconciliation behavior."""
+
+from ccgram.idle_tracker import IdleTracker
+from ccgram.session_lifecycle import SessionLifecycle
+
+
+def test_same_transcript_session_refresh_preserves_monitor_state() -> None:
+    lifecycle = SessionLifecycle()
+    lifecycle.initialize(
+        {
+            "@1": {
+                "session_id": "sess-before-rename",
+                "cwd": "/repo",
+                "window_name": "before",
+                "transcript_path": "/tmp/transcript.jsonl",
+            }
+        }
+    )
+
+    result = lifecycle.reconcile(
+        {
+            "@1": {
+                "session_id": "sess-after-rename",
+                "cwd": "/repo",
+                "window_name": "after",
+                "transcript_path": "/tmp/transcript.jsonl",
+            }
+        },
+        IdleTracker(),
+    )
+
+    assert result.sessions_to_remove == set()
+    assert result.changed_windows == {}

--- a/tests/ccgram/test_transcript_reader.py
+++ b/tests/ccgram/test_transcript_reader.py
@@ -1,0 +1,42 @@
+"""Tests for transcript reader offset handling."""
+
+from ccgram.idle_tracker import IdleTracker
+from ccgram.monitor_state import MonitorState, TrackedSession
+from ccgram.transcript_reader import TranscriptReader
+
+
+async def test_same_transcript_reuses_offset_after_session_map_refresh(
+    tmp_path,
+) -> None:
+    """A tmux rename/session-map refresh must not replay an existing transcript."""
+    first = (
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"old"}]}}\n'
+    )
+    second = (
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"new"}]}}\n'
+    )
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(first + second, newline="\n")
+
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess-before-rename",
+            file_path=str(session_file),
+            last_byte_offset=len(first.encode()),
+        )
+    )
+    reader = TranscriptReader(state, IdleTracker())
+
+    messages = []
+    await reader._process_session_file(
+        "sess-after-rename",
+        session_file,
+        messages,
+        window_id="@1",
+    )
+
+    assert [msg.text for msg in messages] == ["new"]
+    tracked = state.get_session("sess-after-rename")
+    assert tracked is not None
+    assert tracked.last_byte_offset == session_file.stat().st_size

--- a/tests/integration/test_monitor_flow.py
+++ b/tests/integration/test_monitor_flow.py
@@ -266,11 +266,17 @@ async def test_session_change_cleanup(state_dir, session_map_with_transcript) ->
     monitor._last_session_map = old_map
 
     new_sid = "11111111-2222-3333-4444-555555555555"
+    new_transcript = (
+        state_dir / "transcript_new.jsonl"
+    )  # real session change → different file
+    _write_jsonl(
+        new_transcript, _make_task_create_entry("2", "New task", session_id=new_sid)
+    )
     new_map = {
         "@0": {
             "session_id": new_sid,
             "cwd": "/tmp/test",
-            "transcript_path": str(transcript),
+            "transcript_path": str(new_transcript),
         }
     }
     (state_dir / "session_map.json").write_text(


### PR DESCRIPTION
## Summary
- Treat a session-map refresh with the same transcript path as metadata-only, so monitor state is not cleared on tmux rename/session metadata churn.
- Reuse existing transcript byte offsets when the same transcript file appears under a refreshed session id.
- Add focused lifecycle and transcript-reader regression tests to prevent full transcript replay.

Fixes #107

## Tests
- `uv run pytest tests/ccgram/test_transcript_reader.py tests/ccgram/test_session_lifecycle.py -q`
- `uv run ruff format --check src/ccgram/transcript_reader.py src/ccgram/session_lifecycle.py tests/ccgram/test_transcript_reader.py tests/ccgram/test_session_lifecycle.py`
- `uv run ruff check src/ccgram/transcript_reader.py src/ccgram/session_lifecycle.py tests/ccgram/test_transcript_reader.py tests/ccgram/test_session_lifecycle.py`
- `uv run pyright src/ccgram/transcript_reader.py src/ccgram/session_lifecycle.py tests/ccgram/test_transcript_reader.py tests/ccgram/test_session_lifecycle.py`
- `git diff --check -- src/ccgram/transcript_reader.py src/ccgram/session_lifecycle.py tests/ccgram/test_transcript_reader.py tests/ccgram/test_session_lifecycle.py`

Note: native Windows collection of `tests/ccgram/test_session_monitor.py` still fails before tests run because `session_map.py` imports POSIX-only `fcntl`; the focused tests above avoid that platform-only import.