### PR TITLE
fix(provider): respect CLAUDE_CONFIG_DIR in Claude detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Respect `CLAUDE_CONFIG_DIR` when detecting the Claude provider from hook
+  payloads. A Claude session whose config home was redirected away from
+  `~/.claude` (multi-account setups, dev containers, cc-mirror-style clones)
+  was misdetected as codex because the transcript path no longer contained
+  `/.claude/`, dropping the turn's status update on Stop.
+
 ## [4.3.11] - 2026-07-11
 
 ### Fixed

--- a/src/ccgram/hooks/adapters.py
+++ b/src/ccgram/hooks/adapters.py
@@ -337,6 +337,31 @@ def get_hook_adapter(provider_name: str) -> HookAdapter | None:
     return _ADAPTERS[cast(ProviderName, provider_name)]
 
 
+def _claude_transcript_markers() -> tuple[str, ...]:
+    """Path substrings that identify a Claude transcript file.
+
+    Claude writes session transcripts under ``<config_dir>/projects/``. The
+    config dir defaults to ``~/.claude`` but follows the ``CLAUDE_CONFIG_DIR``
+    environment variable (a documented Claude Code setting), so a redirected
+    config home (dev containers, multi-account setups, cc-mirror-style clones)
+    must be honored in addition to the default.
+
+    Each marker ends in ``/projects/`` (Claude's actual transcript subtree) so
+    that the match is specific to Claude's layout and does not fire on
+    unrelated files that merely share a directory prefix, including:
+    - a bare ``CLAUDE_CONFIG_DIR`` of ``~`` (would otherwise match every file
+      under the home directory), and
+    - a codex transcript that happens to live inside the redirected tree.
+    """
+    markers = ["/.claude/projects/"]
+    raw = os.getenv("CLAUDE_CONFIG_DIR")
+    if raw:
+        config_dir = str(Path(raw).expanduser()).rstrip("/")
+        if config_dir:
+            markers.append(f"{config_dir}/projects/")
+    return tuple(markers)
+
+
 def detect_provider_from_payload(payload: dict[str, object]) -> ProviderName | None:
     """Best-effort provider detection when installed hook lacks --provider."""
     explicit = _str_field(payload, "provider_name")
@@ -357,11 +382,12 @@ def detect_provider_from_payload(payload: dict[str, object]) -> ProviderName | N
         provider = "gemini"
     elif (
         _str_field(payload, "permission_mode") or _str_field(payload, "model")
-    ) and "/.claude/" not in transcript_path:
+    ) and not any(m in transcript_path for m in _claude_transcript_markers()):
         # ``model``/``permission_mode`` are weak codex signals: Claude's Stop and
         # Notification payloads now also carry ``model``, so without this guard a
