### PR TITLE
test: auto-close multiplexer windows/tabs created by integration/e2e tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,9 @@ discovers any test that transitively imports ccgram.
 
 import contextlib
 import os
+import subprocess
 import tempfile
+from collections.abc import Iterator
 
 import pytest
 
@@ -71,3 +73,85 @@ def _wire_multiplexer():
     install_multiplexer(get_multiplexer("tmux"))
     yield
     _reset_multiplexer_for_testing()
+
+
+def _close_created_windows(created: list[tuple[str, str]]) -> None:
+    """Close recorded multiplexer windows via the backend CLI (best-effort)."""
+    closed_workspaces: set[str] = set()
+    for backend, window_id in created:
+        if backend == "tmux":
+            # tmux window ids (``@N``) are server-global, so target directly.
+            subprocess.run(
+                ["tmux", "kill-window", "-t", window_id], capture_output=True
+            )
+            continue
+        # herdr: close the tab and the (often auto-created, empty) workspace.
+        subprocess.run(["herdr", "tab", "close", window_id], capture_output=True)
+        workspace_id = window_id.split(":")[0]
+        if workspace_id in closed_workspaces:
+            continue
+        closed_workspaces.add(workspace_id)
+        # A worktree-backed workspace needs `worktree remove` (deletes the
+        # checkout + closes); a plain one just `workspace close`. Try both.
+        subprocess.run(
+            ["herdr", "worktree", "remove", "--workspace", workspace_id, "--force"],
+            capture_output=True,
+        )
+        subprocess.run(
+            ["herdr", "workspace", "close", workspace_id], capture_output=True
+        )
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_created_windows(request, monkeypatch) -> Iterator[None]:
+    """Close multiplexer windows/tabs created by integration/e2e tests.
+
+    Real-window tests spin up tmux windows and herdr tabs (plus the workspaces
+    herdr auto-creates per cwd); when a test forgets — or fails before — its own
+    teardown, they leak and must be closed by hand. Wrap ``create_window`` /
+    ``create_worktree_window`` on both backends to record the ids THIS test
+    creates, then close them after. Recording only this-test ids keeps it
+    race-free under ``-n auto`` (it never touches another worker's windows).
+
+    Gated on the ``integration`` / ``e2e`` markers: unit tests drive the backends
+    with fake runners returning fake ids (e.g. ``"w2:t9"``) that must never reach
+    the live herdr socket.
+    """
+    if not (
+        request.node.get_closest_marker("integration")
+        or request.node.get_closest_marker("e2e")
+    ):
+        yield
+        return
+
+    created: list[tuple[str, str]] = []
+
+    def _wrap(cls: type, attr: str, backend: str) -> None:
+        orig = getattr(cls, attr, None)
+        if orig is None:
+            return
+
+        async def wrapper(self, *args, **kwargs):  # noqa: ANN001, ANN202
+            result = await orig(self, *args, **kwargs)
+            if (
+                isinstance(result, tuple)
+                and len(result) >= 4
+                and result[0]
+                and isinstance(result[3], str)
+                and result[3]
+            ):
+                created.append((backend, result[3]))
+            return result
+
+        monkeypatch.setattr(cls, attr, wrapper)
+
+    from ccgram.multiplexer.herdr import HerdrManager
+    from ccgram.multiplexer.tmux import TmuxManager
+
+    _wrap(TmuxManager, "create_window", "tmux")
+    _wrap(HerdrManager, "create_window", "herdr")
+    _wrap(HerdrManager, "create_worktree_window", "herdr")
+    try:
+        yield
+    finally:
+        _close_created_windows(created)

--- a/tests/integration/test_herdr_contract.py
+++ b/tests/integration/test_herdr_contract.py
@@ -119,15 +119,17 @@ async def test_create_send_capture_kill_roundtrip(
     assert await herdr.find_window(window_id) is None
 
 
-def _workspace_ids() -> set[str]:
-    """Current herdr workspace ids (via the live socket)."""
+def _source_workspace_id(repo: str) -> str:
+    """The herdr workspace id auto-created for *repo* (via the live socket)."""
     out = subprocess.run(
-        ["herdr", "workspace", "list"], capture_output=True, text=True
+        ["herdr", "worktree", "list", "--cwd", repo, "--json"],
+        capture_output=True,
+        text=True,
     ).stdout
     try:
-        return {w["workspace_id"] for w in json.loads(out)["result"]["workspaces"]}
-    except ValueError, KeyError:
-        return set()
+        return json.loads(out)["result"]["source"]["source_workspace_id"] or ""
+    except ValueError, KeyError, TypeError:
+        return ""
 
 
 async def test_create_worktree_window_delegates(herdr: HerdrManager, tmp_path) -> None:
@@ -151,7 +153,6 @@ async def test_create_worktree_window_delegates(herdr: HerdrManager, tmp_path) -
     )
 
     wt_path = str(tmp_path / "wt")
-    before = _workspace_ids()
     ok, _msg, _name, window_id = await herdr.create_worktree_window(
         str(repo), wt_path, "ccg-itest", window_name="ccgram-wt-itest"
     )
@@ -169,15 +170,14 @@ async def test_create_worktree_window_delegates(herdr: HerdrManager, tmp_path) -
         ).stdout.strip()
         assert branch == "ccg-itest"
     finally:
-        # Remove every workspace this test created: the worktree workspace (via
-        # worktree remove → also deletes the checkout) and the auto-created
-        # source workspace for the repo (workspace close).
-        for wsid in _workspace_ids() - before:
+        # The autouse cleanup fixture closes the worktree workspace (the returned
+        # tab's). `worktree create` also auto-creates a *source* workspace for the
+        # repo — close it explicitly here (race-free: only this repo's).
+        source_ws = _source_workspace_id(str(repo))
+        if source_ws:
             subprocess.run(
-                ["herdr", "worktree", "remove", "--workspace", wsid, "--force"],
-                capture_output=True,
+                ["herdr", "workspace", "close", source_ws], capture_output=True
             )
-            subprocess.run(["herdr", "workspace", "close", wsid], capture_output=True)
 
 
 async def test_agent_status_returns_valid_state(herdr: HerdrManager, tmp_path) -> None:


### PR DESCRIPTION
## Why

Integration/e2e tests create real tmux windows and herdr tabs (plus the workspaces herdr auto-creates per cwd). When a test forgets — or fails before — its own teardown, they leak and must be closed by hand.

## What

Autouse fixture in the root conftest that wraps `create_window` / `create_worktree_window` on both backends, records the ids the current test creates, and closes them after (tmux `kill-window`; herdr `tab close` + `worktree remove`/`workspace close`).

- **Race-free under `-n auto`**: records only this test's ids, so it never closes a concurrent worker's in-flight window (a workspace set-difference would).
- **Gated on `integration`/`e2e` markers**: unit tests use fake runners returning fake ids (e.g. `w2:t9`) that must never reach the live herdr socket and close a real workspace.
- herdr worktree contract test: replaced its racy set-difference cleanup with a race-free close of just its own source workspace.

## Test plan

- Full `make check` green; the live herdr workspace list is **unchanged** before vs after the whole suite (no leak).
- Unit `test_herdr_backend` (FakeHerdr fake ids) leaves live workspaces untouched — the marker gate excludes it.