### PR TITLE
[codex] Preserve local recovery, send, and hook fixes

### DIFF
--- a/src/ccgram/handlers/recovery/transcript_discovery.py
+++ b/src/ccgram/handlers/recovery/transcript_discovery.py
@@ -22,6 +22,7 @@ from ...providers import (
     get_provider_for_window,
     should_probe_pane_title_for_provider_detection,
 )
+from ...providers.process_detection import get_cached_foreground_pgid
 from ...session import session_manager
 from ...session_map import session_map_prefix, session_map_sync
 from ...telegram_client import TelegramClient
@@ -222,6 +223,24 @@ def _hook_already_resolved(
     return bool(provider.capabilities.supports_hook and identity.transcript_path)
 
 
+def _foreground_process_restarted(
+    *,
+    before_pgid: int,
+    after_pgid: int,
+    old_identity: identity_state.IdentityProjection,
+    new_identity: identity_state.IdentityProjection,
+) -> bool:
+    """True when the same provider is running in a new foreground process group."""
+    return bool(
+        before_pgid
+        and after_pgid
+        and before_pgid != after_pgid
+        and old_identity.session_id
+        and old_identity.provider_name
+        and old_identity.provider_name == new_identity.provider_name
+    )
+
+
 async def _switch_to_shell(
     window_id: str,
     *,
@@ -271,6 +290,9 @@ async def discover_and_register_transcript(
 
     w = _window or await tmux_manager.find_window_by_id(window_id)
 
+    pgid_before = get_cached_foreground_pgid(window_id)
+    original_identity = identity
+    process_restarted = False
     if w and w.pane_current_command:
         await _detect_and_apply_provider(
             window_id, identity, w, client=client, chat_id=chat_id, thread_id=thread_id
@@ -279,8 +301,15 @@ async def discover_and_register_transcript(
         if refreshed is None:
             return
         identity = refreshed
+        pgid_after = get_cached_foreground_pgid(window_id)
+        process_restarted = _foreground_process_restarted(
+            before_pgid=pgid_before,
+            after_pgid=pgid_after,
+            old_identity=original_identity,
+            new_identity=identity,
+        )
 
-    if _hook_already_resolved(window_id, identity):
+    if _hook_already_resolved(window_id, identity) and not process_restarted:
         return
 
     if not identity.cwd:

--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -1327,7 +1327,9 @@ def hook_main(
     normalized = _process_hook_stdin(
         provider_name if provider_name != "claude" else None
     )
-    if normalized and normalized.provider_name == "codex" and (
-        normalized.canonical_event_name == "Stop"
+    if (
+        normalized
+        and normalized.provider_name == "codex"
+        and (normalized.canonical_event_name == "Stop")
     ):
         print("{}")

--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -31,7 +31,7 @@ from ccgram.hooks.adapters import (
     detect_provider_from_payload,
     get_hook_adapter,
 )
-from ccgram.hooks.model import ProviderName
+from ccgram.hooks.model import NormalizedHookEvent, ProviderName
 from ccgram.multiplexer.self_identify import resolve_self_identity
 
 logger = structlog.get_logger()
@@ -1184,17 +1184,19 @@ def _locate_primary_window(
     return identity.session_window_key, identity.window_id, identity.window_name
 
 
-def _process_hook_stdin(provider_name: str | None = None) -> None:
+def _process_hook_stdin(
+    provider_name: str | None = None,
+) -> NormalizedHookEvent | None:
     """Process an agent hook event from stdin."""
     logger.debug("Processing hook event from stdin")
     try:
         raw_payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError) as e:
         logger.warning("Failed to parse stdin JSON: %s", e)
-        return
+        return None
     if not isinstance(raw_payload, dict):
         logger.warning("Hook stdin JSON must be an object")
-        return
+        return None
     payload: dict[str, object] = raw_payload
 
     payload_provider = detect_provider_from_payload(payload)
@@ -1216,22 +1218,22 @@ def _process_hook_stdin(provider_name: str | None = None) -> None:
     adapter = get_hook_adapter(detected_provider)
     if adapter is None:
         logger.debug("Ignoring hook for unsupported provider: %s", detected_provider)
-        return
+        return None
     normalized = adapter.normalize(payload)
     if normalized is None:
         logger.debug(
             "Ignoring invalid hook payload for provider: %s", detected_provider
         )
-        return
+        return None
 
     event = normalized.canonical_event_name
     if event not in _HOOK_EVENT_TYPES and event not in {"PreCompact", "PostCompact"}:
         logger.debug("Ignoring unhandled event: %s", event)
-        return
+        return None
 
     located = _locate_primary_window(normalized.session_id, event, detected_provider)
     if located is None:
-        return
+        return None
     session_window_key, _window_id, window_name = located
 
     if event == "SessionStart":
@@ -1263,7 +1265,7 @@ def _process_hook_stdin(provider_name: str | None = None) -> None:
             }
         )
         _write_event(event, normalized.session_id, session_window_key, data)
-        return
+        return normalized
 
     _refresh_session_map_if_stale(
         session_window_key,
@@ -1274,6 +1276,28 @@ def _process_hook_stdin(provider_name: str | None = None) -> None:
         str(normalized.transcript_path) if normalized.transcript_path else "",
     )
     _write_event(event, normalized.session_id, session_window_key, normalized.data)
+    return normalized
+
+
+def _configure_hook_logging() -> None:
+    """Keep hook diagnostics off stdout, which some providers parse as protocol."""
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        level=logging.DEBUG,
+        stream=sys.stderr,
+        force=True,
+    )
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.dev.ConsoleRenderer(colors=False),
+        ],
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+        cache_logger_on_first_use=False,
+    )
 
 
 def hook_main(
@@ -1283,11 +1307,7 @@ def hook_main(
     provider_name: str = "claude",
 ) -> None:
     """Process a Claude Code hook event from stdin, or manage hook installation."""
-    logging.basicConfig(
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        level=logging.DEBUG,
-        stream=sys.stderr,
-    )
+    _configure_hook_logging()
 
     if install:
         logger.info("Hook install requested")
@@ -1304,4 +1324,10 @@ def hook_main(
     # keeps the explicit flag to surface the mismatch warning when payload
     # heuristics disagree). The CLI default also resolves to "claude", so the
     # None path covers the common case of an unannotated hook command.
-    _process_hook_stdin(provider_name if provider_name != "claude" else None)
+    normalized = _process_hook_stdin(
+        provider_name if provider_name != "claude" else None
+    )
+    if normalized and normalized.provider_name == "codex" and (
+        normalized.canonical_event_name == "Stop"
+    ):
+        print("{}")

--- a/src/ccgram/multiplexer/window_ops.py
+++ b/src/ccgram/multiplexer/window_ops.py
@@ -17,6 +17,21 @@ from . import multiplexer
 
 logger = structlog.get_logger(__name__)
 
+SEND_KEYS_TIMEOUT_SECONDS = 5.0
+
+
+async def _send_to_window_once(
+    window_id: str, text: str, *, raw: bool, display: str
+) -> tuple[bool, str]:
+    window = await multiplexer.find_window_by_id(window_id)
+    if not window:
+        return False, "Window not found (may have been closed)"
+    success = await multiplexer.send_keys(window.window_id, text, raw=raw)
+    if success:
+        logger.debug("send_to_window complete: window_id=%s (%s)", window_id, display)
+        return True, f"Sent to {display}"
+    return False, "Failed to send keys"
+
 
 async def send_to_window(
     window_id: str, text: str, *, raw: bool = False
@@ -33,13 +48,19 @@ async def send_to_window(
         display,
         len(text),
     )
-    window = await multiplexer.find_window_by_id(window_id)
-    if not window:
-        return False, "Window not found (may have been closed)"
-    success = await multiplexer.send_keys(window.window_id, text, raw=raw)
-    if success:
-        return True, f"Sent to {display}"
-    return False, "Failed to send keys"
+    try:
+        return await asyncio.wait_for(
+            _send_to_window_once(window_id, text, raw=raw, display=display),
+            timeout=SEND_KEYS_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        logger.warning(
+            "send_to_window timed out",
+            window_id=window_id,
+            display=display,
+            timeout=SEND_KEYS_TIMEOUT_SECONDS,
+        )
+        return False, f"Timed out sending keys to {display}"
 
 
 async def send_followup_to_window(window_id: str, text: str) -> tuple[bool, str]:

--- a/src/ccgram/providers/process_detection.py
+++ b/src/ccgram/providers/process_detection.py
@@ -115,6 +115,12 @@ def classify_provider_from_args(args: str) -> str:
 _pgid_cache: dict[str, tuple[int, str]] = {}
 
 
+def get_cached_foreground_pgid(window_id: str) -> int:
+    """Return the cached foreground PGID for a window, or 0 if unknown."""
+    cached = _pgid_cache.get(window_id)
+    return cached[0] if cached else 0
+
+
 async def detect_provider_cached(window_id: str, fg: ForegroundInfo | None) -> str:
     """Classify the provider from a foreground process, cached by PGID.
 

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -31,7 +31,7 @@ from ccgram.handlers.polling.polling_types import (
     is_shell_prompt,
 )
 from ccgram.telegram_client import PTBTelegramClient
-from ccgram.multiplexer.base import PaneInfo
+from ccgram.multiplexer.base import ForegroundInfo, PaneInfo
 
 
 def _assert_handle_called_once_with_client(mock_handle, bot, *args, **kwargs):
@@ -1805,6 +1805,157 @@ class TestMaybeDiscoverTranscript:
         discover_call = mock_asyncio.to_thread.call_args_list[0]
         assert discover_call.args[0] == mock_provider.discover_transcript
         assert discover_call.kwargs["max_age"] is None
+
+    async def test_rebinds_hookful_provider_when_foreground_agent_process_restarted(
+        self,
+    ) -> None:
+        from ccgram.handlers.recovery.transcript_discovery import (
+            discover_and_register_transcript,
+        )
+        from ccgram.providers.base import SessionStartEvent
+        from ccgram.providers.process_detection import _pgid_cache
+
+        event = SessionStartEvent(
+            session_id="new-codex-id",
+            cwd="/proj",
+            transcript_path="/path/to/new-codex.jsonl",
+            window_key="ccgram:@7",
+        )
+        mock_provider = MagicMock()
+        mock_provider.capabilities.supports_hook = True
+        mock_provider.capabilities.chat_first_command_path = False
+        mock_provider.capabilities.name = "codex"
+        mock_provider.discover_transcript.return_value = event
+
+        old_state = MagicMock(
+            session_id="old-codex-id",
+            cwd="/proj",
+            transcript_path="/path/to/old-codex.jsonl",
+            provider_name="codex",
+        )
+
+        _pgid_cache.clear()
+        _pgid_cache["@7"] = (111, "codex")
+        try:
+            with (
+                patch(
+                    "ccgram.handlers.recovery.transcript_discovery.session_map_sync"
+                ) as mock_sms,
+                patch(
+                    "ccgram.window_state_ports.identity_state.window_store"
+                ) as mock_ws,  # noqa: F841
+                patch(
+                    "ccgram.handlers.recovery.transcript_discovery.get_provider_for_window",
+                    return_value=mock_provider,
+                ),
+                patch(
+                    "ccgram.handlers.recovery.transcript_discovery.session_map_prefix",
+                    return_value="ccgram:",
+                ),
+                patch("ccgram.multiplexer.multiplexer") as mock_mux,
+            ):
+                mock_ws.window_states = {"@7": old_state}
+                mock_mux.foreground = AsyncMock(
+                    return_value=ForegroundInfo(
+                        pid=222,
+                        pgid=222,
+                        argv=["node", "/opt/@openai/codex/bin/codex.js"],
+                        cwd="/proj",
+                    )
+                )
+
+                await discover_and_register_transcript(
+                    "@7",
+                    _window=MagicMock(
+                        pane_current_command="node",
+                        pane_tty="/dev/ttys007",
+                        cwd="/proj",
+                    ),
+                )
+        finally:
+            _pgid_cache.clear()
+
+        mock_provider.discover_transcript.assert_called_once()
+        assert mock_provider.discover_transcript.call_args.kwargs["max_age"] == 0
+        mock_sms.register_hookless_session.assert_called_once_with(
+            window_id="@7",
+            session_id="new-codex-id",
+            cwd="/proj",
+            transcript_path="/path/to/new-codex.jsonl",
+            provider_name="codex",
+        )
+
+    async def test_does_not_rebind_hookful_provider_when_agent_process_unchanged(
+        self,
+    ) -> None:
+        from ccgram.handlers.recovery.transcript_discovery import (
+            discover_and_register_transcript,
+        )
+        from ccgram.providers.base import SessionStartEvent
+        from ccgram.providers.process_detection import _pgid_cache
+
+        event = SessionStartEvent(
+            session_id="new-codex-id",
+            cwd="/proj",
+            transcript_path="/path/to/new-codex.jsonl",
+            window_key="ccgram:@7",
+        )
+        mock_provider = MagicMock()
+        mock_provider.capabilities.supports_hook = True
+        mock_provider.capabilities.chat_first_command_path = False
+        mock_provider.capabilities.name = "codex"
+        mock_provider.discover_transcript.return_value = event
+
+        old_state = MagicMock(
+            session_id="old-codex-id",
+            cwd="/proj",
+            transcript_path="/path/to/old-codex.jsonl",
+            provider_name="codex",
+        )
+
+        _pgid_cache.clear()
+        _pgid_cache["@7"] = (111, "codex")
+        try:
+            with (
+                patch(
+                    "ccgram.handlers.recovery.transcript_discovery.session_map_sync"
+                ) as mock_sms,
+                patch(
+                    "ccgram.window_state_ports.identity_state.window_store"
+                ) as mock_ws,  # noqa: F841
+                patch(
+                    "ccgram.handlers.recovery.transcript_discovery.get_provider_for_window",
+                    return_value=mock_provider,
+                ),
+                patch(
+                    "ccgram.handlers.recovery.transcript_discovery.session_map_prefix",
+                    return_value="ccgram:",
+                ),
+                patch("ccgram.multiplexer.multiplexer") as mock_mux,
+            ):
+                mock_ws.window_states = {"@7": old_state}
+                mock_mux.foreground = AsyncMock(
+                    return_value=ForegroundInfo(
+                        pid=111,
+                        pgid=111,
+                        argv=["node", "/opt/@openai/codex/bin/codex.js"],
+                        cwd="/proj",
+                    )
+                )
+
+                await discover_and_register_transcript(
+                    "@7",
+                    _window=MagicMock(
+                        pane_current_command="node",
+                        pane_tty="/dev/ttys007",
+                        cwd="/proj",
+                    ),
+                )
+        finally:
+            _pgid_cache.clear()
+
+        mock_provider.discover_transcript.assert_not_called()
+        mock_sms.register_hookless_session.assert_not_called()
 
     async def test_rebinds_stale_codex_window_to_gemini_from_pane_title(self) -> None:
         from ccgram.handlers.recovery.transcript_discovery import (

--- a/tests/ccgram/test_hook_provider_events.py
+++ b/tests/ccgram/test_hook_provider_events.py
@@ -258,6 +258,30 @@ def test_codex_stop_redacts_raw_prompt_and_tool_payload(
     assert "last_assistant_message" not in event["data"]
 
 
+def test_codex_stop_outputs_valid_stop_hook_json(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("CCGRAM_DIR", str(tmp_path))
+    _run_hook(
+        monkeypatch,
+        {
+            "session_id": _CODEX_SESSION_ID,
+            "cwd": "/tmp/project",
+            "transcript_path": "/tmp/.codex/session.jsonl",
+            "hook_event_name": "Stop",
+            "model": "gpt-5",
+            "permission_mode": "default",
+            "turn_id": "turn",
+            "stop_hook_active": False,
+            "last_assistant_message": "secret output",
+        },
+        "codex",
+    )
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}
+
+
 def test_codex_adapter_rejects_non_uuid_session_id() -> None:
     from ccgram.hooks.adapters import get_hook_adapter
 

--- a/tests/ccgram/test_tmux_followup.py
+++ b/tests/ccgram/test_tmux_followup.py
@@ -1,18 +1,80 @@
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
-from ccgram.multiplexer.window_ops import send_followup_to_window
+from ccgram.multiplexer.window_ops import send_followup_to_window, send_to_window
+
+
+async def test_send_to_window_times_out_when_tmux_send_hangs(monkeypatch) -> None:
+    never = asyncio.Event()
+
+    async def hang_send_keys(*_args, **_kwargs) -> bool:
+        await never.wait()
+        return True
+
+    monkeypatch.setattr(
+        "ccgram.multiplexer.window_ops.SEND_KEYS_TIMEOUT_SECONDS",
+        0.01,
+        raising=False,
+    )
+    mock_router = SimpleNamespace(get_display_name=MagicMock(return_value="project"))
+    with (
+        patch("ccgram.multiplexer.window_ops.thread_router", new=mock_router),
+        patch("ccgram.multiplexer.window_ops.multiplexer") as mock_tmux,
+    ):
+        mock_tmux.find_window_by_id = AsyncMock(
+            return_value=SimpleNamespace(window_id="@1")
+        )
+        mock_tmux.send_keys = AsyncMock(side_effect=hang_send_keys)
+
+        success, message = await asyncio.wait_for(
+            send_to_window("@1", "run tests"), timeout=0.2
+        )
+
+    assert success is False
+    assert message == "Timed out sending keys to project"
+
+
+async def test_send_to_window_times_out_when_window_lookup_hangs(monkeypatch) -> None:
+    never = asyncio.Event()
+
+    async def hang_find_window(*_args, **_kwargs):
+        await never.wait()
+        return SimpleNamespace(window_id="@1")
+
+    monkeypatch.setattr(
+        "ccgram.multiplexer.window_ops.SEND_KEYS_TIMEOUT_SECONDS",
+        0.01,
+        raising=False,
+    )
+    mock_router = SimpleNamespace(get_display_name=MagicMock(return_value="project"))
+    with (
+        patch("ccgram.multiplexer.window_ops.thread_router", new=mock_router),
+        patch("ccgram.multiplexer.window_ops.multiplexer") as mock_tmux,
+    ):
+        mock_tmux.find_window_by_id = AsyncMock(side_effect=hang_find_window)
+        mock_tmux.send_keys = AsyncMock(return_value=True)
+
+        success, message = await asyncio.wait_for(
+            send_to_window("@1", "run tests"), timeout=0.2
+        )
+
+    assert success is False
+    assert message == "Timed out sending keys to project"
+    mock_tmux.send_keys.assert_not_called()
 
 
 async def test_send_followup_to_window_sends_text_then_alt_enter() -> None:
+    mock_router = SimpleNamespace(
+        get_display_name=MagicMock(return_value="project")
+    )
     with (
-        patch("ccgram.multiplexer.window_ops.thread_router") as mock_router,
+        patch("ccgram.multiplexer.window_ops.thread_router", new=mock_router),
         patch("ccgram.multiplexer.window_ops.multiplexer") as mock_tmux,
         patch(
             "ccgram.multiplexer.window_ops.asyncio.sleep", new_callable=AsyncMock
         ) as sleep,
     ):
-        mock_router.get_display_name.return_value = "project"
         mock_tmux.find_window_by_id = AsyncMock(
             return_value=SimpleNamespace(window_id="@1")
         )
@@ -32,11 +94,13 @@ async def test_send_followup_to_window_sends_text_then_alt_enter() -> None:
 
 
 async def test_send_followup_to_window_reports_missing_window() -> None:
+    mock_router = SimpleNamespace(
+        get_display_name=MagicMock(return_value="project")
+    )
     with (
-        patch("ccgram.multiplexer.window_ops.thread_router") as mock_router,
+        patch("ccgram.multiplexer.window_ops.thread_router", new=mock_router),
         patch("ccgram.multiplexer.window_ops.multiplexer") as mock_tmux,
     ):
-        mock_router.get_display_name.return_value = "project"
         mock_tmux.find_window_by_id = AsyncMock(return_value=None)
         mock_tmux.send_keys = AsyncMock(return_value=True)
 

--- a/tests/ccgram/test_tmux_followup.py
+++ b/tests/ccgram/test_tmux_followup.py
@@ -65,9 +65,7 @@ async def test_send_to_window_times_out_when_window_lookup_hangs(monkeypatch) ->
 
 
 async def test_send_followup_to_window_sends_text_then_alt_enter() -> None:
-    mock_router = SimpleNamespace(
-        get_display_name=MagicMock(return_value="project")
-    )
+    mock_router = SimpleNamespace(get_display_name=MagicMock(return_value="project"))
     with (
         patch("ccgram.multiplexer.window_ops.thread_router", new=mock_router),
         patch("ccgram.multiplexer.window_ops.multiplexer") as mock_tmux,
@@ -94,9 +92,7 @@ async def test_send_followup_to_window_sends_text_then_alt_enter() -> None:
 
 
 async def test_send_followup_to_window_reports_missing_window() -> None:
-    mock_router = SimpleNamespace(
-        get_display_name=MagicMock(return_value="project")
-    )
+    mock_router = SimpleNamespace(get_display_name=MagicMock(return_value="project"))
     with (
         patch("ccgram.multiplexer.window_ops.thread_router", new=mock_router),
         patch("ccgram.multiplexer.window_ops.multiplexer") as mock_tmux,


### PR DESCRIPTION
## Summary

This PR ports three local bug fixes onto the current upstream `main` branch:

- Rediscover and rebind hook-backed agent sessions when the foreground process group changes while the provider stays the same. This prevents stale session/transcript bindings after an agent process restart.
- Add a timeout around `send_to_window` in the backend-neutral multiplexer window helper so a stuck window lookup or send operation does not hang the command path indefinitely.
- Keep hook diagnostics on stderr and emit valid `{}` JSON on stdout for Codex `Stop` hooks.

## Why

These fixes cover edge cases not fully handled by the recent upstream changes:

- The upstream `/clear` rediscovery fix clears stale transcript state for explicit session resets, but an agent process restart can leave the stale transcript path in place without going through that clear path.
- The multiplexer refactor moved window send helpers to `multiplexer.window_ops`; this PR applies the timeout at that new boundary.
- Codex stop hooks expect protocol-valid stdout, so hook logging must not contaminate stdout and a successful `Stop` event should return an empty JSON object.

## Tests

```bash
pytest -q tests/ccgram/handlers/polling/test_status_polling.py tests/ccgram/test_tmux_followup.py tests/ccgram/test_hook_provider_events.py -k 'rebinds_hookful_provider_when_foreground_agent_process_restarted or does_not_rebind_hookful_provider_when_agent_process_unchanged or send_to_window_times_out_when_tmux_send_hangs or send_to_window_times_out_when_window_lookup_hangs or send_followup_to_window_sends_text_then_alt_enter or send_followup_to_window_reports_missing_window or codex_stop_outputs_valid_stop_hook_json or codex_stop_redacts_raw_prompt_and_tool_payload'
```

Result: `8 passed, 138 deselected`.