-        # Claude session (transcript under ~/.claude/) installed with no
-        # --provider flag is misdetected as codex.
+        # Claude session installed with no --provider flag is misdetected as
+        # codex. _claude_transcript_markers honors CLAUDE_CONFIG_DIR (defaults to
+        # /.claude/) so redirected config homes are still recognized as Claude.
         provider = "codex"
     elif _str_field(payload, "end_reason") or (
         session_id and not UUID_RE.match(session_id)

--- a/tests/ccgram/test_hook_provider_events.py
+++ b/tests/ccgram/test_hook_provider_events.py
@@ -404,6 +404,83 @@ def test_detect_provider_from_payload_codex_model_field_still_codex() -> None:
     assert detect_provider_from_payload({"model": "gpt-5-codex"}) == "codex"
 
 
+def test_detect_provider_claude_config_dir_redirect_not_codex(monkeypatch) -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    # When CLAUDE_CONFIG_DIR redirects the config home (a documented Claude
+    # Code setting used by multi-account setups, dev containers, and cc-mirror
+    # clones), Claude writes transcripts under the redirected dir, not ~/.claude.
+    # Such a Stop payload must still be recognized as Claude (None), not codex.
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/home/u/.cc-mirror/zai/config")
+    payload: dict[str, object] = {
+        "session_id": "550e8400-e29b-41d4-a716-446655440000",
+        "hook_event_name": "Stop",
+        "transcript_path": "/home/u/.cc-mirror/zai/config/projects/proj/sess.jsonl",
+        "model": "claude-sonnet-5",
+        "permission_mode": "default",
+    }
+    assert detect_provider_from_payload(payload) is None
+
+
+def test_detect_provider_claude_config_dir_redirect_no_false_positive(
+    monkeypatch,
+) -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    # A redirected config dir must not over-match: an unrelated transcript path
+    # that merely contains a generic component like "config" is still codex.
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/home/u/.cc-mirror/zai/config")
+    assert (
+        detect_provider_from_payload(
+            {
+                "session_id": "550e8400-e29b-41d4-a716-446655440000",
+                "transcript_path": "/tmp/some-config/app/sess.jsonl",
+                "model": "gpt-5",
+            }
+        )
+        == "codex"
+    )
+
+
+def test_detect_provider_claude_config_dir_home_value_no_overmatch(monkeypatch) -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    # CLAUDE_CONFIG_DIR="~" resolves to the home directory; the markers must
+    # still anchor on <dir>/projects/ so a codex transcript under the home dir
+    # is not swept up and misdetected as Claude.
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "~")
+    assert (
+        detect_provider_from_payload(
+            {
+                "session_id": "550e8400-e29b-41d4-a716-446655440000",
+                "transcript_path": "/home/u/.codex/sessions/sess.jsonl",
+                "model": "gpt-5",
+            }
+        )
+        == "codex"
+    )
+
+
+def test_detect_provider_claude_config_dir_claude_suffix_redirect(monkeypatch) -> None:
+    from ccgram.hooks.adapters import detect_provider_from_payload
+
+    # A redirect named like ".claude.custom" must be honored as its own config
+    # dir; the default /.claude/projects/ marker must not shadow it.
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/home/u/.claude.custom")
+    assert (
+        detect_provider_from_payload(
+            {
+                "session_id": "550e8400-e29b-41d4-a716-446655440000",
+                "hook_event_name": "Stop",
+                "transcript_path": "/home/u/.claude.custom/projects/proj/sess.jsonl",
+                "model": "claude-sonnet-5",
+                "permission_mode": "default",
+            }
+        )
+        is None
+    )
+
+
 def test_gemini_install_adds_provider_specific_hooks(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
Fixes #133

## Problem

`detect_provider_from_payload` (`src/ccgram/hooks/adapters.py`) recognizes a Claude transcript only by the hardcoded substring `/.claude/`. When `CLAUDE_CONFIG_DIR` redirects the config home (a documented Claude Code setting), Claude writes transcripts under the redirected dir, so the guard fails and the `model`/`permission_mode` fields in Claude Stop/Notification payloads trip the codex branch. The session is misdetected as codex, and on Stop the codex short-circuit drops the turn. See #133 for the full reproduction.

This extends PR #116, which added the `/.claude/` guard for the default home but did not cover redirected config homes.

## Fix

Add `_claude_transcript_markers()`, which returns the transcript-path markers that identify a Claude session:

- `/.claude/projects/` for the default home (basename match works across users), and
- `<resolved CLAUDE_CONFIG_DIR>/projects/` when `CLAUDE_CONFIG_DIR` is set.

Each marker is anchored on `projects/` (Claude's actual transcript subtree) rather than the bare config dir, which avoids three false-positive cases:

- `CLAUDE_CONFIG_DIR=~` would otherwise resolve to the home dir and match almost any path.
- a redirect named `.claude.custom` was silently shadowed by the default `/.claude/` substring.
- a codex transcript physically inside the redirected tree but outside `projects/` would have matched the bare prefix.

`config.py:92` already resolves `CLAUDE_CONFIG_DIR` the same way; this mirrors that resolution.

## Tests

Four new tests in `tests/ccgram/test_hook_provider_events.py`:

- redirected config dir recognized as Claude (not codex)
- redirected config dir does not over-match a generic `/config/` path
- `CLAUDE_CONFIG_DIR=~` does not sweep up a codex transcript under the home dir
- a `.claude.custom` redirect is honored as its own config dir

Full file: 23 passed. `ruff check`, `ruff format --check`, and `pyright` clean.

## CHANGELOG

Added an `Unreleased` > `Fixed` entry.