### PR TITLE
fix(polling): require consecutive misses before declaring a window dead

### DIFF
--- a/src/ccgram/handlers/polling/polling_state.py
+++ b/src/ccgram/handlers/polling/polling_state.py
@@ -29,6 +29,7 @@ import structlog
 from ...providers.base import StatusUpdate
 from ...topic_state_registry import topic_state
 from .polling_types import (
+    MAX_MISSING_POLLS,
     MAX_PROBE_FAILURES,
     PANE_COUNT_TTL,
     RC_DEBOUNCE_SECONDS,
@@ -324,6 +325,23 @@ class TerminalPollState:
         ws = self._states.get(window_id)
         if ws:
             ws.probe_failures = 0
+
+    def record_missing_poll(self, window_id: str) -> int:
+        """Increment the consecutive-missing counter and return the new count."""
+        ws = self.get_state(window_id)
+        ws.missing_polls += 1
+        return ws.missing_polls
+
+    def clear_missing_polls(self, window_id: str) -> None:
+        """Reset the consecutive-missing counter for a single window."""
+        ws = self._states.get(window_id)
+        if ws:
+            ws.missing_polls = 0
+
+    def is_confirmed_missing(self, window_id: str) -> bool:
+        """Check whether a window has been absent for enough consecutive polls."""
+        ws = self._states.get(window_id)
+        return bool(ws) and ws.missing_polls >= MAX_MISSING_POLLS
 
     def clear_seen_status(self, window_id: str) -> None:
         """Clear startup status tracking for a single window."""

--- a/src/ccgram/handlers/polling/polling_types.py
+++ b/src/ccgram/handlers/polling/polling_types.py
@@ -38,6 +38,12 @@ RC_DEBOUNCE_SECONDS = 3.0
 # Consecutive topic probe failure threshold.
 MAX_PROBE_FAILURES = 3
 
+# Consecutive poll cycles a bound window must be absent from the multiplexer
+# listing before it is treated as dead. TmuxManager.list_windows() returns an
+# empty list when get_session() hits a transient error, and drops individual
+# windows whose pane metadata raises, so a single miss is not proof of death.
+MAX_MISSING_POLLS = 3
+
 # Typing indicator throttle interval (seconds).
 TYPING_INTERVAL = 4.0
 
@@ -64,6 +70,7 @@ class WindowPollState:
     has_seen_status: bool = False
     startup_time: float | None = None
     probe_failures: int = 0
+    missing_polls: int = 0
     screen_buffer: ScreenBuffer | None = field(default=None, repr=False)
     pane_count_cache: tuple[int, float] | None = None
     unbound_timer: float | None = None

--- a/src/ccgram/handlers/polling/window_tick/__init__.py
+++ b/src/ccgram/handlers/polling/window_tick/__init__.py
@@ -75,10 +75,21 @@ async def tick_window(
         return
 
     if window is None:
+        # A single absent poll is not proof of death: list_windows() returns []
+        # when the multiplexer session lookup hits a transient error, and drops
+        # individual windows whose pane metadata raises. Require the window to
+        # be missing from MAX_MISSING_POLLS consecutive cycles before showing
+        # the recovery banner, otherwise one bad poll kills a live session's
+        # topic. Genuine deaths still arrive instantly via the event stream.
+        rt.poll_state.record_missing_poll(window_id)
+        if not rt.poll_state.is_confirmed_missing(window_id):
+            return
         await _handle_dead_window_notification(
             bot, user_id, thread_id, window_id, runtime=rt
         )
         return
+
+    rt.poll_state.clear_missing_polls(window_id)
 
     await discover_and_register_transcript(
         window_id,

--- a/tests/ccgram/handlers/polling/test_window_tick.py
+++ b/tests/ccgram/handlers/polling/test_window_tick.py
@@ -12,7 +12,7 @@ from ccgram.handlers.polling.polling_state import (
     terminal_poll_state,
     terminal_screen_buffer,
 )
-from ccgram.handlers.polling.polling_types import TickContext
+from ccgram.handlers.polling.polling_types import MAX_MISSING_POLLS, TickContext
 from ccgram.handlers.polling.window_tick import (
     _check_interactive_only,
     _handle_dead_window_notification,
@@ -65,7 +65,8 @@ class TestTickWindowDeadWindow:
         with patch.object(
             window_tick, "_handle_dead_window_notification", new_callable=AsyncMock
         ) as mock_dead:
-            await tick_window(bot, 1, 100, "@0", None)
+            for _ in range(MAX_MISSING_POLLS):
+                await tick_window(bot, 1, 100, "@0", None)
             mock_dead.assert_called_once()
             args, kwargs = mock_dead.call_args
             assert args == (bot, 1, 100, "@0")
@@ -83,7 +84,8 @@ class TestTickWindowDeadWindow:
                 window_tick, "_scan_window_panes", new_callable=AsyncMock
             ) as mock_scan,
         ):
-            await tick_window(bot, 1, 100, "@0", None)
+            for _ in range(MAX_MISSING_POLLS):
+                await tick_window(bot, 1, 100, "@0", None)
             mock_status.assert_not_called()
             mock_scan.assert_not_called()
 
@@ -95,6 +97,69 @@ class TestTickWindowDeadWindow:
         ) as mock_dead:
             await tick_window(bot, 1, 100, "@0", None)
             mock_dead.assert_not_called()
+
+
+class TestTickWindowMissingPollDebounce:
+    """A window absent from a single poll must not be declared dead.
+
+    list_windows() returns [] when the multiplexer session lookup hits a
+    transient error, and drops individual windows whose pane metadata raises,
+    so one miss is not proof of death.
+    """
+
+    async def test_single_miss_does_not_notify(self):
+        bot = AsyncMock(spec=Bot)
+        with patch.object(
+            window_tick, "_handle_dead_window_notification", new_callable=AsyncMock
+        ) as mock_dead:
+            await tick_window(bot, 1, 100, "@0", None)
+            mock_dead.assert_not_called()
+
+    async def test_misses_below_threshold_do_not_notify(self):
+        bot = AsyncMock(spec=Bot)
+        with patch.object(
+            window_tick, "_handle_dead_window_notification", new_callable=AsyncMock
+        ) as mock_dead:
+            for _ in range(MAX_MISSING_POLLS - 1):
+                await tick_window(bot, 1, 100, "@0", None)
+            mock_dead.assert_not_called()
+
+    async def test_reappearing_window_resets_the_counter(self):
+        bot = AsyncMock(spec=Bot)
+        window = _make_window("@0")
+        with (
+            patch.object(
+                window_tick, "_handle_dead_window_notification", new_callable=AsyncMock
+            ) as mock_dead,
+            patch.object(
+                window_tick, "discover_and_register_transcript", new_callable=AsyncMock
+            ),
+            patch.object(window_tick, "_update_status", new_callable=AsyncMock),
+            patch.object(window_tick, "_scan_window_panes", new_callable=AsyncMock),
+            patch.object(
+                window_tick, "_maybe_check_passive_shell", new_callable=AsyncMock
+            ),
+            patch.object(window_tick, "get_message_queue", return_value=None),
+        ):
+            for _ in range(MAX_MISSING_POLLS - 1):
+                await tick_window(bot, 1, 100, "@0", None)
+            await tick_window(bot, 1, 100, "@0", window)
+            for _ in range(MAX_MISSING_POLLS - 1):
+                await tick_window(bot, 1, 100, "@0", None)
+            mock_dead.assert_not_called()
+
+    async def test_threshold_reached_notifies_once(self):
+        bot = AsyncMock(spec=Bot)
+        with patch.object(
+            window_tick, "_handle_dead_window_notification", new_callable=AsyncMock
+        ) as mock_dead:
+            for _ in range(MAX_MISSING_POLLS + 2):
+                await tick_window(bot, 1, 100, "@0", None)
+            # The real handler marks dead-notified; it is mocked here, so the
+            # early-return guard never engages and every post-threshold tick
+            # calls through. What matters is that no call happened before the
+            # threshold was crossed.
+            assert mock_dead.call_count == 3
 
 
 class TestTickWindowPendingQueue:


### PR DESCRIPTION
## Summary

`status_poll_loop` rebuilds its window lookup every cycle from `TmuxManager.list_windows()`.
That method returns an empty list when `get_session()` hits a transient `_TmuxError`
(`multiplexer/tmux.py:206`) and silently drops individual windows whose pane metadata raises
(`multiplexer/tmux.py:250`, `logger.debug` only). `tick_window` treated a single absent poll as
death and went straight to `_handle_dead_window_notification`, so one bad read could put a
`⚠ Session ... ended.` banner on a topic whose window and agent were both still alive.

The `is_dead_notified` guard muted topics that had already been notified, so on a bad tick the
only topic that visibly got a banner was the most recently created one. That is why it presents
as "only new sessions disconnect".

This adds a `missing_polls` counter to `WindowPollState` and only takes the dead path once
`MAX_MISSING_POLLS` consecutive cycles have missed the window. A window that reappears resets
the counter. It mirrors the `MAX_PROBE_FAILURES` debounce already used for topic probes, so the
shape should be familiar.

Genuine deaths are unaffected: the `window_died` event stream calls
`_handle_dead_window_notification` directly and does not route through this path, so it still
fires instantly.

At the default 1s poll interval this delays a real tmux-backend death banner by about 2 seconds.

I kept the change out of `polling_coordinator.py` deliberately. It is already at its 120 line
ceiling, and a module-level counter there would have needed state the coordinator is not
supposed to own.

## Linked issue

Fixes #130

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Refactor or cleanup (no behaviour change)
- [ ] Documentation
- [ ] CI, tooling, or config

## How to test

1. `uv run pytest tests/ccgram/handlers/polling/test_window_tick.py -k Missing -v` covers the new
   behaviour: a single miss and a sub-threshold run of misses do not notify, a window that
   reappears resets the counter, and nothing fires before the threshold is crossed.
2. The two existing `TestTickWindowDeadWindow` cases now tick `MAX_MISSING_POLLS` times before
   asserting, since one tick is no longer enough to declare death. That is the intended
   behaviour change.
3. To see the original bug, patch `TmuxManager.list_windows` to return `[]` on a single call
   while a bound window is alive. On `main` that produces a recovery banner on a live topic; with
   this change it does not.

Ran locally on Python 3.14: `ruff format --check`, `ruff check`, `pyright src/ccgram/`, `deptry
src` all clean. Unit suite 5931 passed, integration suite 304 passed. Three failures in
`test_status_polling.py::TestMaybeDiscoverTranscript` also fail on a clean checkout of `main`
at a475e0f (a `KeyError: 'shell'` in a provider registry mock), so they are unrelated to this
change.

## Checklist

- [x] One concern only, scope limited to the summary above
- [x] I ran it and verified end to end (or explained below why that does not apply)

I hit this in daily use on ccgram 4.3.11 and have been running the equivalent debounce on my own
box since, with no recurrence of the spurious banner and no delay I have noticed on real window
deaths.

## Model used

Claude Opus 4.8 via Claude Code. It did the code reading, wrote the patch and the tests, and ran
the suites. I found the bug in daily use, directed the investigation, chose to put the debounce
in `window_tick` rather than the coordinator, and reviewed the result.

---

🤖 Generated with Claude Code (Claude Opus 4.8)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
