### PR TITLE
feat(provider): Kimi Code provider support

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -34,8 +34,10 @@ Backend-neutral terminal-multiplexer seam (mirrors the `providers/` seam). Calle
 
 - `base.py` — `AgentProvider` protocol, `ProviderCapabilities`, event types.
 - `registry.py` — `ProviderRegistry` (name→factory, singleton cache).
-- `_jsonl.py` — shared JSONL parsing base for Codex + Gemini + Pi.
-- `claude.py`, `codex.py`, `gemini.py`, `pi.py` — provider implementations.
+- `_jsonl.py` — shared JSONL parsing base for Codex + Gemini + Kimi + Pi.
+- `claude.py`, `codex.py`, `gemini.py`, `kimi.py`, `pi.py` — provider implementations.
+- `kimi.py` — Kimi Code provider (hookless, native binary so `pane_current_command` is `kimi`; a resumed session re-execs as `kimi-code` and both match via the `kimi-` prefix rule). Discovery scans `~/.kimi-code/session_index.jsonl` for the entry whose `workDir` matches the window cwd, newest transcript wins. Resume is `-S <session_id>` (an explicit id skips Kimi's picker; resuming appends to the same `wire.jsonl`, so byte offsets survive a restart). `parse_terminal_status` extracts the last complete `─`-fenced block and requires an interactive affordance (footer hint / `▶`❯ cursor / ≥2 numbered options); a cursor-marked question is `PermissionPrompt`, a plain heading is `SelectionUI`. Busy state comes from the bottom-of-pane spinner line (`<moon|braille>[ label] · Tip: …`). `parse_status_modes` reads `yolo`/`auto`/`plan` off the status bar for `scrape_current_mode`.
+- `kimi_format.py` — Kimi `wire.jsonl` parsers (`turn.prompt`, `context.append_loop_event` → `content.part`/`tool.call`/`tool.result`, epoch-ms → ISO-8601). `context.append_message` is deliberately skipped: it duplicates the user turn and carries injected system reminders.
 - `pi_format.py` — Pi transcript parsers (user/assistant/toolResult/bashExecution, session header, pending-tool tracking).
 - `pi_discovery.py` — Pi command discovery (builtins + skills + prompts + `pi.registerCommand` scans).
 - `codex_status.py`, `codex_format.py` — Codex status snapshot + permission/tool prompt formatter.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Each Telegram topic maps to one multiplexer window. Type in Telegram → keystro
 ## What You Can Do
 
 - **Bind agents to topics** — one agent per Telegram topic; create via directory browser
-- **Auto-detect providers** — Supports Claude Code, Codex, Gemini, Pi, and Shell simultaneously
+- **Auto-detect providers** — Supports Claude Code, Codex, Gemini, Kimi Code, Pi, and Shell simultaneously
 - **Monitor live** — Terminal screenshots on demand or auto-refresh every 5 seconds
 - **Send commands** — Slash commands, voice messages (transcribed via Whisper), or raw shell input
 - **Run multiple agents in parallel** — each topic independent; run different agents at once
@@ -102,16 +102,16 @@ Get user ID from [@userinfobot](https://t.me/userinfobot). Get group ID via [@Ra
 ccgram
 ```
 
-Open your Telegram group, create a topic, send a message — directory browser appears. Pick a project directory, choose your agent (Claude, Codex, Gemini, Pi, or Shell), and you're connected.
+Open your Telegram group, create a topic, send a message — directory browser appears. Pick a project directory, choose your agent (Claude, Codex, Gemini, Kimi, Pi, or Shell), and you're connected.
 
-**Prerequisites:** Python 3.14+, [tmux](https://github.com/tmux/tmux) or [herdr](https://github.com/ogulcancelik/herdr) (CCGram controls a terminal multiplexer; no agent SDK modifications needed), and one agent CLI (`claude`, `codex`, `gemini`, `pi` installed and authenticated, or use `shell` with no extra install).
+**Prerequisites:** Python 3.14+, [tmux](https://github.com/tmux/tmux) or [herdr](https://github.com/ogulcancelik/herdr) (CCGram controls a terminal multiplexer; no agent SDK modifications needed), and one agent CLI (`claude`, `codex`, `gemini`, `kimi`, `pi` installed and authenticated, or use `shell` with no extra install).
 
 ---
 
 ## Documentation
 
 - **[Guides](docs/guides.md)** — CLI reference, configuration, voice transcription, multi-instance setup, session recovery, testing
-- **[Providers](docs/providers.md)** — Claude Code, Codex, Gemini, Pi, Shell; session modes, LLM config, custom commands, git worktrees
+- **[Providers](docs/providers.md)** — Claude Code, Codex, Gemini, Kimi Code, Pi, Shell; session modes, LLM config, custom commands, git worktrees
 
 ---
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -9,19 +9,20 @@ CCGram supports multiple agent CLI backends. Each Telegram topic can use a diffe
 | Claude Code | `claude`    | Yes         | Yes    | Yes      | JSONL      | Hook events + pyte VT100 + spinner                                    |
 | Codex CLI   | `codex`     | Yes         | Yes    | Yes      | JSONL      | Hook Stop + pyte VT100 interactive UI + transcript activity heuristic |
 | Gemini CLI  | `gemini`    | Yes         | Yes    | Yes      | JSONL      | Hook AfterAgent + pane title + interactive UI + `/status` snapshot    |
+| Kimi Code   | `kimi`      | No          | Yes    | Yes      | JSONL wire | Fenced interactive block + spinner line + transcript activity          |
 | Pi          | `pi`        | Yes         | Yes    | Yes      | JSONL (v3) | Hook-runner Stop + transcript activity heuristic                      |
 | Shell       | `bash`      | No          | No     | No       | None       | Shell prompt idle detection                                           |
 
 ## Choosing a Provider
 
-**From Telegram**: When you create a new topic and select a directory, then — if the directory is an eligible git repo — choose whether to use the current branch or create a new worktree on a new branch (non-git directories skip this step), a provider picker appears with Claude (default), Codex, Gemini, Pi, and Shell options. After provider selection, CCGram asks for session mode:
+**From Telegram**: When you create a new topic and select a directory, then — if the directory is an eligible git repo — choose whether to use the current branch or create a new worktree on a new branch (non-git directories skip this step), a provider picker appears with Claude (default), Codex, Gemini, Kimi, Pi, and Shell options. After provider selection, CCGram asks for session mode:
 
 - `✅ Standard` (normal approvals)
 - `🚀 YOLO` (provider-specific permissive mode)
 
 **From the terminal**: If you create a window manually and start an agent CLI, CCGram auto-detects the provider from the running process name. When the pane command is a JS runtime wrapper (node, bun), it inspects the pane's foreground process to reliably identify the actual CLI. How the foreground process is read is owned by the multiplexer backend — tmux uses `ps -t <tty>`, herdr reads `pane process-info` (no tty needed) — so detection works the same on both. The shell provider uses the same seam to classify a bare shell pane. As a last resort, Gemini pane-title symbols (`✦`, `✋`, `◇`) are checked.
 
-**Default provider**: Set `CCGRAM_PROVIDER=codex` (or `gemini`, `pi`, `shell`) to change the default. Claude is the default if unset.
+**Default provider**: Set `CCGRAM_PROVIDER=codex` (or `gemini`, `kimi`, `pi`, `shell`) to change the default. Claude is the default if unset.
 
 ## Session Mode (Standard vs YOLO)
 
@@ -43,10 +44,11 @@ Override the CLI command used to launch each provider via `CCGRAM_<NAME>_COMMAND
 CCGRAM_CLAUDE_COMMAND=ce --current
 CCGRAM_CODEX_COMMAND=my-codex-wrapper
 CCGRAM_GEMINI_COMMAND=/opt/gemini/run
+CCGRAM_KIMI_COMMAND=kimi --model k3-256k
 CCGRAM_PI_COMMAND=pi --model sonnet
 ```
 
-`<NAME>` is uppercase: `CLAUDE`, `CODEX`, `GEMINI`, `PI`. Defaults to the provider's built-in command (`claude`, `codex`, `gemini`, `pi`) when unset. New providers automatically support `CCGRAM_<NAME>_COMMAND` without code changes.
+`<NAME>` is uppercase: `CLAUDE`, `CODEX`, `GEMINI`, `KIMI`, `PI`. Defaults to the provider's built-in command (`claude`, `codex`, `gemini`, `kimi`, `pi`) when unset. New providers automatically support `CCGRAM_<NAME>_COMMAND` without code changes.
 
 You can use this for a global "today" setup (all new sessions), for example:
 
@@ -63,6 +65,7 @@ Each provider exposes its own slash commands to the Telegram menu. Examples:
 - **Claude**: `/clear`, `/compact`, `/cost`, `/doctor`, `/permissions`...
 - **Codex**: `/model`, `/mode`, `/status`, `/diff`, `/compact`, `/mcp`...
 - **Gemini**: `/chat`, `/clear`, `/compress`, `/model`, `/memory`, `/vim`...
+- **Kimi**: `/new`, `/compact`, `/model`, `/effort`, `/permission`, `/plan`, `/yolo`, `/goal`, `/swarm`, `/usage`... (plus discovered skills)
 - **Pi**: `/new`, `/compact`, `/followup`, `/scoped_models`, `/export`, `/name`, `/reload`, `/session`, `/share`, `/changelog`... (plus discovered skills/prompts/extensions)
 
 ---
@@ -147,6 +150,66 @@ Older `session-*.json` whole-file transcripts are no longer monitored; only `.js
 ### Status Snapshot
 
 Gemini supports `/status` snapshots: CCGram parses recent transcript activity to render an inline summary of the current session (last activity, pending tools, tool_use counts) without waiting for the next pane refresh.
+
+## Kimi Code
+
+[Kimi Code](https://moonshotai.github.io/kimi-code/) is Moonshot AI's agent CLI. Unlike the other providers it ships as a **native binary**, so the multiplexer reports `kimi` as the pane command directly — no JS-runtime shim to see through. A resumed session re-execs as `kimi-code`; both spellings detect as the same provider.
+
+Kimi has no Claude-style lifecycle hooks, so it is a hookless provider like Codex and Gemini: session tracking works by scanning `~/.kimi-code/session_index.jsonl` for the entry whose `workDir` matches the window directory, then following it to the transcript. Nothing needs to be installed into Kimi's config.
+
+### Kimi Launch
+
+The default command is `kimi`. Override via `CCGRAM_KIMI_COMMAND`. YOLO mode appends `--yolo`, which takes effect straight from the flag — there is no in-TUI confirmation dialog to accept.
+
+Resume uses `-S <session_id>`. Passing an explicit id resumes non-interactively; bare `-S` would open Kimi's session picker, which ccgram can't drive over `send_keys`. `--continue` backs the Continue recovery button.
+
+### Kimi Transcript
+
+State lives under `~/.kimi-code`:
+
+```
+session_index.jsonl                                     {sessionId, sessionDir, workDir}
+sessions/<workspace>/<session>/agents/main/wire.jsonl   transcript
+```
+
+The transcript is a newline-delimited "wire" log (protocol 1.4). Each line is one record keyed by `type`:
+
+- `turn.prompt` — the human turn (`input` blocks + `origin.kind`)
+- `context.append_loop_event` — the agent loop, discriminated by `event.type`:
+  - `content.part` → `text` (assistant prose) or `think` (reasoning)
+  - `tool.call` → `toolCallId`, `name`, `args`, `description`
+  - `tool.result` → `toolCallId`, `result.output` (+ a `<system>` `result.note`)
+  - `step.begin` / `step.end` → bookkeeping, not relayed
+- `context.append_message` — **deliberately ignored**: it re-appends the same user turn *and* injected system reminders to the model context, so relaying it would duplicate every prompt and leak `<system-reminder>` text.
+
+Resuming appends to the existing `wire.jsonl`, so byte offsets stay valid across a restart and ccgram keeps reading incrementally without re-sending history. Kimi timestamps are epoch milliseconds and are normalised to ISO-8601 UTC.
+
+### Kimi Status Detection
+
+Kimi fences its approval prompts and pickers between full-width `─` rules. CCGram extracts the last complete fence and accepts it only when it carries an interactive affordance (footer hint like `↑/↓ select · 1/2/3/4 choose · ↵ confirm`, a `▶`/`❯` cursor, or a numbered option list), so a plain boxed notice is not mistaken for a prompt. A cursor-marked question (`▶ Run this command?`) is reported as `PermissionPrompt`; a plain heading (`Select permission mode`) as `SelectionUI` — option text mentioning "Approve" does not make a picker an approval.
+
+When no prompt is showing, the busy line above the input box decides: `<spinner>[ <label>] · Tip: …`, where the spinner is a moon phase (thinking) or a braille frame (streaming, labelled `working...`). Only the bottom of the pane is scanned, so a spinner left in scrollback does not read as busy.
+
+The status bar carries the active modes — `yolo`, `auto`, `plan`, combinable — which back the toolbar's Mode button. Shift+Tab toggles plan mode.
+
+### Kimi Commands
+
+Kimi's Telegram-safe built-ins include `/new`, `/compact`, `/model`, `/effort`, `/permission`, `/plan`, `/yolo`, `/auto`, `/goal`, `/swarm`, `/btw`, `/usage`, `/status`, `/init`, `/undo`, `/fork`, `/title`, and `/mcp`. `SKILL.md`-backed skills under `~/.kimi-code/skills/<name>/` and `<project>/.kimi/skills/<name>/` are discovered dynamically.
+
+`/clear` is accepted as a hidden compatibility alias for Kimi's `/new` (Kimi has no `/clear`). `/sessions` is not advertised because it collides with ccgram's bot-native session picker.
+
+### Kimi Toolbar
+
+Kimi's default toolbar uses Shift+Tab for plan mode and a nav row for driving its pickers:
+
+```
+[📸 Screen] [⛔ CtrlC] [📺 Live]
+[🔀 Mode]   [π Model]  [⎋ Esc]
+[🔼 Up]     [⏎ Enter]  [🔽 Down]
+[💬 Last]   [📎 File]  [✖️ Close]
+```
+
+Override with a `[providers.kimi]` block in `~/.ccgram/toolbar.toml`.
 
 ## Pi
 

--- a/src/ccgram/handlers/agent_command.py
+++ b/src/ccgram/handlers/agent_command.py
@@ -49,6 +49,7 @@ _PROVIDERS: tuple[tuple[str, str], ...] = (
     ("claude", "Claude"),
     ("codex", "Codex"),
     ("gemini", "Gemini"),
+    ("kimi", "Kimi"),
     ("pi", "Pi"),
     ("shell", "Shell"),
 )

--- a/src/ccgram/handlers/commands/forward.py
+++ b/src/ccgram/handlers/commands/forward.py
@@ -59,9 +59,13 @@ logger = structlog.get_logger()
 
 
 _NAV_KEYS = ("up", "down", "enter", "esc")
-_PI_CLEAR_ALIAS_COMMAND = "clear"
+_CLEAR_ALIAS_COMMAND = "clear"
+_NEW_COMMAND = "new"
 _PI_FOLLOWUP_COMMAND = "followup"
-_PI_NEW_COMMAND = "new"
+
+# Providers whose documented session reset is ``/new`` — ``/clear`` is kept as
+# a hidden compatibility alias so muscle memory from Claude Code still works.
+_NEW_RESET_PROVIDERS = frozenset({"kimi", "pi"})
 
 
 def _picker_hint(provider_name: str) -> str:
@@ -95,8 +99,11 @@ def _default_command_args(cc_name: str, args: str, display: str) -> str:
 
 def _provider_command_name(provider_name: str, cc_name: str) -> str:
     """Apply provider-specific compatibility aliases before forwarding."""
-    if provider_name == "pi" and cc_name.lower() == _PI_CLEAR_ALIAS_COMMAND:
-        return _PI_NEW_COMMAND
+    if (
+        provider_name in _NEW_RESET_PROVIDERS
+        and cc_name.lower() == _CLEAR_ALIAS_COMMAND
+    ):
+        return _NEW_COMMAND
     return cc_name
 
 
@@ -106,8 +113,8 @@ def _is_session_reset_command(provider_name: str, cc_slash: str) -> bool:
     command = parts[0].lstrip("/").lower()
     if len(parts) > 1:
         return False
-    return command == _PI_CLEAR_ALIAS_COMMAND or (
-        provider_name == "pi" and command == _PI_NEW_COMMAND
+    return command == _CLEAR_ALIAS_COMMAND or (
+        provider_name in _NEW_RESET_PROVIDERS and command == _NEW_COMMAND
     )
 
 

--- a/src/ccgram/handlers/topics/directory_browser.py
+++ b/src/ccgram/handlers/topics/directory_browser.py
@@ -316,6 +316,7 @@ _PROVIDER_META: dict[str, tuple[str, str]] = {
     "claude": ("Claude", "\U0001f7e0"),
     "codex": ("Codex", "\U0001f9e9"),
     "gemini": ("Gemini", "\u264a"),
+    "kimi": ("Kimi", "\U0001f319"),
     "pi": ("Pi", "\U0001f916"),
     "shell": ("Shell", "\U0001f41a"),
 }

--- a/src/ccgram/providers/__init__.py
+++ b/src/ccgram/providers/__init__.py
@@ -32,6 +32,7 @@ _YOLO_FLAGS: dict[str, str] = {
     "claude": "--dangerously-skip-permissions",
     "codex": "--dangerously-bypass-approvals-and-sandbox",
     "gemini": "--yolo",
+    "kimi": "--yolo",
 }
 
 
@@ -62,6 +63,9 @@ def _ensure_registered() -> None:
     from ccgram.providers.gemini import GeminiProvider
 
     # Lazy: provider classes register against the registry at import; defer until the registry factory runs
+    from ccgram.providers.kimi import KimiProvider
+
+    # Lazy: provider classes register against the registry at import; defer until the registry factory runs
     from ccgram.providers.pi import PiProvider
 
     # Lazy: provider classes register against the registry at import; defer until the registry factory runs
@@ -70,6 +74,7 @@ def _ensure_registered() -> None:
     registry.register("claude", ClaudeProvider)
     registry.register("codex", CodexProvider)
     registry.register("gemini", GeminiProvider)
+    registry.register("kimi", KimiProvider)
     registry.register("pi", PiProvider)
     registry.register("shell", ShellProvider)
     _registered = True
@@ -140,7 +145,7 @@ def detect_provider_from_command(pane_current_command: str) -> str:
     # Match basename only (first token) to avoid false positives
     # from paths like /home/claude/bin/vim
     basename = os.path.basename(cmd.split()[0])
-    for name in ("claude", "codex", "gemini", "pi"):
+    for name in ("claude", "codex", "gemini", "kimi", "pi"):
         if basename == name or basename.startswith(name + "-"):
             return name
 
@@ -177,6 +182,8 @@ def detect_provider_from_transcript_path(transcript_path: str) -> str:
         return "claude"
     if "/.gemini/" in normalized and "/chats/" in normalized:
         return "gemini"
+    if "/.kimi-code/sessions/" in normalized:
+        return "kimi"
     if "/.pi/agent/sessions/" in normalized:
         return "pi"
     return ""

--- a/src/ccgram/providers/kimi.py
+++ b/src/ccgram/providers/kimi.py
@@ -1,0 +1,655 @@
+"""Kimi Code provider — Moonshot AI's ``kimi`` CLI behind AgentProvider.
+
+Kimi Code is a native (non-Node) binary, so the multiplexer reports ``kimi``
+as ``pane_current_command`` directly — no runtime-shim detection needed.
+
+State lives under ``~/.kimi-code``::
+
+    session_index.jsonl                     {sessionId, sessionDir, workDir}
+    sessions/<workspace>/<session>/state.json
+    sessions/<workspace>/<session>/agents/main/wire.jsonl   ← transcript
+
+Kimi has no Claude-style lifecycle hooks, so it is a hookless provider like
+Codex and Gemini: sessions are discovered by scanning ``session_index.jsonl``
+for the newest entry whose ``workDir`` matches the window's directory, and the
+transcript is the source of truth for relayed messages.
+
+Resume strategy: ``-S <session_id>``.  Passing an explicit id resumes directly
+without opening kimi's interactive picker, and kimi *appends* to the existing
+``wire.jsonl``, so byte offsets stay valid across a resume.
+
+Terminal chrome (kimi 0.31):
+  - Status bar (last two rows): ``[<modes> ]<model> thinking: <effort>  …/cwd``
+    and ``context: N% (x/256k)``.  Modes are ``yolo``, ``auto`` and ``plan``.
+  - Busy line above the input box: ``<spinner>[ <label>] · Tip: …`` where the
+    spinner is a moon phase (thinking) or braille frame (streaming).
+  - Interactive prompts and pickers are fenced between full-width ``─`` rules.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import time
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from ccgram.providers._jsonl import JsonlProvider
+from ccgram.providers.base import (
+    AgentMessage,
+    DiscoveredCommand,
+    ProviderCapabilities,
+    RESUME_ID_RE,
+    SessionStartEvent,
+    StatusUpdate,
+)
+from ccgram.providers.kimi_format import (
+    LOOP_EVENT,
+    TURN_PROMPT,
+    Pending,
+    normalize_pending,
+    parse_loop_event,
+    parse_turn_prompt,
+)
+
+logger = structlog.get_logger()
+
+# Cap transcript age when adopting an existing pane — guards against picking up
+# an unrelated historical session for the same cwd.
+_STALE_TRANSCRIPT_MAX_AGE_SECS = 120.0
+
+# How many recent index entries to inspect when searching for a cwd match.
+_DISCOVERY_SCAN_LIMIT = 50
+
+_SHORT_SESSION_ID_LEN = 8
+_SHORT_SESSION_ID_THRESHOLD = 10
+
+
+def kimi_home() -> Path:
+    """Return kimi's state directory (``~/.kimi-code``)."""
+    return Path.home() / ".kimi-code"
+
+
+def session_index_path() -> Path:
+    """Return the path of kimi's append-only session index."""
+    return kimi_home() / "session_index.jsonl"
+
+
+def transcript_for_session_dir(session_dir: str) -> Path:
+    """Return the main agent's wire log inside a kimi session directory."""
+    return Path(session_dir) / "agents" / "main" / "wire.jsonl"
+
+
+# ── Terminal chrome ──────────────────────────────────────────────────────
+
+# Full-width horizontal rule fencing an interactive prompt or picker.
+_RULE_RE = re.compile(r"^\s*─{20,}\s*$")
+
+# Footer/legend hints kimi renders inside an interactive region.  Matching any
+# one of these is what separates a real prompt from decorative rules.
+_INTERACTIVE_HINTS = (
+    re.compile(r"↑/?↓\s"),  # "↑/↓ select" / "↑↓ navigate"
+    re.compile(r"(?i)\bEnter\s+select\b"),
+    re.compile(r"(?i)\bEsc\s+cancel\b"),
+    re.compile(r"↵\s+confirm"),  # "↵ confirm"
+    re.compile(r"(?i)\bchoose\b"),
+)
+
+# Selection cursor kimi paints on the highlighted row.
+_CURSOR_RE = re.compile(r"^\s*[▶❯]\s+\S")
+
+# A numbered option row ("  2. Approve for this session").
+_NUMBERED_OPTION_RE = re.compile(r"^\s*(?:[▶❯]\s+)?\d+\.\s+\S")
+
+_MIN_NUMBERED_OPTIONS = 2
+
+# A fence needs an opening and a closing rule, with at least one content row
+# between them, before it can be read as an interactive block.
+_MIN_FENCE_RULES = 2
+_MIN_FENCE_SPAN = 2
+
+# Question header on an approval prompt ("▶ Run this command?").
+_PROMPT_HEADER_RE = re.compile(r"^\s*[▶❯]\s+(.+\?)\s*$")
+
+# Approval prompts carry these; other pickers (model, theme, …) do not.
+_PERMISSION_HINT_RE = re.compile(
+    r"(?i)\b(approve|reject|allow|deny|permission|proceed)\b"
+)
+
+# Busy spinner frames: moon phases U+1F311–U+1F318 (thinking) and braille
+# U+2800–U+28FF (streaming), followed by an optional label then " · <tip>".
+_SPINNER_RE = re.compile(
+    r"^\s*(?:[\U0001f311-\U0001f318]|[⠀-⣿])\s*(?P<label>[^·]*?)\s*·\s"
+)
+
+# Status bar: "[<modes> ]<model> thinking: <effort>  …/cwd".
+_STATUS_BAR_RE = re.compile(
+    r"^\s*(?P<modes>(?:yolo|auto|plan|manual)(?:\s+(?:yolo|auto|plan|manual))*\s+)?\S+ thinking:\s"
+)
+
+_MODE_LABELS = {
+    "yolo": "YOLO",
+    "auto": "Auto",
+    "plan": "Plan",
+    "manual": "Manual",
+}
+
+# How far up from the bottom to look for the status bar / spinner.
+_BOTTOM_SCAN_LINES = 6
+
+
+def _extract_fenced_block(lines: list[str]) -> list[str] | None:
+    """Return the content between the last pair of full-width ``─`` rules.
+
+    Conservative against torn captures: a dangling rule below the closing one
+    (a block mid-render) yields None so the next poll reads a complete frame.
+    """
+    rule_rows = [i for i, line in enumerate(lines) if _RULE_RE.match(line)]
+    if len(rule_rows) < _MIN_FENCE_RULES:
+        return None
+    close_idx = rule_rows[-1]
+    open_idx = rule_rows[-2]
+    if close_idx - open_idx < _MIN_FENCE_SPAN:
+        return None
+    inner = [line.rstrip() for line in lines[open_idx + 1 : close_idx]]
+    while inner and not inner[0].strip():
+        inner.pop(0)
+    while inner and not inner[-1].strip():
+        inner.pop()
+    return inner or None
+
+
+def _block_is_interactive(block: list[str]) -> bool:
+    """True when a fenced block carries an interactive affordance.
+
+    A footer hint or a selection cursor is sufficient on its own; a bare
+    numbered list needs two entries so prose containing "1." is not misread.
+    """
+    numbered = 0
+    for line in block:
+        if any(hint.search(line) for hint in _INTERACTIVE_HINTS):
+            return True
+        if _CURSOR_RE.match(line):
+            return True
+        if _NUMBERED_OPTION_RE.match(line):
+            numbered += 1
+            if numbered >= _MIN_NUMBERED_OPTIONS:
+                return True
+    return False
+
+
+def _block_title(block: list[str]) -> tuple[str, bool]:
+    """Return ``(title, is_question)`` for a fenced interactive block.
+
+    Approval prompts lead with a cursor-marked question (``▶ Run this
+    command?``); menu pickers lead with a plain heading (``Select permission
+    mode``).  The flag lets the caller tell the two apart — the option text of
+    a picker can mention "approve" without the block being an approval.
+    """
+    for line in block:
+        match = _PROMPT_HEADER_RE.match(line)
+        if match:
+            return match.group(1).strip(), True
+
+    for line in block:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if any(hint.search(stripped) for hint in _INTERACTIVE_HINTS):
+            continue
+        if _CURSOR_RE.match(line) or _NUMBERED_OPTION_RE.match(line):
+            break
+        return stripped, False
+    return "", False
+
+
+def _nonblank_tail(pane_text: str) -> list[str]:
+    """Split pane text into lines with trailing blank rows dropped."""
+    lines = pane_text.split("\n")
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return lines
+
+
+def _spinner_label(lines: list[str]) -> str | None:
+    """Return the busy-line label when kimi is mid-turn, else None.
+
+    The spinner sits just above the input box, so only the tail of the pane is
+    scanned — a spinner glyph inside scrollback must not read as "busy".
+    """
+    for line in reversed(lines[-_BOTTOM_SCAN_LINES:]):
+        match = _SPINNER_RE.match(line)
+        if match:
+            return match.group("label").strip()
+    return None
+
+
+def parse_status_modes(pane_text: str) -> str | None:
+    """Extract the mode badge (``YOLO``, ``Plan``, …) from kimi's status bar."""
+    for line in reversed(_nonblank_tail(pane_text)[-_BOTTOM_SCAN_LINES:]):
+        match = _STATUS_BAR_RE.match(line)
+        if not match:
+            continue
+        modes = (match.group("modes") or "").split()
+        labels = [_MODE_LABELS[m] for m in modes if m in _MODE_LABELS]
+        return " ".join(labels) if labels else None
+    return None
+
+
+# ── Commands ─────────────────────────────────────────────────────────────
+
+# Kimi built-ins worth surfacing in Telegram (/commands listing + autocomplete).
+# Modal TUI flows are still forwarded — they are driven with the inline toolbar.
+#
+# /sessions is excluded: it collides with ccgram's own session picker.
+# /clear is accepted as a hidden compatibility alias in forward.py; kimi's
+# documented reset command is /new.
+_KIMI_TELEGRAM_BUILTINS: dict[str, str] = {
+    "/add-dir": "Add or list an additional workspace directory",
+    "/auto": "Toggle Auto mode — fully autonomous, never asks",
+    "/btw": "Ask a forked side agent a question",
+    "/compact": "Compact the conversation context",
+    "/copy": "Copy the last assistant message to the clipboard",
+    "/editor": "Set the external editor for Ctrl-G",
+    "/effort": "Switch thinking effort",
+    "/experiments": "Manage experimental features",
+    "/export-md": "Export current session as a Markdown file",
+    "/fork": "Fork the current session",
+    "/goal": "Start or manage an autonomous goal",
+    "/help": "Show available commands and shortcuts",
+    "/init": "Analyze the codebase and generate AGENTS.md",
+    "/login": "Select a platform and authenticate",
+    "/logout": "Log out of a configured provider",
+    "/mcp": "Show MCP server status",
+    "/mcp-config": "Configure MCP servers and handle MCP OAuth login",
+    "/model": "Switch LLM model",
+    "/new": "Start a fresh session in the current workspace",
+    "/permission": "Select permission mode",
+    "/plan": "Toggle plan mode",
+    "/plugins": "Manage plugins",
+    "/provider": "Manage AI providers (add / delete / refresh)",
+    "/settings": "Open TUI settings",
+    "/status": "Show current session and runtime status",
+    "/swarm": "Toggle swarm mode or run one task in swarm mode",
+    "/tasks": "Browse background tasks",
+    "/theme": "Set the terminal UI theme",
+    "/title": "Set or show session title",
+    "/undo": "Withdraw the last prompt from the transcript",
+    "/usage": "Show session tokens, context window and plan quotas",
+    "/version": "Show version information",
+    "/yolo": "Toggle YOLO mode — auto-approve tool actions",
+}
+
+# Commands that open a modal in-TUI picker the user must drive with arrow keys.
+# Must stay a subset of the built-ins above (enforced by the picker-drift test).
+_KIMI_PICKER_COMMANDS = frozenset(
+    {
+        "editor",
+        "effort",
+        "experiments",
+        "login",
+        "logout",
+        "mcp-config",
+        "model",
+        "permission",
+        "plugins",
+        "provider",
+        "settings",
+        "tasks",
+        "theme",
+    }
+)
+
+
+class KimiProvider(JsonlProvider):
+    """AgentProvider implementation for the Kimi Code CLI."""
+
+    _CAPS = ProviderCapabilities(
+        name="kimi",
+        launch_command="kimi",
+        supports_hook=False,
+        supports_resume=True,
+        supports_continue=True,
+        supports_structured_transcript=True,
+        supports_incremental_read=True,
+        builtin_commands=tuple(_KIMI_TELEGRAM_BUILTINS.keys()),
+        supports_user_command_discovery=False,
+        supports_status_snapshot=True,
+        # ``kimi --yolo`` enters permissive mode straight from the CLI flag —
+        # there is no in-TUI confirmation dialog to accept afterwards.
+        has_yolo_confirmation=False,
+        tui_picker_commands=_KIMI_PICKER_COMMANDS,
+    )
+
+    _BUILTINS = _KIMI_TELEGRAM_BUILTINS
+
+    # ── Launch ───────────────────────────────────────────────────────────
+
+    def make_launch_args(
+        self,
+        resume_id: str | None = None,
+        use_continue: bool = False,
+    ) -> str:
+        """Build CLI args.  ``-S <id>`` resumes without the interactive picker."""
+        if resume_id:
+            if not RESUME_ID_RE.match(resume_id):
+                raise ValueError(f"Invalid resume_id: {resume_id!r}")
+            return f"-S {shlex.quote(resume_id)}"
+        if use_continue:
+            return "--continue"
+        return ""
+
+    # ── Transcript parsing ───────────────────────────────────────────────
+
+    def parse_transcript_entries(
+        self,
+        entries: list[dict[str, Any]],
+        pending_tools: dict[str, Any],
+        cwd: str | None = None,  # noqa: ARG002 — kept for protocol compat
+    ) -> tuple[list[AgentMessage], dict[str, Any]]:
+        """Parse wire records into AgentMessages, pairing tool calls to results."""
+        messages: list[AgentMessage] = []
+        pending: Pending = normalize_pending(pending_tools)
+
+        for entry in entries:
+            record_type = entry.get("type")
+            if record_type == TURN_PROMPT:
+                message = parse_turn_prompt(entry)
+            elif record_type == LOOP_EVENT:
+                message = parse_loop_event(entry, pending)
+            else:
+                # context.append_message duplicates the user turn and carries
+                # injected system reminders — never relayed.
+                continue
+            if message is not None:
+                messages.append(message)
+
+        return messages, dict(pending)
+
+    def is_user_transcript_entry(self, entry: dict[str, Any]) -> bool:
+        """Return True for a human turn (``turn.prompt`` with a user origin)."""
+        if entry.get("type") != TURN_PROMPT:
+            return False
+        origin = entry.get("origin")
+        return not (
+            isinstance(origin, dict) and origin.get("kind") not in (None, "user")
+        )
+
+    def parse_history_entry(self, entry: dict[str, Any]) -> AgentMessage | None:
+        """Parse one wire record for history display (user + assistant text)."""
+        record_type = entry.get("type")
+        if record_type == TURN_PROMPT:
+            return parse_turn_prompt(entry)
+        if record_type == LOOP_EVENT:
+            message = parse_loop_event(entry, {})
+            if message is not None and message.content_type == "text":
+                return message
+        return None
+
+    # ── Discovery ────────────────────────────────────────────────────────
+
+    def _index_entries(self) -> list[dict[str, str]]:
+        """Read kimi's session index, newest last.  Empty on any read error."""
+        try:
+            with open(session_index_path(), encoding="utf-8") as fh:
+                raw_lines = fh.readlines()
+        except OSError:
+            return []
+
+        entries: list[dict[str, str]] = []
+        for raw in raw_lines:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(data, dict):
+                continue
+            session_id = data.get("sessionId")
+            session_dir = data.get("sessionDir")
+            work_dir = data.get("workDir")
+            if not (
+                isinstance(session_id, str)
+                and isinstance(session_dir, str)
+                and isinstance(work_dir, str)
+            ):
+                continue
+            entries.append(
+                {
+                    "session_id": session_id,
+                    "session_dir": session_dir,
+                    "work_dir": work_dir,
+                }
+            )
+        return entries
+
+    def discover_transcript(
+        self,
+        cwd: str,
+        window_key: str,
+        *,
+        max_age: float | None = None,
+    ) -> SessionStartEvent | None:
+        """Return the newest kimi session whose ``workDir`` matches *cwd*.
+
+        Candidates come from ``session_index.jsonl`` (append-only, so the tail
+        is the most recent), and are ranked by transcript mtime rather than
+        index order — a resumed session keeps its original index position but
+        has the freshest wire log.
+        """
+        if not cwd:
+            return None
+
+        age_limit = (
+            _STALE_TRANSCRIPT_MAX_AGE_SECS if max_age is None else float(max_age)
+        )
+        now = time.time()
+        try:
+            resolved_target = str(Path(cwd).resolve())
+        except OSError:
+            return None
+
+        candidates: list[tuple[float, dict[str, str], Path]] = []
+        for entry in reversed(self._index_entries()[-_DISCOVERY_SCAN_LIMIT:]):
+            try:
+                if str(Path(entry["work_dir"]).resolve()) != resolved_target:
+                    continue
+            except OSError:
+                continue
+            transcript = transcript_for_session_dir(entry["session_dir"])
+            try:
+                mtime = transcript.stat().st_mtime
+            except OSError:
+                continue
+            candidates.append((mtime, entry, transcript))
+
+        if not candidates:
+            return None
+
+        mtime, entry, transcript = max(candidates, key=lambda item: item[0])
+        if age_limit > 0 and now - mtime > age_limit:
+            return None
+
+        return SessionStartEvent(
+            session_id=entry["session_id"],
+            cwd=entry["work_dir"],
+            transcript_path=str(transcript),
+            window_key=window_key,
+        )
+
+    # ── Terminal status ──────────────────────────────────────────────────
+
+    def parse_terminal_status(
+        self,
+        pane_text: str,
+        *,
+        pane_title: str = "",  # noqa: ARG002 — kimi's title is a constant
+    ) -> StatusUpdate | None:
+        """Parse kimi's pane for an interactive prompt or a busy spinner.
+
+        Interactive regions are fenced between full-width ``─`` rules, so the
+        last complete fence is extracted and accepted only when it carries an
+        interactive affordance (footer hint, selection cursor, or a numbered
+        option list).  Otherwise the busy line above the input box decides.
+        """
+        if not pane_text:
+            return None
+
+        lines = _nonblank_tail(pane_text)
+        if not lines:
+            return None
+
+        block = _extract_fenced_block(lines)
+        if block and _block_is_interactive(block):
+            title, is_question = _block_title(block)
+            body = "\n".join(block)
+            is_permission = is_question and bool(_PERMISSION_HINT_RE.search(body))
+            ui_type = "PermissionPrompt" if is_permission else "SelectionUI"
+            return StatusUpdate(
+                raw_text=body,
+                display_label=title or ui_type,
+                is_interactive=True,
+                ui_type=ui_type,
+            )
+
+        label = _spinner_label(lines)
+        if label is not None:
+            text = label or "working"
+            return StatusUpdate(raw_text=text, display_label=f"…{text}")
+
+        return None
+
+    async def scrape_current_mode(
+        self,
+        window_id: str,
+        *,
+        capture_fn: Callable[[str], Awaitable[str | None]] | None = None,
+    ) -> str | None:
+        """Return kimi's active mode badge (``YOLO``, ``Plan``, …) or None.
+
+        ``capture_fn`` is injectable for tests — defaults to the multiplexer
+        proxy's ``capture_pane`` so production callers need no changes.
+        """
+        if not window_id:
+            return None
+        if capture_fn is not None:
+            _fn: Callable[[str], Awaitable[str | None]] = capture_fn
+        else:
+            # Lazy: the multiplexer package imports providers; deferring the
+            # import keeps the provider module free of that cycle.
+            from ccgram.multiplexer import multiplexer
+
+            _fn = multiplexer.capture_pane
+        try:
+            capture = await _fn(window_id)
+        except OSError as exc:
+            logger.warning("Mode scrape: capture_pane failed %s (%s)", window_id, exc)
+            return None
+        if not capture:
+            return None
+        return parse_status_modes(capture)
+
+    # ── Status snapshot ──────────────────────────────────────────────────
+
+    def build_status_snapshot(
+        self,
+        transcript_path: str,
+        *,
+        display_name: str = "",
+        session_id: str = "",
+        cwd: str = "",
+    ) -> str | None:
+        """Build a lightweight status snapshot for a kimi session."""
+        try:
+            size = os.path.getsize(transcript_path)
+        except OSError:
+            return None
+
+        # Kimi ids are ``session_<uuid>``; drop the redundant prefix and keep a
+        # readable head. Ids that are already short pass through untouched.
+        short_id = session_id
+        prefix = "session_"
+        if short_id.startswith(prefix):
+            short_id = short_id[len(prefix) :]
+        if len(short_id) > _SHORT_SESSION_ID_THRESHOLD:
+            short_id = short_id[:_SHORT_SESSION_ID_LEN]
+
+        return (
+            f"\U0001f319 [{display_name}] Kimi session active.\n"
+            f"\U0001f4c2 `{cwd}`\n"
+            f"\U0001f4c4 `{os.path.basename(transcript_path)}` ({size} bytes)\n"
+            f"⭐ ID: `{short_id}`"
+        )
+
+    def has_output_since(self, transcript_path: str, offset: int) -> bool:
+        """Check whether the wire log grew past *offset*."""
+        try:
+            return os.path.getsize(transcript_path) > offset
+        except OSError:
+            return False
+
+    # ── Commands ─────────────────────────────────────────────────────────
+
+    def discover_commands(self, base_dir: str) -> list[DiscoveredCommand]:
+        """Return kimi built-ins plus workspace/user skills."""
+        commands = super().discover_commands(base_dir)
+        seen = {cmd.name for cmd in commands}
+        for skill in _discover_kimi_skills(base_dir):
+            if skill.name in seen:
+                continue
+            commands.append(skill)
+            seen.add(skill.name)
+        return commands
+
+
+def _skill_dirs(base_dir: str) -> list[Path]:
+    """Return the skill roots kimi loads: user-level then workspace-level."""
+    dirs = [kimi_home() / "skills"]
+    if base_dir:
+        dirs.append(Path(base_dir) / ".kimi" / "skills")
+    return dirs
+
+
+def _discover_kimi_skills(base_dir: str) -> list[DiscoveredCommand]:
+    """Discover ``SKILL.md``-backed kimi skills as slash commands."""
+    # Lazy: command_catalog pulls provider/config machinery; only needed when
+    # a caller actually enumerates commands.
+    from ccgram.command_catalog import parse_frontmatter
+
+    found: list[DiscoveredCommand] = []
+    for root in _skill_dirs(base_dir):
+        try:
+            children = sorted(root.iterdir())
+        except OSError:
+            continue
+        for entry in children:
+            skill_file = entry / "SKILL.md"
+            if not skill_file.is_file():
+                continue
+            frontmatter = parse_frontmatter(skill_file)
+            name = frontmatter.get("name") or entry.name
+            description = frontmatter.get("description", "")
+            found.append(
+                DiscoveredCommand(
+                    name=f"/{name}",
+                    description=description or f"Kimi skill: {name}",
+                    source="skill",
+                )
+            )
+    return found
+
+
+__all__ = [
+    "KimiProvider",
+    "kimi_home",
+    "parse_status_modes",
+    "session_index_path",
+    "transcript_for_session_dir",
+]

--- a/src/ccgram/providers/kimi_format.py
+++ b/src/ccgram/providers/kimi_format.py
@@ -1,0 +1,290 @@
+"""Kimi Code transcript formatting — parse kimi ``wire.jsonl`` into AgentMessages.
+
+Kimi Code records each session as a newline-delimited "wire" log at::
+
+    ~/.kimi-code/sessions/<workspace_id>/<session_id>/agents/main/wire.jsonl
+
+Every line is one record discriminated by ``type``.  The records that carry
+conversation content are:
+
+``turn.prompt``
+    A human turn — ``{"input": [{"type": "text", "text": ...}],
+    "origin": {"kind": "user"}, "time": <epoch_ms>}``.
+
+``context.append_loop_event``
+    Wraps the agent loop under ``event.type``:
+      - ``content.part`` — ``part.type`` is ``text`` (assistant prose) or
+        ``think`` (reasoning)
+      - ``tool.call`` — ``uuid``/``toolCallId``, ``name``, ``args``,
+        ``description``
+      - ``tool.result`` — ``parentUuid``/``toolCallId``, ``result.output``
+        (plus an optional ``result.note`` ``<system>`` annotation)
+      - ``step.begin`` / ``step.end`` — turn bookkeeping, no relay output
+
+``context.append_message`` re-appends the same user turn *and* injected system
+reminders to the model context, so it is deliberately ignored: relaying it
+would duplicate every prompt and leak ``<system-reminder>`` text into Telegram.
+
+Timestamps are epoch milliseconds; they are normalised to ISO-8601 UTC so
+history rendering matches the other providers.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from ccgram.expandable_quote import format_expandable_quote
+from ccgram.providers.base import AgentMessage, ContentType
+from ccgram.tool_format import format_tool_line
+
+# Record type discriminators.
+TURN_PROMPT = "turn.prompt"
+LOOP_EVENT = "context.append_loop_event"
+APPEND_MESSAGE = "context.append_message"
+METADATA = "metadata"
+
+# ``event.type`` values inside a ``context.append_loop_event`` record.
+EVENT_CONTENT_PART = "content.part"
+EVENT_TOOL_CALL = "tool.call"
+EVENT_TOOL_RESULT = "tool.result"
+
+# Outputs longer than this render as a line count + expandable quote.
+_TOOL_RESULT_QUOTE_THRESHOLD = 3
+
+# Pending value: toolCallId -> tool name.
+Pending = dict[str, str]
+
+# Milliseconds-since-epoch guard: kimi always emits ms, but a seconds-based
+# value would silently render as 1970, so only convert plausible timestamps.
+_MIN_EPOCH_MS = 10**11
+
+
+def epoch_ms_to_iso(value: Any) -> str | None:
+    """Convert kimi's epoch-millisecond ``time`` field to an ISO-8601 UTC string."""
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    if value < _MIN_EPOCH_MS:
+        return None
+    try:
+        return datetime.fromtimestamp(value / 1000, tz=UTC).isoformat()
+    except OverflowError, OSError, ValueError:
+        return None
+
+
+def extract_text(content: Any) -> str:
+    """Collect visible text from a kimi content field (string or block list)."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts)
+
+
+# Preferred ``args`` keys per tool, used to build a short call summary.
+_TOOL_SUMMARY_ARG_KEYS: dict[str, tuple[str, ...]] = {
+    "bash": ("command",),
+    "read": ("path", "file_path"),
+    "readmediafile": ("path", "file_path"),
+    "write": ("path", "file_path"),
+    "edit": ("path", "file_path"),
+    "grep": ("pattern",),
+    "glob": ("pattern",),
+    "websearch": ("query",),
+    "fetchurl": ("url",),
+    "skill": ("name", "command"),
+    "agent": ("description", "prompt"),
+    "agentswarm": ("description", "prompt"),
+    "askuserquestion": ("question",),
+}
+
+
+def _first_string_arg(args: dict[str, Any], keys: tuple[str, ...]) -> str:
+    """Return the first non-empty string value among *keys*."""
+    for key in keys:
+        value = args.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def tool_call_summary(name: str, args: dict[str, Any], description: str = "") -> str:
+    """Build the one-line tool-call display for a kimi ``tool.call`` event.
+
+    Prefers the tool's own argument (command / path / pattern) so the summary
+    matches the other providers, then kimi's prewritten ``description``
+    ("Running: ls -la"), then any string argument.
+    """
+    preferred = _first_string_arg(args, _TOOL_SUMMARY_ARG_KEYS.get(name.lower(), ()))
+    if preferred:
+        return format_tool_line(name, preferred)
+    if description:
+        return format_tool_line(name, description)
+    for value in args.values():
+        if isinstance(value, str) and value:
+            return format_tool_line(name, value)
+    return format_tool_line(name, "")
+
+
+def format_tool_result_text(output: str) -> str:
+    """Render long outputs as ``N lines`` + expandable quote, short ones inline."""
+    if not output:
+        return "Done"
+    line_count = output.count("\n") + 1
+    if line_count > _TOOL_RESULT_QUOTE_THRESHOLD:
+        unit = "line" if line_count == 1 else "lines"
+        return f"  ⎿  {line_count} {unit}\n" + format_expandable_quote(output)
+    return output
+
+
+def parse_turn_prompt(record: dict[str, Any]) -> AgentMessage | None:
+    """Parse a ``turn.prompt`` record into the user's AgentMessage.
+
+    Only ``origin.kind == "user"`` turns are relayed — kimi replays queued or
+    synthesised prompts through the same record type.
+    """
+    origin = record.get("origin")
+    if isinstance(origin, dict) and origin.get("kind") not in (None, "user"):
+        return None
+    text = extract_text(record.get("input", "")).strip()
+    if not text:
+        return None
+    return AgentMessage(
+        text=text,
+        role="user",
+        content_type="text",
+        timestamp=epoch_ms_to_iso(record.get("time")),
+    )
+
+
+def parse_content_part(
+    event: dict[str, Any], timestamp: str | None = None
+) -> AgentMessage | None:
+    """Parse a ``content.part`` loop event into assistant text or thinking."""
+    part = event.get("part")
+    if not isinstance(part, dict):
+        return None
+    part_type = part.get("type")
+    content_type: ContentType
+    if part_type == "text":
+        text = part.get("text")
+        content_type = "text"
+    elif part_type == "think":
+        text = part.get("think")
+        content_type = "thinking"
+    else:
+        return None
+    if not isinstance(text, str) or not text.strip():
+        return None
+    return AgentMessage(
+        text=text.strip(),
+        role="assistant",
+        content_type=content_type,
+        timestamp=timestamp,
+    )
+
+
+def _call_id(event: dict[str, Any], *keys: str) -> str:
+    """Return the first non-empty string id among *keys*."""
+    for key in keys:
+        value = event.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def parse_tool_call(
+    event: dict[str, Any], pending: Pending, timestamp: str | None = None
+) -> AgentMessage | None:
+    """Parse a ``tool.call`` loop event, recording the call in *pending*."""
+    name = event.get("name")
+    if not isinstance(name, str) or not name:
+        name = "unknown"
+    args = event.get("args")
+    if not isinstance(args, dict):
+        args = {}
+    description = event.get("description")
+    if not isinstance(description, str):
+        description = ""
+
+    call_id = _call_id(event, "toolCallId", "uuid")
+    if call_id:
+        pending[call_id] = name
+
+    return AgentMessage(
+        text=tool_call_summary(name, args, description),
+        role="assistant",
+        content_type="tool_use",
+        tool_use_id=call_id or None,
+        tool_name=name,
+        timestamp=timestamp,
+    )
+
+
+def parse_tool_result(
+    event: dict[str, Any], pending: Pending, timestamp: str | None = None
+) -> AgentMessage | None:
+    """Parse a ``tool.result`` loop event, pairing it back to its call.
+
+    ``result.note`` is a ``<system>`` annotation kimi feeds back to the model
+    (line counts, truncation hints); it is metadata, not output, so it is
+    dropped rather than relayed.
+    """
+    call_id = _call_id(event, "toolCallId", "parentUuid")
+    name = pending.pop(call_id, "") if call_id else ""
+    if not name:
+        native = event.get("toolName")
+        name = native if isinstance(native, str) and native else "unknown"
+
+    result = event.get("result")
+    if not isinstance(result, dict):
+        result = {}
+
+    error = result.get("error")
+    if isinstance(error, str) and error:
+        text = f"Error: {error}"
+    else:
+        output = result.get("output")
+        text = format_tool_result_text(output if isinstance(output, str) else "")
+
+    return AgentMessage(
+        text=text,
+        role="assistant",
+        content_type="tool_result",
+        tool_use_id=call_id or None,
+        tool_name=name,
+        timestamp=timestamp,
+    )
+
+
+def parse_loop_event(record: dict[str, Any], pending: Pending) -> AgentMessage | None:
+    """Dispatch one ``context.append_loop_event`` record to its parser."""
+    event = record.get("event")
+    if not isinstance(event, dict):
+        return None
+    timestamp = epoch_ms_to_iso(record.get("time"))
+    event_type = event.get("type")
+    if event_type == EVENT_CONTENT_PART:
+        return parse_content_part(event, timestamp)
+    if event_type == EVENT_TOOL_CALL:
+        return parse_tool_call(event, pending, timestamp)
+    if event_type == EVENT_TOOL_RESULT:
+        return parse_tool_result(event, pending, timestamp)
+    return None
+
+
+def normalize_pending(value: Any) -> Pending:
+    """Coerce the cross-batch pending dict into ``{call_id: tool_name}``."""
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: item
+        for key, item in value.items()
+        if isinstance(key, str) and isinstance(item, str)
+    }

--- a/src/ccgram/providers/process_detection.py
+++ b/src/ccgram/providers/process_detection.py
@@ -48,6 +48,7 @@ _PROVIDER_BASENAMES: tuple[tuple[frozenset[str], str], ...] = (
     (frozenset({"claude", "ce", "cc-mirror", "zai"}), "claude"),
     (frozenset({"codex"}), "codex"),
     (frozenset({"gemini"}), "gemini"),
+    (frozenset({"kimi"}), "kimi"),
     (frozenset({"pi"}), "pi"),
 )
 
@@ -57,6 +58,7 @@ _PROVIDER_PATH_MARKERS: tuple[tuple[tuple[str, ...], str], ...] = (
     (("claude-code", "cc-team"), "claude"),
     (("@openai/codex", "/codex/", "/codex-"), "codex"),
     (("gemini-cli",), "gemini"),
+    ((".kimi-code/bin/", "/kimi-code/"), "kimi"),
     (("@mariozechner/pi-coding-agent", "/pi-coding-agent/"), "pi"),
 )
 

--- a/src/ccgram/tool_format.py
+++ b/src/ccgram/tool_format.py
@@ -63,6 +63,22 @@ TOOL_EMOJI: dict[str, str] = {
     "ripgrep": "\U0001f50e",
     "search": "\U0001f50e",
     "fetch": "\U0001f310",
+    # Kimi Code native names
+    "TodoList": "\U0001f4cb",
+    "EnterPlanMode": "\U0001f4cb",
+    "FetchURL": "\U0001f310",
+    "ReadMediaFile": "\U0001f4d6",
+    "Agent": "\U0001f916",
+    "AgentSwarm": "\U0001f916",
+    "TaskOutput": "\U0001f4cb",
+    "TaskStop": "\U0001f4cb",
+    "CreateGoal": "\U0001f3af",
+    "GetGoal": "\U0001f3af",
+    "UpdateGoal": "\U0001f3af",
+    "SetGoalBudget": "\U0001f3af",
+    "CronCreate": "⏰",
+    "CronDelete": "⏰",
+    "CronList": "⏰",
     # MCP bare tool names (used after prefix stripping)
     "ask_question": "❓",
 }

--- a/src/ccgram/toolbar_config.py
+++ b/src/ccgram/toolbar_config.py
@@ -219,6 +219,17 @@ DEFAULT_LAYOUTS: dict[str, ToolbarLayout] = {
             ("last", "getfile", "close"),
         ),
     ),
+    # Kimi drives its approval prompts and pickers with ↑/↓ + Enter/Esc, and
+    # Shift+Tab (the shared "mode" action) toggles plan mode.
+    "kimi": ToolbarLayout(
+        style="emoji_text",
+        buttons=(
+            ("screen", "ctrlc", "live"),
+            ("mode", "model", "esc"),
+            ("up", "enter", "down"),
+            ("last", "getfile", "close"),
+        ),
+    ),
     "pi": ToolbarLayout(
         style="emoji_text",
         buttons=(

--- a/tests/ccgram/providers/test_contracts.py
+++ b/tests/ccgram/providers/test_contracts.py
@@ -15,6 +15,7 @@ from ccgram.providers._jsonl import JsonlProvider
 from ccgram.providers.claude import ClaudeProvider
 from ccgram.providers.codex import CodexProvider
 from ccgram.providers.gemini import GeminiProvider
+from ccgram.providers.kimi import KimiProvider
 from ccgram.providers.pi import PiProvider
 from ccgram.providers.shell import ShellProvider
 
@@ -49,6 +50,7 @@ PROVIDER_FIXTURES: list[type] = [
     ClaudeProvider,
     CodexProvider,
     GeminiProvider,
+    KimiProvider,
     PiProvider,
     ShellProvider,
 ]
@@ -134,6 +136,11 @@ def _make_assistant_entry(
         }
     if name == "gemini":
         return {"type": "gemini", "content": text}
+    if name == "kimi":
+        return {
+            "type": "context.append_loop_event",
+            "event": {"type": "content.part", "part": {"type": "text", "text": text}},
+        }
     return {
         "type": "assistant",
         "message": {"content": [{"type": "text", "text": text}]},
@@ -157,6 +164,17 @@ def _make_tool_use_entry(provider: AgentProvider) -> dict[str, Any]:
             "type": "gemini",
             "content": "Using tool",
             "toolCalls": [{"id": "t1", "name": "Read"}],
+        }
+    if name == "kimi":
+        return {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "tool.call",
+                "uuid": "t1",
+                "toolCallId": "t1",
+                "name": "Read",
+                "args": {"path": "foo.py"},
+            },
         }
     if name == "pi":
         return {
@@ -193,6 +211,16 @@ def _make_tool_result_entry(provider: AgentProvider) -> dict[str, Any]:
         }
     if name == "gemini":
         return {"type": "gemini", "content": "result ok"}
+    if name == "kimi":
+        return {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "tool.result",
+                "parentUuid": "t1",
+                "toolCallId": "t1",
+                "result": {"output": "ok"},
+            },
+        }
     if name == "pi":
         return {
             "type": "toolResult",
@@ -302,6 +330,8 @@ class TestIsUserTranscriptEntry:
             entry = {"type": "input_item", "payload": {"role": "user"}}
         elif name == "gemini":
             entry = {"type": "user"}
+        elif name == "kimi":
+            entry = {"type": "turn.prompt", "origin": {"kind": "user"}}
         else:
             entry = {"type": "user"}
         assert provider.is_user_transcript_entry(entry) is True
@@ -312,6 +342,8 @@ class TestIsUserTranscriptEntry:
             entry = {"type": "response_item", "payload": {"role": "assistant"}}
         elif name == "gemini":
             entry = {"type": "gemini"}
+        elif name == "kimi":
+            entry = {"type": "context.append_loop_event", "event": {"type": "step.end"}}
         else:
             entry = {"type": "assistant"}
         assert provider.is_user_transcript_entry(entry) is False
@@ -345,6 +377,12 @@ class TestParseHistoryEntry:
             }
         elif name == "gemini":
             entry = {"type": "user", "content": "my question"}
+        elif name == "kimi":
+            entry = {
+                "type": "turn.prompt",
+                "input": [{"type": "text", "text": "my question"}],
+                "origin": {"kind": "user"},
+            }
         else:
             entry = {
                 "type": "user",
@@ -471,7 +509,7 @@ class TestStatusSnapshot:
 
     def test_supports_status_snapshot_flag(self, provider: AgentProvider) -> None:
         caps = provider.capabilities
-        if caps.name in ("codex", "gemini"):
+        if caps.name in ("codex", "gemini", "kimi"):
             assert caps.supports_status_snapshot is True
         else:
             assert caps.supports_status_snapshot is False

--- a/tests/ccgram/providers/test_kimi.py
+++ b/tests/ccgram/providers/test_kimi.py
@@ -1,0 +1,900 @@
+"""Kimi Code provider tests.
+
+Pane fixtures are verbatim ``tmux capture-pane`` output from kimi 0.31.1
+(box borders trimmed to keep lines readable) so the terminal-chrome parsers
+are pinned against the real TUI rather than an idealised transcript.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ccgram.providers import (
+    detect_provider_from_command,
+    detect_provider_from_transcript_path,
+    resolve_launch_command,
+)
+from ccgram.providers.kimi import (
+    KimiProvider,
+    parse_status_modes,
+    session_index_path,
+    transcript_for_session_dir,
+)
+from ccgram.providers.kimi_format import (
+    epoch_ms_to_iso,
+    extract_text,
+    format_tool_result_text,
+    normalize_pending,
+    parse_content_part,
+    parse_tool_call,
+    parse_tool_result,
+    parse_turn_prompt,
+    tool_call_summary,
+)
+from ccgram.providers.process_detection import classify_provider_from_argv
+
+RULE = "─" * 118
+
+
+@pytest.fixture
+def kimi() -> KimiProvider:
+    return KimiProvider()
+
+
+# ── Capabilities & launch ────────────────────────────────────────────────
+
+
+class TestCapabilities:
+    def test_identity(self, kimi: KimiProvider) -> None:
+        caps = kimi.capabilities
+        assert caps.name == "kimi"
+        assert caps.launch_command == "kimi"
+
+    def test_is_hookless_with_resume(self, kimi: KimiProvider) -> None:
+        caps = kimi.capabilities
+        assert caps.supports_hook is False
+        assert caps.supports_resume is True
+        assert caps.supports_continue is True
+        assert caps.supports_incremental_read is True
+
+    def test_yolo_flag_needs_no_tui_confirmation(self, kimi: KimiProvider) -> None:
+        # ``kimi --yolo`` enters permissive mode from the flag alone.
+        assert kimi.capabilities.has_yolo_confirmation is False
+
+    def test_picker_commands_are_builtins(self, kimi: KimiProvider) -> None:
+        caps = kimi.capabilities
+        builtins = {name.lstrip("/") for name in caps.builtin_commands}
+        assert caps.tui_picker_commands <= builtins
+
+    def test_sessions_command_not_exposed(self, kimi: KimiProvider) -> None:
+        # /sessions collides with ccgram's own session picker.
+        assert "/sessions" not in kimi.capabilities.builtin_commands
+
+
+class TestLaunchArgs:
+    def test_fresh_session(self, kimi: KimiProvider) -> None:
+        assert kimi.make_launch_args() == ""
+
+    def test_resume_uses_short_flag(self, kimi: KimiProvider) -> None:
+        session = "session_24dbec47-d2ee-410f-9b08-3d64973cc015"
+        assert kimi.make_launch_args(resume_id=session) == f"-S {session}"
+
+    def test_continue(self, kimi: KimiProvider) -> None:
+        assert kimi.make_launch_args(use_continue=True) == "--continue"
+
+    def test_resume_wins_over_continue(self, kimi: KimiProvider) -> None:
+        assert kimi.make_launch_args(resume_id="session_a", use_continue=True) == (
+            "-S session_a"
+        )
+
+    @pytest.mark.parametrize(
+        "bad", ["a; rm -rf /", "$(whoami)", "a b", "`id`", "../etc"]
+    )
+    def test_rejects_shell_metacharacters(self, kimi: KimiProvider, bad: str) -> None:
+        with pytest.raises(ValueError, match="Invalid resume_id"):
+            kimi.make_launch_args(resume_id=bad)
+
+    def test_yolo_flag_appended(self) -> None:
+        assert resolve_launch_command("kimi", approval_mode="yolo") == "kimi --yolo"
+
+    def test_normal_mode_has_no_flag(self) -> None:
+        assert resolve_launch_command("kimi") == "kimi"
+
+
+# ── Detection ────────────────────────────────────────────────────────────
+
+
+class TestDetection:
+    def test_from_pane_command(self) -> None:
+        # kimi is a native binary, so the pane reports it directly.
+        assert detect_provider_from_command("kimi") == "kimi"
+
+    def test_from_absolute_path(self) -> None:
+        assert detect_provider_from_command("/home/u/.kimi-code/bin/kimi") == "kimi"
+
+    def test_kimi_code_argv0_variant(self) -> None:
+        """A resumed kimi re-execs with argv[0] == "kimi-code"."""
+        assert detect_provider_from_command("kimi-code") == "kimi"
+        assert classify_provider_from_argv(["kimi-code", "-S", "session_a"]) == "kimi"
+
+    @pytest.mark.parametrize("cmd", ["kimono", "kimi_other", "akimi"])
+    def test_does_not_match_unrelated_command(self, cmd: str) -> None:
+        assert detect_provider_from_command(cmd) == ""
+
+    def test_from_foreground_argv(self) -> None:
+        argv = ["/home/u/.kimi-code/bin/kimi", "--yolo"]
+        assert classify_provider_from_argv(argv) == "kimi"
+
+    def test_argv_skips_wrapper_tokens(self) -> None:
+        assert classify_provider_from_argv(["env", "kimi", "--yolo"]) == "kimi"
+
+    def test_from_transcript_path(self) -> None:
+        path = "/home/u/.kimi-code/sessions/wd_x_1/session_abc/agents/main/wire.jsonl"
+        assert detect_provider_from_transcript_path(path) == "kimi"
+
+    def test_transcript_path_does_not_shadow_claude(self) -> None:
+        path = "/home/u/.claude/projects/foo/bar.jsonl"
+        assert detect_provider_from_transcript_path(path) == "claude"
+
+
+# ── Transcript format helpers ────────────────────────────────────────────
+
+
+class TestEpochConversion:
+    def test_converts_milliseconds(self) -> None:
+        assert epoch_ms_to_iso(1785613222039) == "2026-08-01T19:40:22.039000+00:00"
+
+    @pytest.mark.parametrize("bad", [None, "1785613222039", True, 0, 1785613222])
+    def test_rejects_non_millisecond_values(self, bad: object) -> None:
+        # A seconds-based value would silently render as 1970.
+        assert epoch_ms_to_iso(bad) is None
+
+
+class TestExtractText:
+    def test_block_list(self) -> None:
+        blocks = [{"type": "text", "text": "olá "}, {"type": "text", "text": "mundo"}]
+        assert extract_text(blocks) == "olá mundo"
+
+    def test_plain_string(self) -> None:
+        assert extract_text("plain") == "plain"
+
+    def test_skips_non_text_blocks(self) -> None:
+        blocks = [{"type": "image", "url": "x"}, {"type": "text", "text": "keep"}]
+        assert extract_text(blocks) == "keep"
+
+    @pytest.mark.parametrize("bad", [None, 42, {"type": "text"}])
+    def test_non_list_non_string(self, bad: object) -> None:
+        assert extract_text(bad) == ""
+
+
+class TestToolCallSummary:
+    @pytest.mark.parametrize(
+        ("name", "args", "expected_fragment"),
+        [
+            ("Bash", {"command": "ls -la"}, "ls -la"),
+            ("Read", {"path": "src/app.py"}, "src/app.py"),
+            ("Write", {"path": "a.txt", "content": "x"}, "a.txt"),
+            ("Grep", {"pattern": "TODO"}, "TODO"),
+            ("WebSearch", {"query": "kimi cli"}, "kimi cli"),
+            ("FetchURL", {"url": "https://x.dev"}, "https://x.dev"),
+        ],
+    )
+    def test_prefers_tool_argument(
+        self, name: str, args: dict, expected_fragment: str
+    ) -> None:
+        assert expected_fragment in tool_call_summary(name, args)
+
+    def test_falls_back_to_description(self) -> None:
+        summary = tool_call_summary("TodoList", {}, "Updating the todo list")
+        assert "Updating the todo list" in summary
+
+    def test_falls_back_to_any_string_arg(self) -> None:
+        assert "abc" in tool_call_summary("Mystery", {"thing": "abc"})
+
+    def test_bare_name_when_nothing_to_show(self) -> None:
+        assert tool_call_summary("Mystery", {}) == "🔧 **mystery**"
+
+
+class TestToolResultText:
+    def test_empty_output(self) -> None:
+        assert format_tool_result_text("") == "Done"
+
+    def test_short_output_inline(self) -> None:
+        assert format_tool_result_text("a\nb") == "a\nb"
+
+    def test_long_output_becomes_expandable_quote(self) -> None:
+        text = format_tool_result_text("\n".join(str(i) for i in range(10)))
+        assert "10 lines" in text
+        assert "EXPQUOTE_START" in text
+
+
+class TestNormalizePending:
+    def test_keeps_string_values(self) -> None:
+        assert normalize_pending({"id1": "Bash"}) == {"id1": "Bash"}
+
+    def test_drops_malformed_entries(self) -> None:
+        assert normalize_pending({"id1": ("Bash", "Bash"), 2: "x"}) == {}
+
+    @pytest.mark.parametrize("bad", [None, "x", 5])
+    def test_non_dict(self, bad: object) -> None:
+        assert normalize_pending(bad) == {}
+
+
+# ── Record parsers ───────────────────────────────────────────────────────
+
+
+class TestParseTurnPrompt:
+    def test_user_turn(self) -> None:
+        record = {
+            "type": "turn.prompt",
+            "input": [{"type": "text", "text": "olá"}],
+            "origin": {"kind": "user"},
+            "time": 1785613222039,
+        }
+        msg = parse_turn_prompt(record)
+        assert msg is not None
+        assert msg.role == "user"
+        assert msg.content_type == "text"
+        assert msg.text == "olá"
+        assert msg.timestamp == "2026-08-01T19:40:22.039000+00:00"
+
+    def test_non_user_origin_skipped(self) -> None:
+        record = {
+            "type": "turn.prompt",
+            "input": [{"type": "text", "text": "replayed"}],
+            "origin": {"kind": "injection"},
+        }
+        assert parse_turn_prompt(record) is None
+
+    def test_empty_input_skipped(self) -> None:
+        assert parse_turn_prompt({"type": "turn.prompt", "input": []}) is None
+
+
+class TestParseContentPart:
+    def test_assistant_text(self) -> None:
+        msg = parse_content_part({"part": {"type": "text", "text": "pronto"}})
+        assert msg is not None
+        assert msg.role == "assistant"
+        assert msg.content_type == "text"
+        assert msg.text == "pronto"
+
+    def test_thinking(self) -> None:
+        msg = parse_content_part({"part": {"type": "think", "think": "hmm"}})
+        assert msg is not None
+        assert msg.content_type == "thinking"
+        assert msg.text == "hmm"
+
+    def test_blank_part_skipped(self) -> None:
+        assert parse_content_part({"part": {"type": "think", "think": "  "}}) is None
+
+    def test_unknown_part_type(self) -> None:
+        assert parse_content_part({"part": {"type": "image", "url": "x"}}) is None
+
+    def test_missing_part(self) -> None:
+        assert parse_content_part({}) is None
+
+
+class TestToolCallResultPairing:
+    def test_call_then_result_share_id(self) -> None:
+        pending: dict[str, str] = {}
+        call = parse_tool_call(
+            {
+                "type": "tool.call",
+                "uuid": "tool_1",
+                "toolCallId": "tool_1",
+                "name": "Bash",
+                "args": {"command": "ls"},
+                "description": "Running: ls",
+            },
+            pending,
+        )
+        assert call is not None
+        assert call.content_type == "tool_use"
+        assert call.tool_use_id == "tool_1"
+        assert call.tool_name == "Bash"
+        assert pending == {"tool_1": "Bash"}
+
+        result = parse_tool_result(
+            {
+                "type": "tool.result",
+                "parentUuid": "tool_1",
+                "toolCallId": "tool_1",
+                "result": {"output": "a.txt"},
+            },
+            pending,
+        )
+        assert result is not None
+        assert result.content_type == "tool_result"
+        assert result.tool_use_id == "tool_1"
+        assert result.tool_name == "Bash"
+        assert result.text == "a.txt"
+        assert pending == {}
+
+    def test_result_without_matching_call(self) -> None:
+        result = parse_tool_result(
+            {"toolCallId": "orphan", "result": {"output": "x"}}, {}
+        )
+        assert result is not None
+        assert result.tool_name == "unknown"
+
+    def test_result_falls_back_to_native_tool_name(self) -> None:
+        result = parse_tool_result(
+            {"toolCallId": "x", "toolName": "Read", "result": {"output": "y"}}, {}
+        )
+        assert result is not None
+        assert result.tool_name == "Read"
+
+    def test_error_result(self) -> None:
+        result = parse_tool_result(
+            {"toolCallId": "x", "result": {"error": "boom"}}, {"x": "Bash"}
+        )
+        assert result is not None
+        assert result.text == "Error: boom"
+
+    def test_system_note_is_not_relayed(self) -> None:
+        result = parse_tool_result(
+            {
+                "toolCallId": "x",
+                "result": {"output": "1\tola", "note": "<system>1 line read</system>"},
+            },
+            {"x": "Read"},
+        )
+        assert result is not None
+        assert "<system>" not in result.text
+
+    def test_call_falls_back_to_uuid_when_no_call_id(self) -> None:
+        pending: dict[str, str] = {}
+        call = parse_tool_call({"uuid": "u1", "name": "Read", "args": {}}, pending)
+        assert call is not None
+        assert call.tool_use_id == "u1"
+        assert pending == {"u1": "Read"}
+
+
+# ── Batch parsing ────────────────────────────────────────────────────────
+
+
+def _loop(event: dict, time_ms: int = 1785613222039) -> dict:
+    return {"type": "context.append_loop_event", "event": event, "time": time_ms}
+
+
+class TestParseTranscriptEntries:
+    def test_full_turn(self, kimi: KimiProvider) -> None:
+        entries = [
+            {"type": "metadata", "protocol_version": "1.4"},
+            {
+                "type": "turn.prompt",
+                "input": [{"type": "text", "text": "liste"}],
+                "origin": {"kind": "user"},
+                "time": 1785613222039,
+            },
+            _loop({"type": "step.begin", "step": 1}),
+            _loop({"type": "content.part", "part": {"type": "think", "think": "ok"}}),
+            _loop(
+                {
+                    "type": "tool.call",
+                    "toolCallId": "t1",
+                    "name": "Bash",
+                    "args": {"command": "ls"},
+                }
+            ),
+            _loop(
+                {
+                    "type": "tool.result",
+                    "toolCallId": "t1",
+                    "result": {"output": "a.txt"},
+                }
+            ),
+            _loop({"type": "content.part", "part": {"type": "text", "text": "feito"}}),
+            _loop({"type": "step.end", "finishReason": "stop"}),
+        ]
+        messages, pending = kimi.parse_transcript_entries(entries, {})
+        assert [(m.role, m.content_type) for m in messages] == [
+            ("user", "text"),
+            ("assistant", "thinking"),
+            ("assistant", "tool_use"),
+            ("assistant", "tool_result"),
+            ("assistant", "text"),
+        ]
+        assert pending == {}
+
+    def test_append_message_is_ignored(self, kimi: KimiProvider) -> None:
+        """context.append_message duplicates the prompt and carries injections."""
+        entries = [
+            {
+                "type": "turn.prompt",
+                "input": [{"type": "text", "text": "olá"}],
+                "origin": {"kind": "user"},
+            },
+            {
+                "type": "context.append_message",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "olá"}],
+                    "origin": {"kind": "user"},
+                },
+            },
+            {
+                "type": "context.append_message",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "<system-reminder>x"}],
+                    "origin": {"kind": "injection", "variant": "todo_list_reminder"},
+                },
+            },
+        ]
+        messages, _ = kimi.parse_transcript_entries(entries, {})
+        assert len(messages) == 1
+        assert messages[0].text == "olá"
+
+    def test_pending_carries_across_batches(self, kimi: KimiProvider) -> None:
+        first = [
+            _loop(
+                {
+                    "type": "tool.call",
+                    "toolCallId": "t9",
+                    "name": "Grep",
+                    "args": {"pattern": "x"},
+                }
+            )
+        ]
+        _, pending = kimi.parse_transcript_entries(first, {})
+        assert pending == {"t9": "Grep"}
+
+        second = [
+            _loop({"type": "tool.result", "toolCallId": "t9", "result": {"output": ""}})
+        ]
+        messages, pending = kimi.parse_transcript_entries(second, pending)
+        assert messages[0].tool_name == "Grep"
+        assert pending == {}
+
+    def test_bookkeeping_records_produce_nothing(self, kimi: KimiProvider) -> None:
+        entries = [
+            {"type": "llm.request", "model": "k3"},
+            {"type": "usage.record", "model": "k3"},
+            {"type": "permission.record_approval_result", "toolName": "Bash"},
+            {"type": "tools.set_active_tools", "names": ["Bash"]},
+            _loop({"type": "step.begin"}),
+        ]
+        messages, _ = kimi.parse_transcript_entries(entries, {})
+        assert messages == []
+
+
+class TestHistoryEntries:
+    def test_user_turn_flagged(self, kimi: KimiProvider) -> None:
+        entry = {"type": "turn.prompt", "input": [{"type": "text", "text": "hi"}]}
+        assert kimi.is_user_transcript_entry(entry) is True
+
+    def test_injected_turn_not_flagged(self, kimi: KimiProvider) -> None:
+        entry = {"type": "turn.prompt", "origin": {"kind": "injection"}}
+        assert kimi.is_user_transcript_entry(entry) is False
+
+    def test_loop_event_not_flagged(self, kimi: KimiProvider) -> None:
+        assert kimi.is_user_transcript_entry(_loop({"type": "step.begin"})) is False
+
+    def test_history_renders_user_and_assistant_text(self, kimi: KimiProvider) -> None:
+        prompt = {
+            "type": "turn.prompt",
+            "input": [{"type": "text", "text": "pergunta"}],
+            "origin": {"kind": "user"},
+        }
+        reply = _loop({"type": "content.part", "part": {"type": "text", "text": "r"}})
+        assert kimi.parse_history_entry(prompt).text == "pergunta"
+        assert kimi.parse_history_entry(reply).text == "r"
+
+    def test_history_skips_thinking_and_tools(self, kimi: KimiProvider) -> None:
+        think = _loop({"type": "content.part", "part": {"type": "think", "think": "t"}})
+        call = _loop({"type": "tool.call", "toolCallId": "1", "name": "Bash"})
+        assert kimi.parse_history_entry(think) is None
+        assert kimi.parse_history_entry(call) is None
+
+
+# ── Discovery ────────────────────────────────────────────────────────────
+
+
+def _write_session(
+    home: Path, workspace: str, session_id: str, work_dir: Path, body: str = "{}\n"
+) -> Path:
+    session_dir = home / ".kimi-code" / "sessions" / workspace / session_id
+    transcript = session_dir / "agents" / "main" / "wire.jsonl"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text(body, encoding="utf-8")
+
+    index = home / ".kimi-code" / "session_index.jsonl"
+    with index.open("a", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "sessionId": session_id,
+                    "sessionDir": str(session_dir),
+                    "workDir": str(work_dir),
+                }
+            )
+            + "\n"
+        )
+    return transcript
+
+
+class TestPaths:
+    def test_index_path(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert session_index_path() == tmp_path / ".kimi-code" / "session_index.jsonl"
+
+    def test_transcript_path(self) -> None:
+        assert transcript_for_session_dir("/s/x") == Path("/s/x/agents/main/wire.jsonl")
+
+
+class TestDiscoverTranscript:
+    def test_finds_matching_workdir(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project = tmp_path / "proj"
+        project.mkdir()
+        transcript = _write_session(tmp_path, "wd_proj_1", "session_a", project)
+
+        event = kimi.discover_transcript(str(project), "ccgram:@1")
+        assert event is not None
+        assert event.session_id == "session_a"
+        assert event.transcript_path == str(transcript)
+        assert event.window_key == "ccgram:@1"
+
+    def test_ignores_other_workdirs(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        other = tmp_path / "other"
+        other.mkdir()
+        wanted = tmp_path / "wanted"
+        wanted.mkdir()
+        _write_session(tmp_path, "wd_other_1", "session_other", other)
+
+        assert kimi.discover_transcript(str(wanted), "ccgram:@1") is None
+
+    def test_picks_freshest_transcript(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project = tmp_path / "proj"
+        project.mkdir()
+        old = _write_session(tmp_path, "wd_proj_1", "session_old", project)
+        new = _write_session(tmp_path, "wd_proj_1", "session_new", project)
+        import os
+
+        os.utime(old, (1, 1))
+
+        event = kimi.discover_transcript(str(project), "ccgram:@1")
+        assert event is not None
+        assert event.session_id == "session_new"
+        assert event.transcript_path == str(new)
+
+    def test_stale_transcript_rejected(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project = tmp_path / "proj"
+        project.mkdir()
+        transcript = _write_session(tmp_path, "wd_proj_1", "session_a", project)
+        import os
+
+        os.utime(transcript, (1, 1))
+
+        assert kimi.discover_transcript(str(project), "ccgram:@1") is None
+
+    def test_max_age_zero_disables_staleness(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project = tmp_path / "proj"
+        project.mkdir()
+        transcript = _write_session(tmp_path, "wd_proj_1", "session_a", project)
+        import os
+
+        os.utime(transcript, (1, 1))
+
+        event = kimi.discover_transcript(str(project), "ccgram:@1", max_age=0)
+        assert event is not None
+
+    def test_missing_index_returns_none(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert kimi.discover_transcript(str(tmp_path), "ccgram:@1") is None
+
+    def test_corrupt_index_lines_skipped(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project = tmp_path / "proj"
+        project.mkdir()
+        _write_session(tmp_path, "wd_proj_1", "session_a", project)
+        index = tmp_path / ".kimi-code" / "session_index.jsonl"
+        index.write_text(
+            "not json\n{}\n" + index.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+        event = kimi.discover_transcript(str(project), "ccgram:@1")
+        assert event is not None
+        assert event.session_id == "session_a"
+
+    def test_index_entry_without_transcript_skipped(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project = tmp_path / "proj"
+        project.mkdir()
+        index = tmp_path / ".kimi-code"
+        index.mkdir(parents=True, exist_ok=True)
+        (index / "session_index.jsonl").write_text(
+            json.dumps(
+                {
+                    "sessionId": "ghost",
+                    "sessionDir": str(tmp_path / "gone"),
+                    "workDir": str(project),
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        assert kimi.discover_transcript(str(project), "ccgram:@1") is None
+
+    def test_empty_cwd(self, kimi: KimiProvider) -> None:
+        assert kimi.discover_transcript("", "ccgram:@1") is None
+
+
+# ── Terminal chrome ──────────────────────────────────────────────────────
+
+
+IDLE_PANE = (
+    " ● Feito.\n"
+    " ╭──────────────────────╮\n"
+    " │ >                    │\n"
+    " ╰──────────────────────╯\n"
+    " K3 thinking: high  …/proj                /init: generate AGENTS.md\n"
+    "                                          context: 9% (21k/256k)\n"
+)
+
+BUSY_MOON_PANE = (
+    " ✨ Liste os arquivos\n"
+    "  🌘 · Tip: ctrl-s to add guidance without waiting for the turn to finish\n"
+    " ╭──────────────────────╮\n"
+    " │ >                    │\n"
+    " ╰──────────────────────╯\n"
+    " K3 thinking: high  …/proj\n"
+    "                                          context: 9% (20.5k/256k)\n"
+)
+
+BUSY_BRAILLE_PANE = BUSY_MOON_PANE.replace(
+    "  🌘 · Tip: ctrl-s to add guidance without waiting for the turn to finish",
+    "  ⠹ working... · Tip: ! to run a shell command",
+)
+
+BASH_PERMISSION_PANE = (
+    " ● Running a command\n"
+    "   $ ls -la\n"
+    f" {RULE}\n"
+    "   ▶ Run this command?\n"
+    "\n"
+    "   cwd: /proj\n"
+    "   $ ls -la\n"
+    "\n"
+    "   ▶ 1. Approve once\n"
+    "     2. Approve for this session\n"
+    "     3. Reject\n"
+    "     4. Reject with feedback\n"
+    "\n"
+    "   ↑/↓ select · 1/2/3/4 choose · ↵ confirm\n"
+    f" {RULE}\n"
+    " K3 thinking: high  …/proj\n"
+    "                                          context: 9% (20.5k/256k)\n"
+)
+
+WRITE_PERMISSION_PANE = BASH_PERMISSION_PANE.replace(
+    "▶ Run this command?", "▶ Write this file?"
+).replace("↵ confirm", "↵ confirm · ctrl+e preview")
+
+PERMISSION_PICKER_PANE = (
+    f" {RULE}\n"
+    "  Select permission mode\n"
+    "  ↑↓ navigate · Enter select · Esc cancel\n"
+    "   ❯ Manual ← current\n"
+    "     Approve every action yourself.\n"
+    "     YOLO\n"
+    "     Auto-approve tool actions, but the agent may still ask questions.\n"
+    f" {RULE}\n"
+    " yolo plan  K3 thinking: high  …/proj\n"
+    "                                          context: 0% (0/256k)\n"
+)
+
+PROSE_FENCE_PANE = (
+    f" {RULE}\n"
+    "   Plan mode: ON\n"
+    "   Plan will be created here: /home/u/plans/x.md\n"
+    f" {RULE}\n"
+    " K3 thinking: high  …/proj\n"
+    "                                          context: 0% (0/256k)\n"
+)
+
+
+class TestParseTerminalStatus:
+    def test_idle_yields_no_status(self, kimi: KimiProvider) -> None:
+        assert kimi.parse_terminal_status(IDLE_PANE) is None
+
+    def test_empty_pane(self, kimi: KimiProvider) -> None:
+        assert kimi.parse_terminal_status("") is None
+
+    def test_moon_spinner_is_busy(self, kimi: KimiProvider) -> None:
+        status = kimi.parse_terminal_status(BUSY_MOON_PANE)
+        assert status is not None
+        assert status.is_interactive is False
+        assert status.display_label == "…working"
+
+    def test_braille_spinner_carries_label(self, kimi: KimiProvider) -> None:
+        status = kimi.parse_terminal_status(BUSY_BRAILLE_PANE)
+        assert status is not None
+        assert status.is_interactive is False
+        assert status.display_label == "…working..."
+
+    def test_bash_approval_prompt(self, kimi: KimiProvider) -> None:
+        status = kimi.parse_terminal_status(BASH_PERMISSION_PANE)
+        assert status is not None
+        assert status.is_interactive is True
+        assert status.ui_type == "PermissionPrompt"
+        assert status.display_label == "Run this command?"
+        assert "1. Approve once" in status.raw_text
+
+    def test_write_approval_prompt(self, kimi: KimiProvider) -> None:
+        status = kimi.parse_terminal_status(WRITE_PERMISSION_PANE)
+        assert status is not None
+        assert status.ui_type == "PermissionPrompt"
+        assert status.display_label == "Write this file?"
+
+    def test_menu_picker_is_selection_not_permission(self, kimi: KimiProvider) -> None:
+        """Option text mentioning "Approve" must not make a picker an approval."""
+        status = kimi.parse_terminal_status(PERMISSION_PICKER_PANE)
+        assert status is not None
+        assert status.is_interactive is True
+        assert status.ui_type == "SelectionUI"
+        assert status.display_label == "Select permission mode"
+
+    def test_prose_fence_is_not_interactive(self, kimi: KimiProvider) -> None:
+        assert kimi.parse_terminal_status(PROSE_FENCE_PANE) is None
+
+    def test_spinner_in_scrollback_is_not_busy(self, kimi: KimiProvider) -> None:
+        pane = (
+            "  🌘 · Tip: stale frame\n"
+            + ("\n".join(["   output"] * 12))
+            + ("\n K3 thinking: high  …/proj\n")
+        )
+        assert kimi.parse_terminal_status(pane) is None
+
+    def test_prompt_wins_over_spinner(self, kimi: KimiProvider) -> None:
+        pane = BUSY_MOON_PANE + BASH_PERMISSION_PANE
+        status = kimi.parse_terminal_status(pane)
+        assert status is not None
+        assert status.is_interactive is True
+
+
+class TestParseStatusModes:
+    @pytest.mark.parametrize(
+        ("bar", "expected"),
+        [
+            (" K3 thinking: high  …/proj", None),
+            (" yolo  K3 thinking: high  …/proj", "YOLO"),
+            (" plan  K3 thinking: high  …/proj", "Plan"),
+            (" yolo plan  K3 thinking: high  …/proj", "YOLO Plan"),
+            (" auto plan  K3 thinking: high  …/proj", "Auto Plan"),
+        ],
+    )
+    def test_modes(self, bar: str, expected: str | None) -> None:
+        pane = f"{bar}\n                       context: 0% (0/256k)\n"
+        assert parse_status_modes(pane) == expected
+
+    def test_no_status_bar(self) -> None:
+        assert parse_status_modes("just some text\n") is None
+
+    def test_reads_from_full_pane(self) -> None:
+        assert parse_status_modes(PERMISSION_PICKER_PANE) == "YOLO Plan"
+
+
+class TestScrapeCurrentMode:
+    async def test_returns_mode_label(self, kimi: KimiProvider) -> None:
+        async def fake_capture(_window_id: str) -> str:
+            return PERMISSION_PICKER_PANE
+
+        assert await kimi.scrape_current_mode("@1", capture_fn=fake_capture) == (
+            "YOLO Plan"
+        )
+
+    async def test_no_window_id(self, kimi: KimiProvider) -> None:
+        assert await kimi.scrape_current_mode("") is None
+
+    async def test_capture_failure_is_swallowed(self, kimi: KimiProvider) -> None:
+        async def boom(_window_id: str) -> str:
+            raise OSError("no pane")
+
+        assert await kimi.scrape_current_mode("@1", capture_fn=boom) is None
+
+    async def test_empty_capture(self, kimi: KimiProvider) -> None:
+        async def empty(_window_id: str) -> str:
+            return ""
+
+        assert await kimi.scrape_current_mode("@1", capture_fn=empty) is None
+
+
+# ── Status snapshot & commands ───────────────────────────────────────────
+
+
+class TestStatusSnapshot:
+    def test_snapshot_shortens_session_id(
+        self, kimi: KimiProvider, tmp_path: Path
+    ) -> None:
+        transcript = tmp_path / "wire.jsonl"
+        transcript.write_text("{}\n", encoding="utf-8")
+        snapshot = kimi.build_status_snapshot(
+            str(transcript),
+            display_name="proj",
+            session_id="session_24dbec47-d2ee-410f",
+            cwd="/proj",
+        )
+        assert snapshot is not None
+        assert "[proj]" in snapshot
+        assert "24dbec47" in snapshot
+        assert "session_24dbec47" not in snapshot
+
+    def test_missing_transcript(self, kimi: KimiProvider, tmp_path: Path) -> None:
+        assert kimi.build_status_snapshot(str(tmp_path / "nope.jsonl")) is None
+
+    def test_has_output_since(self, kimi: KimiProvider, tmp_path: Path) -> None:
+        transcript = tmp_path / "wire.jsonl"
+        transcript.write_text("x" * 100, encoding="utf-8")
+        assert kimi.has_output_since(str(transcript), 50) is True
+        assert kimi.has_output_since(str(transcript), 100) is False
+
+    def test_has_output_since_missing_file(self, kimi: KimiProvider) -> None:
+        assert kimi.has_output_since("/nope/wire.jsonl", 0) is False
+
+
+class TestDiscoverCommands:
+    def test_builtins_present(self, kimi: KimiProvider, tmp_path: Path) -> None:
+        names = {c.name for c in kimi.discover_commands(str(tmp_path))}
+        assert "/new" in names
+        assert "/model" in names
+        assert "/yolo" in names
+
+    def test_workspace_skills_discovered(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        skill = tmp_path / ".kimi" / "skills" / "deploy-app"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: deploy-app\ndescription: Ship it\n---\nbody\n",
+            encoding="utf-8",
+        )
+
+        commands = kimi.discover_commands(str(tmp_path))
+        deploy = next(c for c in commands if c.name == "/deploy-app")
+        assert deploy.description == "Ship it"
+        assert deploy.source == "skill"
+
+    def test_skill_without_frontmatter_gets_fallback(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        skill = tmp_path / ".kimi" / "skills" / "bare"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("just text\n", encoding="utf-8")
+
+        commands = kimi.discover_commands(str(tmp_path))
+        bare = next(c for c in commands if c.name == "/bare")
+        assert "bare" in bare.description
+
+    def test_missing_skill_dirs_are_fine(
+        self, kimi: KimiProvider, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        assert kimi.discover_commands(str(tmp_path / "nowhere"))


### PR DESCRIPTION
## Add Kimi Code support

### Summary
Adds Kimi Code as a supported provider, so users can run
code-related tasks against Kimi models in addition to the existing providers

Wrote using Claude Code Opus 5

Tested on my enviroment, working normally as it is. 