### PR TITLE
fix: harden Telegram topic, polling, and relay flows

### DIFF
--- a/.archfit.yaml
+++ b/.archfit.yaml
@@ -17,7 +17,7 @@
 #   mirror and advisory gate: keep `no-import-cycles` as warn because the repo
 #   intentionally uses lazy imports that runtime tests accept.
 # - The config below is intended for full scans and delta scans. Keep it aligned
-#   with the current package map before running `archfit analyze --full` or
+#   with the current package map before running `archfit analyze` or
 #   `archfit analyze --base <ref>`.
 #
 # Solo-developer / distance note (Balanced Coupling):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           go-version: stable
       - name: Install archfit + analyzers
         run: |
-          go install github.com/alexei-led/archfit/cmd/archfit@v0.12.1
+          go install github.com/alexei-led/archfit/cmd/archfit@v1.6.0
           npm install -g @sourcegraph/scip-python jscpd @ast-grep/cli
           uv tool install lizard
       - name: Architecture drift gate (archfit)

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,9 @@ archfit:
 # advisory cycle, BC advisories, coupling scorecard) do NOT block. Run by the
 # pre-push hook (scoped to src changes) and suitable for CI.
 arch-check:
-	@command -v archfit >/dev/null 2>&1 || { echo "archfit not installed — skipping (see github.com/alexei-led/archfit)"; exit 0; }
-	@archfit check --config .archfit.yaml; ec=$$?; \
+	@command -v archfit >/dev/null 2>&1 || { echo "archfit not installed — skipping (see github.com/alexei-led/archfit)"; exit 0; }; \
+	archfit check --help >/dev/null 2>&1 || { echo "archfit version does not support 'check' — skipping (install v1.6+)"; exit 0; }; \
+	archfit check --config .archfit.yaml; ec=$$?; \
 	if [ $$ec -eq 0 ] || [ $$ec -eq 2 ]; then exit 0; fi; \
 	echo "make: archfit drift gate FAILED (exit $$ec)"; exit $$ec
 

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,9 @@ arch-guard:
 	  tests/ccgram/test_herdr_identity_audit.py \
 	  tests/ccgram/test_herdr_legacy_model_audit.py
 
-# archfit: full report-only architecture analysis.
+# archfit: report-only architecture analysis.
 archfit:
-	@archfit analyze --config .archfit.yaml --full
+	@archfit analyze --config .archfit.yaml
 
 # arch-check: archfit whole-graph drift gate (forbidden-dep + cycle + coupling).
 # ~45s (scip indexing). Blocks only on gate findings (exit 1); warnings (exit 2:
@@ -64,19 +64,19 @@ archfit:
 # pre-push hook (scoped to src changes) and suitable for CI.
 arch-check:
 	@command -v archfit >/dev/null 2>&1 || { echo "archfit not installed — skipping (see github.com/alexei-led/archfit)"; exit 0; }
-	@archfit --gate --config .archfit.yaml --full; ec=$$?; \
+	@archfit check --config .archfit.yaml; ec=$$?; \
 	if [ $$ec -eq 0 ] || [ $$ec -eq 2 ]; then exit 0; fi; \
 	echo "make: archfit drift gate FAILED (exit $$ec)"; exit $$ec
 
 # arch-score: banded architecture scorecard (coupling / cohesion / fitness).
 # Report-only — use to track architecture health and improvement over time.
 arch-score:
-	@archfit analyze --config .archfit.yaml --full --format scorecard
+	@archfit analyze --config .archfit.yaml --markdown
 
 # arch-review: off-gate LLM narrative appended to the standard analysis output.
 # Needs AI config in .archfit.yaml and provider credentials in the environment.
 arch-review:
-	@archfit analyze --config .archfit.yaml --full --llm
+	@archfit analyze --config .archfit.yaml --ai-summary
 
 install:
 	uv sync

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -607,6 +607,11 @@ systemctl --user enable ccgram
 systemctl --user start ccgram
 ```
 
+ccgram retries brief Telegram polling conflicts for up to 90 seconds, which can
+occur after a network reconnect. Persistent conflicts stop with a non-zero exit
+so `Restart=on-failure` restarts the service. Check for another bot process that
+uses the same token if the conflict returns.
+
 On macOS, you can use a launchd plist or simply run in a detached tmux session:
 
 ```bash

--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -324,6 +324,11 @@ async def shutdown_runtime() -> None:
 
     await shutdown_workers()
 
+    # Lazy: tracker is only needed to discard ephemeral input correlations at shutdown.
+    from .handlers.telegram_origin import clear_pending_telegram_injections
+
+    clear_pending_telegram_injections()
+
     # Lazy: main → bot → bootstrap cycle (same as start path).
     from .main import stop_miniapp_if_enabled
 
@@ -350,6 +355,10 @@ def reset_for_testing() -> None:
 
     _callbacks_wired = False
     session_monitor = None
+    # Lazy: test reset must also discard ephemeral input correlations.
+    from .handlers.telegram_origin import clear_pending_telegram_injections
+
+    clear_pending_telegram_injections()
     _status_poll_task = None
     clear_active_monitor()
 

--- a/src/ccgram/bot.py
+++ b/src/ccgram/bot.py
@@ -14,8 +14,8 @@ Responsibilities kept here:
     by the message handler registry
 """
 
-import os
 import signal
+import time
 
 import structlog
 from telegram.error import BadRequest, Conflict, NetworkError
@@ -68,6 +68,48 @@ __all__ = [
 ]
 
 logger = structlog.get_logger()
+
+_CONFLICT_GRACE_PERIOD_S = 90.0
+
+
+class _PollingConflictState:
+    """Track consecutive getUpdates conflicts until a successful poll resets them."""
+
+    def __init__(self) -> None:
+        self._first_conflict_at: float | None = None
+        self.shutdown_requested = False
+
+    def reset(self) -> None:
+        self._first_conflict_at = None
+        self.shutdown_requested = False
+
+    def record_success(self) -> None:
+        self._first_conflict_at = None
+
+    def record_conflict(self, now: float) -> bool:
+        if self._first_conflict_at is None:
+            self._first_conflict_at = now
+            return False
+        if now - self._first_conflict_at < _CONFLICT_GRACE_PERIOD_S:
+            return False
+        self.shutdown_requested = True
+        return True
+
+
+_polling_conflict_state = _PollingConflictState()
+
+
+def _reset_polling_conflict_state() -> None:
+    _polling_conflict_state.reset()
+
+
+def polling_conflict_requires_restart() -> bool:
+    """Return whether sustained polling conflicts stopped the application."""
+    return _polling_conflict_state.shutdown_requested
+
+
+def _record_successful_poll() -> None:
+    _polling_conflict_state.record_success()
 
 
 def is_user_allowed(user_id: int | None) -> bool:
@@ -135,11 +177,19 @@ async def post_shutdown(_application: Application) -> None:
 async def _error_handler(_update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle bot-level errors from updater and handlers."""
     if isinstance(context.error, Conflict):
-        logger.critical(
-            "Another bot instance is polling with the same token. "
-            "Shutting down to avoid conflicts."
-        )
-        os.kill(os.getpid(), signal.SIGINT)
+        if _polling_conflict_state.record_conflict(time.monotonic()):
+            logger.critical(
+                "Telegram polling conflict persisted for %.0fs; stopping so the "
+                "service supervisor can restart ccgram. Check for another bot instance.",
+                _CONFLICT_GRACE_PERIOD_S,
+            )
+            context.application.stop_running()
+        else:
+            logger.warning(
+                "Telegram polling conflict; retrying for up to %.0fs before stopping. "
+                "This can follow a network reconnect.",
+                _CONFLICT_GRACE_PERIOD_S,
+            )
         return
     if isinstance(context.error, BadRequest) and "too old" in str(context.error):
         logger.debug("Callback query expired (query too old)")
@@ -154,6 +204,7 @@ async def _error_handler(_update: object, context: ContextTypes.DEFAULT_TYPE) ->
 
 
 def create_bot() -> Application:
+    _reset_polling_conflict_state()
     # Suppress PTBUserWarning about JobQueue (we intentionally don't use it for core tasks)
     # Lazy: only used inside the deprecation guard
     import warnings
@@ -164,7 +215,12 @@ def create_bot() -> Application:
         .token(config.telegram_bot_token)
         .rate_limiter(AIORateLimiter(max_retries=5))
         .request(ResilientPollingHTTPXRequest())
-        .get_updates_request(ResilientPollingHTTPXRequest(connection_pool_size=1))
+        .get_updates_request(
+            ResilientPollingHTTPXRequest(
+                connection_pool_size=1,
+                on_success=_record_successful_poll,
+            )
+        )
         .post_init(post_init)
         .post_stop(post_stop)
         .post_shutdown(post_shutdown)

--- a/src/ccgram/handlers/agent_command.py
+++ b/src/ccgram/handlers/agent_command.py
@@ -64,7 +64,12 @@ def _resolve_window(update: Update) -> tuple[int, int, str] | None:
     thread_id = get_thread_id(update)
     if thread_id is None:
         return None
-    window_id = thread_router.get_window_for_thread(user.id, thread_id)
+    chat_id = update.effective_chat.id if update.effective_chat else None
+    window_id = (
+        thread_router.get_window_for_thread(user.id, thread_id, chat_id)
+        if isinstance(chat_id, int)
+        else thread_router.get_window_for_thread(user.id, thread_id)
+    )
     if not window_id:
         return None
     return user.id, thread_id, window_id

--- a/src/ccgram/handlers/callback_helpers.py
+++ b/src/ccgram/handlers/callback_helpers.py
@@ -11,8 +11,13 @@ from ..thread_router import thread_router
 from .callback_data import CB_PANE_DELIMITER
 
 
-def user_owns_window(user_id: int, window_id: str) -> bool:
-    """Check if a user has any thread binding to the given window."""
+def user_owns_window(user_id: int, window_id: str, chat_id: int | None = None) -> bool:
+    """Check ownership in the callback's chat when available."""
+    if chat_id is not None:
+        return any(
+            uid == user_id and bound_chat == chat_id and wid == window_id
+            for uid, bound_chat, _tid, wid in thread_router.iter_thread_bindings_with_chat()
+        )
     return window_id in thread_router.get_all_thread_windows(user_id).values()
 
 

--- a/src/ccgram/handlers/cleanup.py
+++ b/src/ccgram/handlers/cleanup.py
@@ -40,6 +40,7 @@ async def clear_topic_state(
     client: TelegramClient | None = None,
     user_data: dict[str, Any] | None = None,
     window_id: str | None = None,
+    chat_id: int | None = None,
     *,
     window_dead: bool = True,
 ) -> None:
@@ -57,7 +58,7 @@ async def clear_topic_state(
             when the window is truly dead, to preserve skip/offer state for
             live sessions.
     """
-    chat_id = thread_router.resolve_chat_id(user_id, thread_id)
+    chat_id = chat_id or thread_router.resolve_chat_id(user_id, thread_id)
 
     qualified_id: str | None = None
     if window_id and window_dead:
@@ -138,7 +139,12 @@ async def unbind_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             await safe_reply(update.message, "❌ Use this command inside a topic.")
         return
 
-    window_id = thread_router.get_window_for_thread(user.id, thread_id)
+    chat_id = update.effective_chat.id if update.effective_chat else None
+    window_id = (
+        thread_router.get_window_for_thread(user.id, thread_id, chat_id)
+        if isinstance(chat_id, int)
+        else thread_router.get_window_for_thread(user.id, thread_id)
+    )
     if not window_id:
         await safe_reply(update.message, "❌ This topic is not bound to any session.")
         return
@@ -149,15 +155,15 @@ async def unbind_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         legacy_state.archive_legacy_herdr(window_id, user.id, thread_id)
     client = PTBTelegramClient(context.bot)
     await enqueue_status_update(client, user.id, window_id, None, thread_id)
+    clear_kwargs: dict = {"window_id": window_id, "window_dead": False}
+    if isinstance(chat_id, int):
+        clear_kwargs["chat_id"] = chat_id
     await clear_topic_state(
-        user.id,
-        thread_id,
-        client,
-        context.user_data,
-        window_id=window_id,
-        window_dead=False,
+        user.id, thread_id, client, context.user_data, **clear_kwargs
     )
-    thread_router.unbind_thread(user.id, thread_id)
+    thread_router.unbind_thread(
+        user.id, thread_id, chat_id=chat_id if isinstance(chat_id, int) else None
+    )
     if is_legacy_herdr:
         await safe_reply(
             update.message,
@@ -187,7 +193,14 @@ async def rollback_command(update: Update, _context: ContextTypes.DEFAULT_TYPE) 
             update.message, "❌ Use this command inside the archived topic."
         )
         return
-    if thread_router.get_window_for_thread(user.id, thread_id) is not None:
+    if (
+        thread_router.get_window_for_thread(
+            user.id,
+            thread_id,
+            update.effective_chat.id if update.effective_chat else None,
+        )
+        is not None
+    ):
         await safe_reply(update.message, "❌ This topic is already bound to a session.")
         return
 

--- a/src/ccgram/handlers/commands/__init__.py
+++ b/src/ccgram/handlers/commands/__init__.py
@@ -63,7 +63,9 @@ async def commands_command(update: Update, _context: ContextTypes.DEFAULT_TYPE) 
         return
 
     thread_id = _get_thread_id(update)
-    window_id = thread_router.resolve_window_for_thread(user.id, thread_id)
+    window_id = thread_router.resolve_window_for_thread(
+        user.id, thread_id, update.message.chat.id
+    )
     if not window_id:
         await safe_reply(update.message, "❌ No session bound to this topic.")
         return
@@ -112,7 +114,9 @@ async def toolbar_command(update: Update, _context: ContextTypes.DEFAULT_TYPE) -
             await safe_reply(update.message, "❌ Use this command inside a topic.")
         return
 
-    window_id = thread_router.get_window_for_thread(user.id, thread_id)
+    window_id = thread_router.get_window_for_thread(
+        user.id, thread_id, update.message.chat.id
+    )
     if not window_id:
         await safe_reply(update.message, "❌ This topic is not bound to any session.")
         return

--- a/src/ccgram/handlers/commands/forward.py
+++ b/src/ccgram/handlers/commands/forward.py
@@ -33,7 +33,10 @@ from ...telegram_client import PTBTelegramClient
 from ...window_state_store import window_store
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
-from ...multiplexer.window_ops import send_followup_to_window, send_to_window
+from ..telegram_origin import (
+    send_telegram_followup_to_window,
+    send_telegram_to_window,
+)
 from ..callback_helpers import get_thread_id as _get_thread_id
 from ..command_history import record_command
 from ..messaging_pipeline.message_queue import enqueue_status_update
@@ -130,7 +133,9 @@ async def _handle_pi_followup_command(
         message_thread_id=thread_id,
         action=ChatAction.TYPING,
     )
-    success, error_msg = await send_followup_to_window(window_id, args)
+    success, error_msg = await send_telegram_followup_to_window(
+        user_id, window_id, thread_id, args, message.chat.id
+    )
     if not success:
         await safe_reply(message, f"❌ {error_msg}")
         return
@@ -254,7 +259,7 @@ async def forward_command_handler(
     # args is forwarded verbatim to the provider via tmux send-keys -l (literal mode).
     # Gated by config.is_user_allowed — authorised users can type anything into their own agent.
     args = parts[1] if len(parts) > 1 else ""
-    window_id = thread_router.resolve_window_for_thread(user.id, thread_id)
+    window_id = thread_router.resolve_window_for_thread(user.id, thread_id, chat.id)
     if not window_id:
         await safe_reply(update.message, "❌ No session bound to this topic.")
         return
@@ -300,7 +305,9 @@ async def forward_command_handler(
     ) = await _capture_forward_probe_context(window_id, provider, cc_slash, status_like)
 
     lifecycle_strategy.clear_probe_failures(window_id)
-    success, error_msg = await send_to_window(window_id, cc_slash)
+    success, error_msg = await send_telegram_to_window(
+        user.id, window_id, thread_id, cc_slash, update.message.chat.id
+    )
     if not success:
         await safe_reply(update.message, f"❌ {error_msg}")
         return

--- a/src/ccgram/handlers/commands/menu_sync.py
+++ b/src/ccgram/handlers/commands/menu_sync.py
@@ -199,7 +199,9 @@ async def sync_scoped_menu_for_text_context(update: Update, user_id: int) -> Non
     thread_id = _get_thread_id(update)
     if thread_id is None:
         return
-    window_id = thread_router.resolve_window_for_thread(user_id, thread_id)
+    window_id = thread_router.resolve_window_for_thread(
+        user_id, thread_id, message.chat.id
+    )
     if not window_id:
         return
     provider = get_provider_for_window(

--- a/src/ccgram/handlers/file_handler.py
+++ b/src/ccgram/handlers/file_handler.py
@@ -23,7 +23,7 @@ from telegram.error import TelegramError
 from ..config import config
 from ..telegram_client import PTBTelegramClient
 from ..window_query import view_window
-from ..multiplexer.window_ops import send_to_window
+from .telegram_origin import send_telegram_to_window
 from ..thread_router import thread_router
 from .callback_helpers import get_thread_id
 from .messaging_pipeline.message_sender import ack_reaction, safe_reply
@@ -106,13 +106,13 @@ def _generate_photo_filename(file_unique_id: str) -> str:
 
 
 def _resolve_upload_dir(
-    user_id: int, thread_id: int | None
+    user_id: int, thread_id: int | None, chat_id: int | None = None
 ) -> tuple[str | None, Path | None, str | None]:
     """Resolve window_id and upload directory for a thread.
 
     Returns (window_id, upload_path, error_message).
     """
-    window_id = thread_router.resolve_window_for_thread(user_id, thread_id)
+    window_id = thread_router.resolve_window_for_thread(user_id, thread_id, chat_id)
     if not window_id:
         return None, None, "No session bound to this topic."
 
@@ -192,7 +192,9 @@ async def _upload_and_notify(
     success_emoji: str,
 ) -> None:
     """Shared upload flow: resolve dir, download, notify Claude, reply to user."""
-    window_id, upload_path, error = _resolve_upload_dir(user_id, thread_id)
+    window_id, upload_path, error = _resolve_upload_dir(
+        user_id, thread_id, message.chat.id
+    )
     if error or not window_id or not upload_path:
         await safe_reply(message, f"\u274c {error}")
         return
@@ -211,7 +213,9 @@ async def _upload_and_notify(
     if caption:
         claude_msg += f"\n\nUser note: {_sanitize_caption(caption)}"
 
-    success, err = await send_to_window(window_id, claude_msg)
+    success, err = await send_telegram_to_window(
+        user_id, window_id, message.message_thread_id, claude_msg, message.chat.id
+    )
     if success:
         await ack_reaction(
             PTBTelegramClient(message.get_bot()), message.chat.id, message.message_id

--- a/src/ccgram/handlers/live/screenshot_callbacks.py
+++ b/src/ccgram/handlers/live/screenshot_callbacks.py
@@ -129,7 +129,8 @@ async def _handle_live_start(
     """Handle CB_LIVE_START: start auto-refreshing live view."""
     target = data[len(CB_LIVE_START) :]
     window_id, pane_id = parse_target(target)
-    if not user_owns_window(user_id, window_id):
+    callback_chat_id = query.message.chat.id if query.message else None
+    if not user_owns_window(user_id, window_id, callback_chat_id):
         await query.answer("Not your session", show_alert=True)
         return
     thread_id = get_thread_id(update)
@@ -205,7 +206,8 @@ async def _handle_live_stop(
     """Handle CB_LIVE_STOP: stop live view and revert to screenshot keyboard."""
     target = data[len(CB_LIVE_STOP) :]
     window_id, pane_id = parse_target(target)
-    if not user_owns_window(user_id, window_id):
+    callback_chat_id = query.message.chat.id if query.message else None
+    if not user_owns_window(user_id, window_id, callback_chat_id):
         await query.answer("Not your session", show_alert=True)
         return
     thread_id = get_thread_id(update)
@@ -236,7 +238,8 @@ async def _handle_pane_screenshot(
     window_id = rest[:delim_idx]
     pane_id = rest[delim_idx + 1 :]
 
-    if not user_owns_window(user_id, window_id):
+    callback_chat_id = query.message.chat.id if query.message else None
+    if not user_owns_window(user_id, window_id, callback_chat_id):
         await query.answer("Not your session", show_alert=True)
         return
 
@@ -305,7 +308,8 @@ async def _handle_refresh(query: CallbackQuery, user_id: int, data: str) -> None
     """Handle CB_SCREENSHOT_REFRESH: refresh an existing screenshot."""
     target = data[len(CB_SCREENSHOT_REFRESH) :]
     window_id, pane_id = parse_target(target)
-    if not user_owns_window(user_id, window_id):
+    callback_chat_id = query.message.chat.id if query.message else None
+    if not user_owns_window(user_id, window_id, callback_chat_id):
         await query.answer("Not your session", show_alert=True)
         return
     w = await tmux_manager.find_window_by_id(window_id)
@@ -343,7 +347,8 @@ async def _handle_status_screenshot(
 ) -> None:
     """Handle CB_STATUS_SCREENSHOT: take screenshot from status message."""
     window_id = data[len(CB_STATUS_SCREENSHOT) :]
-    if not user_owns_window(user_id, window_id):
+    callback_chat_id = query.message.chat.id if query.message else None
+    if not user_owns_window(user_id, window_id, callback_chat_id):
         await query.answer("Not your session", show_alert=True)
         return
     w = await tmux_manager.find_window_by_id(window_id)

--- a/src/ccgram/handlers/messaging_pipeline/message_queue.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_queue.py
@@ -174,6 +174,10 @@ def _can_merge_tasks(base: ContentTask, candidate: MessageTask) -> bool:
         return False
     if base.window_id != candidate.window_id:
         return False
+    # Never merge across topics or chats: identical thread IDs can exist in
+    # different chats, and merged text is delivered to a single destination.
+    if base.thread_id != candidate.thread_id or base.chat_id != candidate.chat_id:
+        return False
     if base.content_type in ("tool_use", "tool_result"):
         return False
     return candidate.content_type not in ("tool_use", "tool_result")
@@ -232,6 +236,7 @@ async def _merge_content_tasks(
             content_type=first.content_type,
             role=first.role,
             thread_id=first.thread_id,
+            chat_id=first.chat_id,
         ),
         merge_count,
     )
@@ -416,7 +421,7 @@ async def _process_content_task(
 ) -> None:
     """Process a content message task."""
     tkey = thread_key(task.thread_id)
-    chat_id = thread_router.resolve_chat_id(user_id, task.thread_id)
+    chat_id = task.chat_id or thread_router.resolve_chat_id(user_id, task.thread_id)
 
     if task.content_type == "tool_result" and task.tool_use_id:
         _tkey = (task.tool_use_id, user_id, tkey)
@@ -439,7 +444,7 @@ async def _process_content_task(
     for part in task.parts:
         sent = None
 
-        if first_part:
+        if first_part and task.chat_id is None:
             first_part = False
             converted_msg_id = await convert_status_to_content(
                 client,
@@ -451,6 +456,8 @@ async def _process_content_task(
             if converted_msg_id is not None:
                 last_msg_id = converted_msg_id
                 continue
+        else:
+            first_part = False
 
         sent = await rate_limit_send_message(
             client, chat_id, part, **send_kwargs(task.thread_id)
@@ -482,6 +489,7 @@ async def enqueue_content_message(
     content_type: ContentType = "text",
     role: MessageRole = "assistant",
     thread_id: int | None = None,
+    chat_id: int | None = None,
 ) -> None:
     """Enqueue a content message task."""
     if _is_ghost_window_task_at_enqueue(window_id):
@@ -496,6 +504,7 @@ async def enqueue_content_message(
         content_type=content_type,
         role=role,
         thread_id=thread_id,
+        chat_id=chat_id,
     )
     queue.put_nowait(task)
 

--- a/src/ccgram/handlers/messaging_pipeline/message_routing.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_routing.py
@@ -23,6 +23,7 @@ from ..interactive import (
     set_interactive_mode,
 )
 from ..response_builder import build_response_parts
+from ..telegram_origin import consume_telegram_injection
 from .message_queue import enqueue_content_message, get_message_queue
 
 logger = structlog.get_logger()
@@ -55,6 +56,14 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
         structlog.contextvars.bind_contextvars(
             window_id=window_id, session_id=msg.session_id
         )
+
+        if (
+            msg.is_complete
+            and msg.role == "user"
+            and consume_telegram_injection(user_id, window_id, thread_id, msg.text)
+        ):
+            logger.debug("Suppressed Telegram-originated user transcript message")
+            continue
 
         if msg.content_type == "thinking":
             stripped = (msg.text or "").strip()

--- a/src/ccgram/handlers/messaging_pipeline/message_routing.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_routing.py
@@ -51,7 +51,7 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
         logger.debug("No active users for session %s", msg.session_id)
         return
 
-    for user_id, window_id, thread_id in active_users:
+    for user_id, window_id, thread_id, chat_id in active_users:
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(
             window_id=window_id, session_id=msg.session_id
@@ -60,7 +60,9 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
         if (
             msg.is_complete
             and msg.role == "user"
-            and consume_telegram_injection(user_id, window_id, thread_id, msg.text)
+            and consume_telegram_injection(
+                user_id, window_id, thread_id, msg.text, chat_id
+            )
         ):
             logger.debug("Suppressed Telegram-originated user transcript message")
             continue
@@ -112,6 +114,7 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
                 content_type=msg.content_type,  # type: ignore[arg-type]  # NewMessage.content_type is str, narrows at runtime
                 role=msg.role,  # type: ignore[arg-type]  # NewMessage.role is str, narrows at runtime
                 thread_id=thread_id,
+                chat_id=chat_id,
             )
 
             session = await session_query.resolve_session_for_window(window_id)

--- a/src/ccgram/handlers/messaging_pipeline/message_task.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_task.py
@@ -23,6 +23,7 @@ class ContentTask:
     tool_use_id: str | None = None
     tool_name: str | None = None
     thread_id: int | None = None
+    chat_id: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ccgram/handlers/polling/polling_coordinator.py
+++ b/src/ccgram/handlers/polling/polling_coordinator.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import structlog
 from telegram.error import TelegramError
 
-from ...thread_router import thread_router
+from ...thread_router import chat_scope, thread_router
 from ...multiplexer import multiplexer as tmux_manager
 from ...multiplexer.reconciliation import list_windows_for_reconciliation
 from ...utils import log_throttled
@@ -26,8 +26,6 @@ _BACKOFF_MIN = 2.0
 _BACKOFF_MAX = 30.0
 
 _LoopError = (TelegramError, OSError, RuntimeError, ValueError)
-
-
 # ── Per-iteration tick helper ─────────────────────────────────────────────
 
 
@@ -42,14 +40,20 @@ async def _tick_bound_windows(
     Extracted so tests can drive a single iteration with an isolated
     ``PollingRuntime``. Production callers pass no runtime; default singletons.
     """
-    for user_id, thread_id, wid in list(thread_router.iter_thread_bindings()):
+    bindings = list(thread_router.iter_thread_bindings_with_chat()) or [
+        (uid, None, tid, wid) for uid, tid, wid in thread_router.iter_thread_bindings()
+    ]
+    for user_id, chat_id, thread_id, wid in bindings:
+        if chat_id is None:
+            chat_id = thread_router.resolve_chat_id(user_id, thread_id)
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(window_id=wid)
         try:
-            w = window_lookup.get(wid)
-            await window_tick.tick_window(
-                bot, user_id, thread_id, wid, w, runtime=runtime
-            )
+            with chat_scope(chat_id):
+                w = window_lookup.get(wid)
+                await window_tick.tick_window(
+                    bot, user_id, thread_id, wid, w, runtime=runtime
+                )
         except (TelegramError, OSError) as e:
             log_throttled(
                 logger,

--- a/src/ccgram/handlers/recovery/recovery_banner.py
+++ b/src/ccgram/handlers/recovery/recovery_banner.py
@@ -37,7 +37,7 @@ from ...session_map import session_map_sync
 from ...telegram_client import PTBTelegramClient
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
-from ...multiplexer.window_ops import send_to_window
+from ..telegram_origin import send_telegram_to_window
 from ...window_state_store import CCGRAM_CREATED_WINDOW_ORIGIN
 from ..callback_data import (
     CB_RECOVERY_BACK,
@@ -282,10 +282,14 @@ async def _create_and_bind_window(
     session_manager.set_window_provider(created_wid, provider.capabilities.name)
     session_manager.set_window_approval_mode(created_wid, approval_mode)
 
-    thread_router.bind_thread(
-        user_id, thread_id, created_wid, window_name=created_wname
-    )
     chat = query.message.chat if query.message else None
+    thread_router.bind_thread(
+        user_id,
+        thread_id,
+        created_wid,
+        window_name=created_wname,
+        chat_id=chat.id if chat and chat.type in ("group", "supergroup") else None,
+    )
     if chat and chat.type in ("group", "supergroup"):
         thread_router.set_group_chat_id(user_id, thread_id, chat.id)
 
@@ -306,7 +310,9 @@ async def _create_and_bind_window(
     )
     _clear_recovery_state(context.user_data)
     if pending_text:
-        send_ok, send_msg = await send_to_window(created_wid, pending_text)
+        send_ok, send_msg = await send_telegram_to_window(
+            user_id, created_wid, thread_id, pending_text, chat.id if chat else None
+        )
         if not send_ok:
             logger.warning(
                 "Failed to forward pending text to window %s (user %s): %s",

--- a/src/ccgram/handlers/send/send_callbacks.py
+++ b/src/ccgram/handlers/send/send_callbacks.py
@@ -119,7 +119,9 @@ async def _dispatch(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     stored_window_id = context.user_data.get(SEND_WINDOW_ID_KEY)
-    current_window_id = thread_router.resolve_window_for_thread(user.id, thread_id)
+    current_window_id = thread_router.resolve_window_for_thread(
+        user.id, thread_id, query.message.chat.id if query.message else None
+    )
     if stored_window_id is None or stored_window_id != current_window_id:
         _clear_send_state(context)
         await query.answer("Browser expired — use /send to restart", show_alert=True)

--- a/src/ccgram/handlers/send/send_command.py
+++ b/src/ccgram/handlers/send/send_command.py
@@ -456,7 +456,9 @@ async def send_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         await safe_reply(update.message, "Use this command inside a topic.")
         return
 
-    window_id = thread_router.resolve_window_for_thread(user.id, thread_id)
+    window_id = thread_router.resolve_window_for_thread(
+        user.id, thread_id, update.message.chat.id
+    )
     if not window_id:
         await safe_reply(update.message, "No session bound to this topic.")
         return

--- a/src/ccgram/handlers/shell/shell_commands.py
+++ b/src/ccgram/handlers/shell/shell_commands.py
@@ -34,7 +34,7 @@ from ...llm import get_completer
 from ...llm import CommandResult
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
-from ...multiplexer.window_ops import send_to_window
+from ..telegram_origin import send_telegram_to_window as send_to_window
 from ..callback_data import (
     CB_SHELL_CANCEL,
     CB_SHELL_CONFIRM_DANGER,
@@ -207,12 +207,20 @@ async def handle_shell_message(
     window_id: str,
     text: str,
     message: Message | None = None,
+    chat_id: int | None = None,
 ) -> None:
     """Route shell provider messages: ``!`` prefix = raw, else = NL via LLM."""
     await enqueue_status_update(client, user_id, window_id, None, thread_id)
     lifecycle_strategy.clear_probe_failures(window_id)
 
-    chat_id = thread_router.resolve_chat_id(user_id, thread_id)
+    message_chat_id = message.chat.id if message is not None else None
+    chat_id = (
+        message_chat_id
+        if isinstance(message_chat_id, int)
+        else chat_id
+        if isinstance(chat_id, int)
+        else thread_router.resolve_chat_id(user_id, thread_id)
+    )
     clear_shell_pending(chat_id, thread_id)
     await _ensure_prompt_marker(window_id)
 
@@ -233,7 +241,13 @@ async def handle_shell_message(
         if not raw:
             return
         await _execute_raw_command(
-            client, user_id, thread_id, window_id, raw, message_id=msg_id
+            client,
+            user_id,
+            thread_id,
+            window_id,
+            raw,
+            message_id=msg_id,
+            chat_id=chat_id,
         )
         return
 
@@ -252,7 +266,13 @@ async def handle_shell_message(
     if not completer:
         # No LLM configured — raw mode is intentional
         await _execute_raw_command(
-            client, user_id, thread_id, window_id, text, message_id=msg_id
+            client,
+            user_id,
+            thread_id,
+            window_id,
+            text,
+            message_id=msg_id,
+            chat_id=chat_id,
         )
         return
 
@@ -322,6 +342,7 @@ async def _execute_raw_command(
     window_id: str,
     command: str,
     message_id: int = 0,
+    chat_id: int | None = None,
 ) -> None:
     """Send a raw command to the shell and start output capture.
 
@@ -331,7 +352,9 @@ async def _execute_raw_command(
     """
     await _cancel_stuck_input(window_id)
 
-    success, err_message = await send_to_window(window_id, command, raw=True)
+    success, err_message = await send_to_window(
+        user_id, window_id, thread_id, command, chat_id, raw=True
+    )
     if not success:
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
         await safe_send(
@@ -464,7 +487,12 @@ async def handle_shell_callback(
         await query.answer("No topic context")
         return
 
-    chat_id = thread_router.resolve_chat_id(user_id, thread_id)
+    callback_chat_id = query.message.chat.id if query.message is not None else None
+    chat_id = (
+        callback_chat_id
+        if isinstance(callback_chat_id, int)
+        else thread_router.resolve_chat_id(user_id, thread_id)
+    )
     pending = _shell_pending.get((chat_id, thread_id))
 
     if data.startswith(CB_SHELL_RUN) or data.startswith(CB_SHELL_CONFIRM_DANGER):
@@ -495,7 +523,7 @@ async def _cb_run(
         return
 
     # Use window from thread binding (authoritative), not callback data
-    window_id = thread_router.get_window_for_thread(user_id, thread_id)
+    window_id = thread_router.get_window_for_thread(user_id, thread_id, chat_id)
     if not window_id:
         clear_shell_pending(chat_id, thread_id)
         await safe_edit(query, "❌ No session bound")
@@ -504,7 +532,13 @@ async def _cb_run(
     clear_shell_pending(chat_id, thread_id)
     await safe_edit(query, f"▶ `{command}`")
     await _execute_raw_command(
-        client, user_id, thread_id, window_id, command, message_id=msg_id
+        client,
+        user_id,
+        thread_id,
+        window_id,
+        command,
+        message_id=msg_id,
+        chat_id=chat_id,
     )
 
 

--- a/src/ccgram/handlers/status/status_bar_actions.py
+++ b/src/ccgram/handlers/status/status_bar_actions.py
@@ -34,7 +34,7 @@ from ... import window_query
 from ...telegram_client import PTBTelegramClient
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
-from ...multiplexer.window_ops import send_to_window
+from ..telegram_origin import send_telegram_to_window
 from ...topic_state_registry import topic_state
 from ..callback_data import (
     CB_KEYS_PREFIX,
@@ -122,7 +122,12 @@ async def _handle_status_recall(
     if thread_id is None:
         await query.answer("Use in a topic", show_alert=True)
         return
-    if thread_router.resolve_window_for_thread(user_id, thread_id) != window_id:
+    if (
+        thread_router.resolve_window_for_thread(
+            user_id, thread_id, query.message.chat.id if query.message else None
+        )
+        != window_id
+    ):
         await query.answer("Stale status button", show_alert=True)
         return
 
@@ -159,7 +164,13 @@ async def _handle_status_recall(
         await query.answer("\u21a9 Recalled")
         return
 
-    ok, err = await send_to_window(window_id, command)
+    ok, err = await send_telegram_to_window(
+        user_id,
+        window_id,
+        thread_id,
+        command,
+        query.message.chat.id if query.message else None,
+    )
     if not ok:
         await query.answer(err or "Failed to send command", show_alert=True)
         return
@@ -171,7 +182,8 @@ async def _handle_status_recall(
 async def _handle_status_esc(query: CallbackQuery, user_id: int, data: str) -> None:
     """Handle CB_STATUS_ESC: send Escape key from status message."""
     window_id = data[len(CB_STATUS_ESC) :]
-    if not user_owns_window(user_id, window_id):
+    callback_chat_id = query.message.chat.id if query.message else None
+    if not user_owns_window(user_id, window_id, callback_chat_id):
         await query.answer("Not your session", show_alert=True)
         return
     w = await tmux_manager.find_window_by_id(window_id)
@@ -195,7 +207,8 @@ async def _handle_keys(
     target = rest[colon_idx + 1 :]
     window_id, pane_id = parse_target(target)
 
-    if not user_owns_window(user_id, window_id):
+    callback_chat_id = query.message.chat.id if query.message else None
+    if not user_owns_window(user_id, window_id, callback_chat_id):
         await query.answer("Not your session", show_alert=True)
         return
 

--- a/src/ccgram/handlers/sync_command.py
+++ b/src/ccgram/handlers/sync_command.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 import asyncio
-import contextlib
 import re
 
 import structlog
@@ -39,6 +38,7 @@ from .callback_registry import register
 from .cleanup import clear_topic_state
 from .messaging_pipeline.message_sender import is_thread_gone, safe_edit, safe_reply
 from .status.topic_emoji import sync_topic_name
+from .topics.topic_probe import probe_topic_exists
 
 if TYPE_CHECKING:
     from telegram.ext import ContextTypes
@@ -295,7 +295,7 @@ async def _adopt_orphaned_windows(
         )
         try:
             await _handle_new_window(event, client)
-        except TelegramError:
+        except TelegramError, OSError:
             logger.exception("Failed to adopt orphaned window %s", window_id)
 
 
@@ -321,26 +321,14 @@ async def _probe_dead_topics(client: TelegramClient) -> list[AuditIssue]:
         user_id: int, thread_id: int, window_id: str, chat_id: int
     ) -> AuditIssue | None:
         async with sem:
-            try:
-                msg = await client.send_message(
-                    chat_id,
-                    ".",
-                    message_thread_id=thread_id,
-                    disable_notification=True,
+            exists = await probe_topic_exists(client, chat_id, thread_id)
+            if exists is False:
+                display = thread_router.get_display_name(window_id)
+                return AuditIssue(
+                    category="dead_topic",
+                    detail=f"user:{user_id} thread:{thread_id} window:{window_id} ({display})",
+                    fixable=True,
                 )
-                # Topic exists — clean up probe message
-                with contextlib.suppress(TelegramError):
-                    await client.delete_message(chat_id, msg.message_id)
-            except BadRequest as exc:
-                if is_thread_gone(exc):
-                    display = thread_router.get_display_name(window_id)
-                    return AuditIssue(
-                        category="dead_topic",
-                        detail=f"user:{user_id} thread:{thread_id} window:{window_id} ({display})",
-                        fixable=True,
-                    )
-            except TelegramError:
-                pass  # network error, skip — not a dead topic
         return None
 
     results = await asyncio.gather(
@@ -395,32 +383,33 @@ async def _recreate_dead_topics(
             cwd=view.cwd if view else "",
         )
 
-        # Preserve group_chat_id before unbinding — unbind_thread deletes it,
-        # but _handle_new_window needs it to know which chat to create the topic in.
+        # Preserve group_chat_id before unbinding; the targeted repair passes it
+        # directly so another user's binding cannot short-circuit recreation.
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
 
-        # Unbind THEN recreate — must unbind first so _handle_new_window
-        # doesn't skip the window as "already bound".  On failure, restore.
         thread_router.unbind_thread(user_id, thread_id)
 
-        # Inject a temporary in-memory-only group_chat_id so _handle_new_window
-        # can discover the chat.  Direct dict mutation avoids _save_state() —
-        # if the process crashes, the placeholder won't persist to state.json.
-        _placeholder_key = f"{user_id}:0"
-        if chat_id != user_id:
-            thread_router.group_chat_ids[_placeholder_key] = chat_id
-
+        created = False
         try:
-            await _handle_new_window(event, client)
-            recreated += 1
+            created = await _handle_new_window(
+                event,
+                client,
+                target_user_id=user_id,
+                target_chat_id=chat_id,
+            )
+            if created:
+                recreated += 1
+            else:
+                logger.warning("Could not recreate topic for window %s", window_id)
         except TelegramError, OSError:
             logger.exception("Failed to recreate topic for window %s", window_id)
-            # Restore binding so the window isn't orphaned
-            thread_router.bind_thread(user_id, thread_id, window_id, window_name=name)
-            if chat_id != user_id:
-                thread_router.set_group_chat_id(user_id, thread_id, chat_id)
         finally:
-            thread_router.group_chat_ids.pop(_placeholder_key, None)
+            if not created:
+                thread_router.bind_thread(
+                    user_id, thread_id, window_id, window_name=name, chat_id=chat_id
+                )
+                if chat_id != user_id:
+                    thread_router.set_group_chat_id(user_id, thread_id, chat_id)
     return recreated
 
 

--- a/src/ccgram/handlers/sync_command.py
+++ b/src/ccgram/handlers/sync_command.py
@@ -302,8 +302,8 @@ async def _adopt_orphaned_windows(
 async def _probe_dead_topics(client: TelegramClient) -> list[AuditIssue]:
     """Probe Telegram topics for all live bindings, return dead_topic issues.
 
-    Sends a silent zero-width-space message to each thread and deletes it
-    immediately. ``send_chat_action`` does NOT validate thread existence —
+    Sends a silent dot message to each thread and deletes it immediately.
+    ``send_chat_action`` does NOT validate thread existence —
     only ``send_message`` reliably throws "thread not found" for deleted topics.
     """
     bindings = [
@@ -324,7 +324,7 @@ async def _probe_dead_topics(client: TelegramClient) -> list[AuditIssue]:
             try:
                 msg = await client.send_message(
                     chat_id,
-                    "​",  # zero-width space — invisible
+                    ".",
                     message_thread_id=thread_id,
                     disable_notification=True,
                 )

--- a/src/ccgram/handlers/telegram_origin.py
+++ b/src/ccgram/handlers/telegram_origin.py
@@ -6,8 +6,9 @@ from collections import deque
 from dataclasses import dataclass
 import time
 
+from ..multiplexer.window_ops import send_followup_to_window, send_to_window
+
 _PENDING_INJECTION_TTL_S = 30.0
-_MAX_PENDING_INJECTIONS = 16
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -16,25 +17,33 @@ class _PendingInjection:
     created_at: float
 
 
-_pending_injections: dict[tuple[int, str, int], deque[_PendingInjection]] = {}
+_pending_injections: dict[
+    tuple[int, int | None, str, int], deque[_PendingInjection]
+] = {}
 
 
 def _normalize(text: str) -> str:
-    return text.replace("\r\n", "\n").rstrip("\n")
+    return text.replace("\r\n", "\n").strip()
+
+
+def _key(user_id: int, window_id: str, thread_id: int, chat_id: int | None):
+    return user_id, chat_id, window_id, thread_id
 
 
 def remember_telegram_injection(
-    user_id: int, window_id: str, thread_id: int, text: str
+    user_id: int,
+    window_id: str,
+    thread_id: int,
+    text: str,
+    chat_id: int | None = None,
 ) -> _PendingInjection:
-    """Reserve a Telegram prompt before terminal injection."""
-    key = (user_id, window_id, thread_id)
-    pending = _pending_injections.setdefault(key, deque())
     now = time.monotonic()
-    _discard_expired(pending, now)
+    _discard_all_expired(now)
+    pending = _pending_injections.setdefault(
+        _key(user_id, window_id, thread_id, chat_id), deque()
+    )
     injection = _PendingInjection(_normalize(text), now)
     pending.append(injection)
-    while len(pending) > _MAX_PENDING_INJECTIONS:
-        pending.popleft()
     return injection
 
 
@@ -43,10 +52,9 @@ def forget_telegram_injection(
     window_id: str,
     thread_id: int,
     injection: _PendingInjection,
+    chat_id: int | None = None,
 ) -> None:
-    """Remove a reservation when terminal injection fails."""
-    key = (user_id, window_id, thread_id)
-    pending = _pending_injections.get(key)
+    pending = _pending_injections.get(_key(user_id, window_id, thread_id, chat_id))
     if pending is None:
         return
     try:
@@ -54,36 +62,89 @@ def forget_telegram_injection(
     except ValueError:
         return
     if not pending:
-        _pending_injections.pop(key, None)
+        _pending_injections.pop(_key(user_id, window_id, thread_id, chat_id), None)
+
+
+async def send_telegram_to_window(
+    user_id: int,
+    window_id: str,
+    thread_id: int | None,
+    text: str,
+    chat_id: int | None = None,
+    *,
+    raw: bool = False,
+) -> tuple[bool, str]:
+    if thread_id is None:
+        return await send_to_window(window_id, text, raw=raw)
+    injection = remember_telegram_injection(
+        user_id, window_id, thread_id, text, chat_id
+    )
+    success = False
+    try:
+        success, message = await send_to_window(window_id, text, raw=raw)
+        return success, message
+    finally:
+        if not success:
+            forget_telegram_injection(user_id, window_id, thread_id, injection, chat_id)
+
+
+async def send_telegram_followup_to_window(
+    user_id: int,
+    window_id: str,
+    thread_id: int | None,
+    text: str,
+    chat_id: int | None = None,
+) -> tuple[bool, str]:
+    if thread_id is None:
+        return await send_followup_to_window(window_id, text)
+    injection = remember_telegram_injection(
+        user_id, window_id, thread_id, text, chat_id
+    )
+    success = False
+    try:
+        success, message = await send_followup_to_window(window_id, text)
+        return success, message
+    finally:
+        if not success:
+            forget_telegram_injection(user_id, window_id, thread_id, injection, chat_id)
 
 
 def consume_telegram_injection(
-    user_id: int, window_id: str, thread_id: int, text: str
+    user_id: int,
+    window_id: str,
+    thread_id: int,
+    text: str,
+    chat_id: int | None = None,
 ) -> bool:
-    """Consume one matching pending prompt, returning whether it was Telegram-originated."""
-    key = (user_id, window_id, thread_id)
+    key = _key(user_id, window_id, thread_id, chat_id)
     pending = _pending_injections.get(key)
     if pending is None:
         return False
-
     _discard_expired(pending, time.monotonic())
     if not pending:
         _pending_injections.pop(key, None)
         return False
-    if pending[0].text != _normalize(text):
-        return False
-
-    pending.popleft()
-    if not pending:
-        _pending_injections.pop(key, None)
-    return True
+    normalized = _normalize(text)
+    for index, injection in enumerate(pending):
+        if injection.text == normalized:
+            del pending[index]
+            if not pending:
+                _pending_injections.pop(key, None)
+            return True
+    return False
 
 
 def clear_pending_telegram_injections() -> None:
-    """Clear pending input correlations. Used by tests and process shutdown."""
     _pending_injections.clear()
 
 
 def _discard_expired(pending: deque[_PendingInjection], now: float) -> None:
     while pending and now - pending[0].created_at >= _PENDING_INJECTION_TTL_S:
         pending.popleft()
+
+
+def _discard_all_expired(now: float) -> None:
+    for key, pending in list(_pending_injections.items()):
+        _discard_expired(pending, now)
+        if not pending:
+            _pending_injections.pop(key, None)

--- a/src/ccgram/handlers/telegram_origin.py
+++ b/src/ccgram/handlers/telegram_origin.py
@@ -1,0 +1,89 @@
+"""Correlate Telegram-to-terminal input with transcript user messages."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+import time
+
+_PENDING_INJECTION_TTL_S = 30.0
+_MAX_PENDING_INJECTIONS = 16
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class _PendingInjection:
+    text: str
+    created_at: float
+
+
+_pending_injections: dict[tuple[int, str, int], deque[_PendingInjection]] = {}
+
+
+def _normalize(text: str) -> str:
+    return text.replace("\r\n", "\n").rstrip("\n")
+
+
+def remember_telegram_injection(
+    user_id: int, window_id: str, thread_id: int, text: str
+) -> _PendingInjection:
+    """Reserve a Telegram prompt before terminal injection."""
+    key = (user_id, window_id, thread_id)
+    pending = _pending_injections.setdefault(key, deque())
+    now = time.monotonic()
+    _discard_expired(pending, now)
+    injection = _PendingInjection(_normalize(text), now)
+    pending.append(injection)
+    while len(pending) > _MAX_PENDING_INJECTIONS:
+        pending.popleft()
+    return injection
+
+
+def forget_telegram_injection(
+    user_id: int,
+    window_id: str,
+    thread_id: int,
+    injection: _PendingInjection,
+) -> None:
+    """Remove a reservation when terminal injection fails."""
+    key = (user_id, window_id, thread_id)
+    pending = _pending_injections.get(key)
+    if pending is None:
+        return
+    try:
+        pending.remove(injection)
+    except ValueError:
+        return
+    if not pending:
+        _pending_injections.pop(key, None)
+
+
+def consume_telegram_injection(
+    user_id: int, window_id: str, thread_id: int, text: str
+) -> bool:
+    """Consume one matching pending prompt, returning whether it was Telegram-originated."""
+    key = (user_id, window_id, thread_id)
+    pending = _pending_injections.get(key)
+    if pending is None:
+        return False
+
+    _discard_expired(pending, time.monotonic())
+    if not pending:
+        _pending_injections.pop(key, None)
+        return False
+    if pending[0].text != _normalize(text):
+        return False
+
+    pending.popleft()
+    if not pending:
+        _pending_injections.pop(key, None)
+    return True
+
+
+def clear_pending_telegram_injections() -> None:
+    """Clear pending input correlations. Used by tests and process shutdown."""
+    _pending_injections.clear()
+
+
+def _discard_expired(pending: deque[_PendingInjection], now: float) -> None:
+    while pending and now - pending[0].created_at >= _PENDING_INJECTION_TTL_S:
+        pending.popleft()

--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -51,10 +51,7 @@ from ..messaging_pipeline.message_sender import (
 )
 from ..recovery.recovery_banner import RecoveryBanner, render_banner
 from ..polling.polling_state import lifecycle_strategy
-from ..telegram_origin import (
-    forget_telegram_injection,
-    remember_telegram_injection,
-)
+from ..telegram_origin import send_telegram_to_window
 from ...topic_state_registry import topic_state
 from ..user_state import (
     AWAITING_WORKTREE_BRANCH_NAME,
@@ -70,7 +67,6 @@ from ... import window_query
 from ...thread_router import thread_router
 from ...providers import get_provider_for_window
 from ...multiplexer import multiplexer as tmux_manager
-from ...multiplexer.window_ops import send_to_window
 from ...utils import handle_general_topic_message, is_general_topic, task_done_callback
 
 if TYPE_CHECKING:
@@ -269,7 +265,7 @@ async def _handle_unbound_topic(
 
     Returns True if the topic is unbound (handled), False if already bound.
     """
-    window_id = thread_router.get_window_for_thread(user_id, thread_id)
+    window_id = thread_router.get_window_for_thread(user_id, thread_id, message.chat.id)
     if window_id is not None:
         return False
 
@@ -425,13 +421,9 @@ async def _forward_message(
 
     lifecycle_strategy.clear_probe_failures(window_id)
 
-    injection = remember_telegram_injection(user_id, window_id, thread_id, text)
-    success = False
-    try:
-        success, err_message = await send_to_window(window_id, text)
-    finally:
-        if not success:
-            forget_telegram_injection(user_id, window_id, thread_id, injection)
+    success, err_message = await send_telegram_to_window(
+        user_id, window_id, thread_id, text, message.chat.id
+    )
     if not success:
         await safe_reply(message, f"\u274c {err_message}")
         return
@@ -532,7 +524,7 @@ async def handle_text_message(
         return
 
     # Bound topic — check if window is still alive
-    window_id = thread_router.get_window_for_thread(user.id, thread_id)
+    window_id = thread_router.get_window_for_thread(user.id, thread_id, message.chat.id)
     assert window_id is not None  # _handle_unbound_topic returned False
 
     if await _handle_dead_window(

--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -51,6 +51,10 @@ from ..messaging_pipeline.message_sender import (
 )
 from ..recovery.recovery_banner import RecoveryBanner, render_banner
 from ..polling.polling_state import lifecycle_strategy
+from ..telegram_origin import (
+    forget_telegram_injection,
+    remember_telegram_injection,
+)
 from ...topic_state_registry import topic_state
 from ..user_state import (
     AWAITING_WORKTREE_BRANCH_NAME,
@@ -421,7 +425,13 @@ async def _forward_message(
 
     lifecycle_strategy.clear_probe_failures(window_id)
 
-    success, err_message = await send_to_window(window_id, text)
+    injection = remember_telegram_injection(user_id, window_id, thread_id, text)
+    success = False
+    try:
+        success, err_message = await send_to_window(window_id, text)
+    finally:
+        if not success:
+            forget_telegram_injection(user_id, window_id, thread_id, injection)
     if not success:
         await safe_reply(message, f"\u274c {err_message}")
         return

--- a/src/ccgram/handlers/toolbar/toolbar_callbacks.py
+++ b/src/ccgram/handlers/toolbar/toolbar_callbacks.py
@@ -5,7 +5,7 @@ looked up in the loaded ``ToolbarConfig.actions`` and dispatched by
 ``action_type``:
 
   - ``key``    → ``tmux_manager.send_keys(payload, enter=False, literal=...)``
-  - ``text``   → ``tmux_manager.send_keys(payload, enter=True, literal=True)``
+  - ``text``   → origin-aware terminal injection with Enter
   - ``builtin`` → dispatched via ``_BUILTIN_DISPATCH`` to a specialized handler
 
 Keyboard construction lives in ``toolbar_keyboard``.
@@ -30,6 +30,7 @@ from ...multiplexer import multiplexer as tmux_manager
 from ...toolbar_config import ToolbarAction
 from ..callback_data import CB_TOOLBAR
 from ..callback_helpers import get_thread_id, user_owns_window
+from ..telegram_origin import send_telegram_to_window
 from ..callback_tokens import resolve_callback_data
 from ..callback_registry import register
 from .toolbar_keyboard import get_toolbar_config, refresh_button_label
@@ -64,14 +65,27 @@ async def _dispatch_key(
 
 
 async def _dispatch_text(
-    action: ToolbarAction, query: CallbackQuery, window_id: str
+    action: ToolbarAction,
+    query: CallbackQuery,
+    user_id: int,
+    window_id: str,
+    thread_id: int | None,
 ) -> None:
     """Send literal text + Enter for a ``text`` action."""
     w = await tmux_manager.find_window_by_id(window_id)
     if w is None:
         await query.answer("Window not found", show_alert=True)
         return
-    await tmux_manager.send_keys(w.window_id, action.payload, enter=True, literal=True)
+    success, error = await send_telegram_to_window(
+        user_id,
+        w.window_id,
+        thread_id,
+        action.payload,
+        query.message.chat.id if query.message else None,
+    )
+    if not success:
+        await query.answer(error or "Failed to send action", show_alert=True)
+        return
     if action.read_state:
         short_label = await refresh_button_label(action, query, window_id)
         await query.answer(f"{action.emoji} {short_label}")
@@ -297,7 +311,7 @@ async def handle_toolbar_callback(
     if action.action_type == "key":
         await _dispatch_key(action, query, window_id)
     elif action.action_type == "text":
-        await _dispatch_text(action, query, window_id)
+        await _dispatch_text(action, query, user_id, window_id, get_thread_id(update))
     elif action.action_type == "builtin":
         handler = _BUILTIN_DISPATCH.get(action.payload)
         if handler is None:

--- a/src/ccgram/handlers/topics/topic_lifecycle.py
+++ b/src/ccgram/handlers/topics/topic_lifecycle.py
@@ -87,7 +87,18 @@ async def _close_expired_topic(
     client: TelegramClient, user_id: int, thread_id: int, state: str
 ) -> None:
     """Attempt to close/delete an expired topic and clean up state."""
-    window_id = thread_router.get_window_for_thread(user_id, thread_id)
+    # Pick chat_id from bindings if exactly one candidate exists.
+    candidates = [
+        (chat_id, wid)
+        for uid, chat_id, tid, wid in thread_router.iter_thread_bindings_with_chat()
+        if uid == user_id and tid == thread_id
+    ]
+    scoped_chat_id = candidates[0][0] if len(candidates) == 1 else None
+    window_id = (
+        thread_router.get_window_for_thread(user_id, thread_id, scoped_chat_id)
+        if scoped_chat_id is not None
+        else thread_router.get_window_for_thread(user_id, thread_id)
+    )
     if state == "dead" and window_id is not None:
         live_window = await tmux_manager.find_window_by_id(window_id)
         if live_window is not None:
@@ -100,7 +111,7 @@ async def _close_expired_topic(
             )
             return
 
-    chat_id = thread_router.resolve_chat_id(user_id, thread_id)
+    chat_id = scoped_chat_id or thread_router.resolve_chat_id(user_id, thread_id)
     removed = False
     try:
         await client.delete_forum_topic(chat_id=chat_id, message_thread_id=thread_id)
@@ -126,13 +137,10 @@ async def _close_expired_topic(
         logger.info(
             "auto_removed_topic", chat_id=chat_id, thread_id=thread_id, user_id=user_id
         )
-        await clear_topic_state(
-            user_id,
-            thread_id,
-            client=client,
-            window_id=window_id,
-            window_dead=True,
-        )
+        cleanup_kwargs: dict = {"window_id": window_id, "window_dead": True}
+        if scoped_chat_id is not None:
+            cleanup_kwargs["chat_id"] = scoped_chat_id
+        await clear_topic_state(user_id, thread_id, client=client, **cleanup_kwargs)
         thread_router.unbind_thread(user_id, thread_id)
 
 
@@ -223,12 +231,20 @@ _probe_pin_disabled: set[str] = set()
 
 async def probe_topic_existence(client: TelegramClient) -> None:
     """Probe all bound topics via Telegram API; detect deleted topics."""
-    for user_id, thread_id, wid in list(thread_router.iter_thread_bindings()):
+    bindings = list(thread_router.iter_thread_bindings_with_chat())
+    if not bindings:
+        bindings = [
+            (user_id, None, thread_id, wid)
+            for user_id, thread_id, wid in thread_router.iter_thread_bindings()
+        ]
+    for user_id, chat_id, thread_id, wid in bindings:
+        if chat_id is None:
+            chat_id = thread_router.resolve_chat_id(user_id, thread_id)
         if wid in _probe_pin_disabled or lifecycle_strategy.should_skip_probe(wid):
             continue
         try:
             await client.unpin_all_forum_topic_messages(
-                chat_id=thread_router.resolve_chat_id(user_id, thread_id),
+                chat_id=chat_id,
                 message_thread_id=thread_id,
             )
             terminal_poll_state.reset_probe_failures(wid)
@@ -244,8 +260,10 @@ async def probe_topic_existence(client: TelegramClient) -> None:
                     await tmux_manager.kill_window(w.window_id)
                     killed = True
                 terminal_poll_state.reset_probe_failures(wid)
-                await clear_topic_state(user_id, thread_id, client, window_id=wid)
-                thread_router.unbind_thread(user_id, thread_id)
+                await clear_topic_state(
+                    user_id, thread_id, client, window_id=wid, chat_id=chat_id
+                )
+                thread_router.unbind_thread(user_id, thread_id, chat_id=chat_id)
                 action = "killed" if killed else "unbound"
                 logger.info(
                     "Topic deleted: %s window_id '%s' and unbound thread %d for user %d",
@@ -295,18 +313,29 @@ async def topic_closed_handler(
     if thread_id is None:
         return
 
-    window_id = thread_router.get_window_for_thread(user.id, thread_id)
+    raw_chat_id = update.effective_chat.id if update.effective_chat else None
+    chat_id = raw_chat_id if isinstance(raw_chat_id, int) else None
+    window_id = (
+        thread_router.get_window_for_thread(user.id, thread_id, chat_id)
+        if isinstance(chat_id, int)
+        else thread_router.get_window_for_thread(user.id, thread_id)
+    )
     if window_id:
         display = thread_router.get_display_name(window_id)
+        cleanup_kwargs = {"window_id": window_id, "window_dead": False}
+        if chat_id is not None:
+            cleanup_kwargs["chat_id"] = chat_id
         await clear_topic_state(
             user.id,
             thread_id,
             PTBTelegramClient(context.bot),
             context.user_data,
-            window_id=window_id,
-            window_dead=False,
+            **cleanup_kwargs,
         )
-        thread_router.unbind_thread(user.id, thread_id)
+        if isinstance(chat_id, int):
+            thread_router.unbind_thread(user.id, thread_id, chat_id=chat_id)
+        else:
+            thread_router.unbind_thread(user.id, thread_id)
         logger.info(
             "Topic closed: window %s unbound (kept alive for rebinding, user=%d, thread=%d)",
             display,

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -12,7 +12,8 @@ Core responsibilities:
 from __future__ import annotations
 
 import asyncio
-import contextlib
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 import time
 from pathlib import Path
 
@@ -31,8 +32,8 @@ from ...session_monitor import NewWindowEvent
 from ...telegram_client import TelegramClient
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
-from ..messaging_pipeline.message_sender import is_thread_gone
 from ..status.topic_emoji import strip_emoji_prefix
+from .topic_probe import probe_topic_exists
 
 logger = structlog.get_logger()
 
@@ -46,6 +47,39 @@ _TOPIC_CREATE_RETRY_BUFFER_SECONDS = 1
 # longer outages are caught by the existing flood-control backoff.
 _TOPIC_CREATE_TRANSIENT_RETRIES = 1
 _TOPIC_CREATE_TRANSIENT_BACKOFF_S = 1.0
+
+
+# Serializes every auto-create/rebind attempt for one window. Session-monitor,
+# startup adoption, and /sync can otherwise create duplicate topics concurrently.
+@dataclass(slots=True)
+class _WindowTopicLock:
+    lock: asyncio.Lock
+    users: int = 0
+
+
+_window_topic_locks: dict[str, _WindowTopicLock] = {}
+
+
+@asynccontextmanager
+async def _window_topic_lock(window_id: str):
+    state = _window_topic_locks.setdefault(
+        window_id, _WindowTopicLock(lock=asyncio.Lock())
+    )
+    state.users += 1
+    try:
+        await state.lock.acquire()
+    except BaseException:
+        state.users -= 1
+        if state.users == 0 and _window_topic_locks.get(window_id) is state:
+            _window_topic_locks.pop(window_id, None)
+        raise
+    try:
+        yield
+    finally:
+        state.lock.release()
+        state.users -= 1
+        if state.users == 0 and _window_topic_locks.get(window_id) is state:
+            _window_topic_locks.pop(window_id, None)
 
 
 async def _create_forum_topic_with_retry(
@@ -207,30 +241,75 @@ def collect_target_chats(window_id: str) -> set[int]:
     return seen_chats
 
 
-def _bind_topic_to_user(
-    thread_id: int, window_id: str, chat_id: int, topic_name: str
-) -> None:
-    """Bind a newly created topic to a user in the given chat."""
-    for user_id, tid, _ in thread_router.iter_thread_bindings():
-        if thread_router.resolve_chat_id(user_id, tid) == chat_id:
-            thread_router.bind_thread(
-                user_id, thread_id, window_id, window_name=topic_name
-            )
-            thread_router.set_group_chat_id(user_id, thread_id, chat_id)
-            return
+def _chat_window_is_free(user_id: int, chat_id: int, window_id: str) -> bool:
+    bindings = getattr(thread_router, "chat_thread_bindings", None)
+    if isinstance(bindings, dict):
+        return (user_id, chat_id, window_id) not in {
+            (uid, bound_chat, bound_window)
+            for (uid, bound_chat, _thread), bound_window in bindings.items()
+        }
+    return True
 
-    if config.allowed_users:
-        first_user_id = next(iter(config.allowed_users))
-        thread_router.bind_thread(
-            first_user_id, thread_id, window_id, window_name=topic_name
+
+def _find_topic_owner(
+    chat_id: int, window_id: str, preferred_user_id: int | None = None
+) -> int | None:
+    """Find a user who can bind this window without evicting another topic."""
+    bindings = list(thread_router.iter_thread_bindings())
+    if preferred_user_id is not None:
+        return (
+            preferred_user_id
+            if _chat_window_is_free(preferred_user_id, chat_id, window_id)
+            else None
         )
-        thread_router.set_group_chat_id(first_user_id, thread_id, chat_id)
+
+    users_in_chat = {
+        user_id
+        for user_id, thread_id, _ in bindings
+        if thread_router.resolve_chat_id(user_id, thread_id) == chat_id
+    }
+    candidates = users_in_chat or set(config.allowed_users)
+    return next(
+        (
+            user_id
+            for user_id in sorted(candidates)
+            if _chat_window_is_free(user_id, chat_id, window_id)
+        ),
+        None,
+    )
+
+
+def _bind_topic_to_user(
+    user_id: int, thread_id: int, window_id: str, chat_id: int, topic_name: str
+) -> None:
+    """Bind a newly created topic to its preselected user."""
+    thread_router.bind_thread(
+        user_id,
+        thread_id,
+        window_id,
+        window_name=topic_name,
+        chat_id=chat_id,
+    )
+    thread_router.set_group_chat_id(user_id, thread_id, chat_id)
 
 
 async def create_topic_in_chat(
-    client: TelegramClient, chat_id: int, window_id: str, topic_name: str
-) -> None:
-    """Create a forum topic in one chat with backoff handling."""
+    client: TelegramClient,
+    chat_id: int,
+    window_id: str,
+    topic_name: str,
+    *,
+    user_id: int | None = None,
+) -> bool:
+    """Create and bind one forum topic, returning whether it succeeded."""
+    owner_id = _find_topic_owner(chat_id, window_id, user_id)
+    if owner_id is None:
+        logger.warning(
+            "Skipping topic creation for window %s in chat %d: no bindable user",
+            window_id,
+            chat_id,
+        )
+        return False
     retry_until = _topic_create_retry_until.get(chat_id, 0.0)
     now = time.monotonic()
     if now < retry_until:
@@ -242,7 +321,7 @@ async def create_topic_in_chat(
             window_id,
             wait_seconds,
         )
-        return
+        return False
 
     try:
         topic = await _create_forum_topic_with_retry(client, chat_id, topic_name)
@@ -254,7 +333,10 @@ async def create_topic_in_chat(
             chat_id,
             window_id,
         )
-        _bind_topic_to_user(topic.message_thread_id, window_id, chat_id, topic_name)
+        _bind_topic_to_user(
+            owner_id, topic.message_thread_id, window_id, chat_id, topic_name
+        )
+        return True
     except RetryAfter as e:
         retry_after_seconds = (
             e.retry_after
@@ -271,32 +353,14 @@ async def create_topic_in_chat(
             chat_id,
             retry_after_seconds,
         )
+        return False
     except TelegramError:
         logger.exception(
             "Failed to create topic for window %s in chat %d",
             window_id,
             chat_id,
         )
-
-
-async def _topic_exists(
-    client: TelegramClient, chat_id: int, thread_id: int
-) -> bool | None:
-    """Probe a Telegram topic. True=exists, False=gone, None=unknown."""
-    try:
-        msg = await client.send_message(
-            chat_id,
-            ".",
-            message_thread_id=thread_id,
-            disable_notification=True,
-        )
-    except TelegramError as exc:
-        if is_thread_gone(exc):
-            return False
-        return None
-    with contextlib.suppress(TelegramError):
-        await client.delete_message(chat_id, msg.message_id)
-    return True
+        return False
 
 
 async def _rebind_existing_topic_by_name(
@@ -329,7 +393,7 @@ async def _rebind_existing_topic_by_name(
         return False
 
     user_id, thread_id, old_window_id, chat_id = matches[0]
-    exists = await _topic_exists(client, chat_id, thread_id)
+    exists = await probe_topic_exists(client, chat_id, thread_id)
     if exists is False:
         thread_router.unbind_thread(user_id, thread_id)
         logger.info(
@@ -347,7 +411,11 @@ async def _rebind_existing_topic_by_name(
         return False
 
     thread_router.bind_thread(
-        user_id, thread_id, event.window_id, window_name=topic_name
+        user_id,
+        thread_id,
+        event.window_id,
+        window_name=topic_name,
+        chat_id=chat_id,
     )
     thread_router.set_group_chat_id(user_id, thread_id, chat_id)
     logger.info(
@@ -360,17 +428,36 @@ async def _rebind_existing_topic_by_name(
     return True
 
 
-async def handle_new_window(event: NewWindowEvent, client: TelegramClient) -> None:
-    """Create or bind a Telegram forum topic for a newly detected tmux window.
+async def handle_new_window(
+    event: NewWindowEvent,
+    client: TelegramClient,
+    *,
+    target_user_id: int | None = None,
+    target_chat_id: int | None = None,
+) -> bool:
+    """Ensure a new window has a topic, returning whether it is bound."""
+    async with _window_topic_lock(event.window_id):
+        return await _handle_new_window_locked(
+            event,
+            client,
+            target_user_id=target_user_id,
+            target_chat_id=target_chat_id,
+        )
 
-    Skips if the window is already bound. Reuses one stale same-name topic when
-    it still exists; otherwise creates one topic per unique group chat.
-    """
-    if _is_window_already_bound(event.window_id):
+
+async def _handle_new_window_locked(
+    event: NewWindowEvent,
+    client: TelegramClient,
+    *,
+    target_user_id: int | None = None,
+    target_chat_id: int | None = None,
+) -> bool:
+    """Create or bind a topic while holding the per-window creation lock."""
+    if target_user_id is None and _is_window_already_bound(event.window_id):
         logger.debug(
             "New window %s already bound, skipping topic creation", event.window_id
         )
-        return
+        return True
 
     if _is_pending_user_creation(event.window_id):
         logger.debug(
@@ -378,20 +465,35 @@ async def handle_new_window(event: NewWindowEvent, client: TelegramClient) -> No
             "skipping auto topic creation",
             event.window_id,
         )
-        return
+        return False
 
     await _auto_detect_provider(event.window_id)
 
     topic_name = event.window_name or Path(event.cwd).name or event.window_id
-    if await _rebind_existing_topic_by_name(event, client, topic_name):
-        return
+    if target_user_id is None and await _rebind_existing_topic_by_name(
+        event, client, topic_name
+    ):
+        return True
 
-    seen_chats = collect_target_chats(event.window_id)
+    seen_chats = (
+        {target_chat_id}
+        if target_chat_id is not None
+        else collect_target_chats(event.window_id)
+    )
     if not seen_chats:
-        return
+        return False
 
-    for chat_id in seen_chats:
-        await create_topic_in_chat(client, chat_id, event.window_id, topic_name)
+    results = [
+        await create_topic_in_chat(
+            client,
+            chat_id,
+            event.window_id,
+            topic_name,
+            user_id=target_user_id,
+        )
+        for chat_id in seen_chats
+    ]
+    return any(results)
 
 
 async def adopt_unbound_windows(client: TelegramClient) -> None:

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -286,7 +286,7 @@ async def _topic_exists(
     try:
         msg = await client.send_message(
             chat_id,
-            "​",
+            ".",
             message_thread_id=thread_id,
             disable_notification=True,
         )

--- a/src/ccgram/handlers/topics/topic_probe.py
+++ b/src/ccgram/handlers/topics/topic_probe.py
@@ -1,0 +1,40 @@
+"""Non-destructive forum-topic existence probe shared by repair flows."""
+
+import structlog
+from telegram.error import TelegramError
+
+from ...telegram_client import TelegramClient
+from ..messaging_pipeline.message_sender import is_thread_gone
+
+logger = structlog.get_logger()
+
+_TOPIC_PROBE_TEXT = "."
+
+
+async def probe_topic_exists(
+    client: TelegramClient, chat_id: int, thread_id: int
+) -> bool | None:
+    """Return True when a topic exists, False when deleted, and None on uncertainty."""
+    try:
+        message = await client.send_message(
+            chat_id,
+            _TOPIC_PROBE_TEXT,
+            message_thread_id=thread_id,
+            disable_notification=True,
+        )
+    except TelegramError as exc:
+        if is_thread_gone(exc):
+            return False
+        return None
+
+    try:
+        await client.delete_message(chat_id, message.message_id)
+    except TelegramError as exc:
+        logger.warning(
+            "Failed to delete topic probe message",
+            chat_id=chat_id,
+            thread_id=thread_id,
+            message_id=message.message_id,
+            error=str(exc),
+        )
+    return True

--- a/src/ccgram/handlers/topics/window_callbacks.py
+++ b/src/ccgram/handlers/topics/window_callbacks.py
@@ -21,7 +21,7 @@ from ...telegram_client import PTBTelegramClient, TelegramClient
 from ...session import session_manager
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
-from ...multiplexer.window_ops import send_to_window
+from ..telegram_origin import send_telegram_to_window
 from ..callback_data import CB_WIN_BIND, CB_WIN_CANCEL, CB_WIN_NEW
 from ..callback_helpers import get_thread_id
 from .directory_browser import (
@@ -136,6 +136,7 @@ async def _forward_pending_text(
     provider_name: str,
     *,
     is_existing_window: bool = False,
+    chat_id: int | None = None,
 ) -> None:
     """Forward pending text to a newly bound window, routing shell via LLM.
 
@@ -153,12 +154,16 @@ async def _forward_pending_text(
         # Lazy: shell ↔ topics cycle.
         from ..shell.shell_commands import handle_shell_message
 
-        await handle_shell_message(client, user_id, thread_id, window_id, text)
+        await handle_shell_message(
+            client, user_id, thread_id, window_id, text, chat_id=chat_id
+        )
     else:
         # For non-shell providers or existing shell windows, send raw text.
         # Existing shell windows skip handle_shell_message to avoid
         # _ensure_prompt_marker racing with the offer keyboard just shown.
-        send_ok, send_msg = await send_to_window(window_id, text)
+        send_ok, send_msg = await send_telegram_to_window(
+            user_id, window_id, thread_id, text, chat_id
+        )
         if not send_ok:
             logger.warning(
                 "Failed to forward pending text to window %s (user %s): %s",
@@ -215,7 +220,17 @@ async def _handle_bind(
 
     display = w.window_name
     clear_window_picker_state(context.user_data)
-    thread_router.bind_thread(user_id, thread_id, selected_wid, window_name=display)
+    thread_router.bind_thread(
+        user_id,
+        thread_id,
+        selected_wid,
+        window_name=display,
+        chat_id=(
+            update.callback_query.message.chat.id
+            if update.callback_query and update.callback_query.message
+            else None
+        ),
+    )
     _store_group_chat_id(user_id, thread_id, update, query)
 
     client: TelegramClient = PTBTelegramClient(context.bot)
@@ -258,6 +273,11 @@ async def _handle_bind(
             pending_text,
             detected,
             is_existing_window=True,
+            chat_id=(
+                update.callback_query.message.chat.id
+                if update.callback_query and update.callback_query.message
+                else None
+            ),
         )
     await query.answer("Bound")
 

--- a/src/ccgram/handlers/topics/window_launch_service.py
+++ b/src/ccgram/handlers/topics/window_launch_service.py
@@ -24,7 +24,7 @@ from ...session import session_manager
 from ...session_map import session_map_sync
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
-from ...multiplexer.window_ops import send_to_window
+from ..telegram_origin import send_telegram_to_window
 from ...user_preferences import user_preferences
 from ...window_state_store import CCGRAM_CREATED_WINDOW_ORIGIN
 from ..messaging_pipeline.message_sender import safe_edit, safe_send
@@ -63,6 +63,7 @@ class WindowLaunchRequest:
     cwd: str
     mode: str
     pending_text: str | None
+    chat_id: int | None = None
     # Worktree metadata is NOT carried in this request. It flows through
     # context.user_data via PENDING_WORKTREE_PATH / PENDING_WORKTREE_BRANCH /
     # PENDING_WORKTREE_REPO keys, read directly by _persist_worktree_state and
@@ -301,6 +302,8 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
                 thread_router.unbind_thread(user_id, pending_thread_id)
         raise
 
+    query_message = query.message
+    chat = query_message.chat if query_message else None
     provider_caps = provider_registry.get(provider_name).capabilities
     if provider_caps.chat_first_command_path:
         # Lazy: shell ↔ topics cycle via window_callbacks adoption flow.
@@ -318,10 +321,12 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
 
     if pending_thread_id is not None:
         thread_router.bind_thread(
-            user_id, pending_thread_id, created_wid, window_name=created_wname
+            user_id,
+            pending_thread_id,
+            created_wid,
+            window_name=created_wname,
+            chat_id=chat.id if chat and chat.type in ("group", "supergroup") else None,
         )
-        query_message = query.message
-        chat = query_message.chat if query_message else None
         if chat and chat.type in ("group", "supergroup"):
             thread_router.set_group_chat_id(user_id, pending_thread_id, chat.id)
 
@@ -407,9 +412,16 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
                 pending_thread_id,
                 created_wid,
                 pending_text,
+                chat_id=chat.id if chat else None,
             )
         else:
-            send_ok, send_msg = await send_to_window(created_wid, pending_text)
+            send_ok, send_msg = await send_telegram_to_window(
+                user_id,
+                created_wid,
+                pending_thread_id,
+                pending_text,
+                chat.id if chat else None,
+            )
             if not send_ok:
                 logger.warning(
                     "Failed to forward pending text to window %s (user %s): %s",

--- a/src/ccgram/handlers/voice/voice_callbacks.py
+++ b/src/ccgram/handlers/voice/voice_callbacks.py
@@ -16,7 +16,7 @@ from telegram.error import TelegramError
 from ...providers import get_provider_for_window
 from ...telegram_client import PTBTelegramClient
 from ...window_query import get_window_provider
-from ...multiplexer.window_ops import send_to_window
+from ..telegram_origin import send_telegram_to_window
 from ...thread_router import thread_router
 from ..callback_data import CB_VOICE
 from ..callback_helpers import get_thread_id
@@ -86,7 +86,7 @@ async def _handle_send(
         return
 
     thread_id = get_thread_id(update)
-    window_id = thread_router.resolve_window_for_thread(user_id, thread_id)
+    window_id = thread_router.resolve_window_for_thread(user_id, thread_id, msg.chat.id)
     if not window_id:
         pending_store[(msg.chat.id, message_id)] = pending_text
         await query.answer("⚠️ No session bound.", show_alert=True)
@@ -117,7 +117,9 @@ async def _handle_send(
         await _ack_delivered(client, msg, query, message_id)
         return
 
-    success, err = await send_to_window(window_id, pending_text)
+    success, err = await send_telegram_to_window(
+        user_id, window_id, thread_id, pending_text, msg.chat.id
+    )
 
     if success:
         await _ack_delivered(client, msg, query, message_id)

--- a/src/ccgram/handlers/voice/voice_handler.py
+++ b/src/ccgram/handlers/voice/voice_handler.py
@@ -125,7 +125,9 @@ async def handle_voice_message(
         return
 
     thread_id = get_thread_id(update)
-    window_id = thread_router.resolve_window_for_thread(user.id, thread_id)
+    window_id = thread_router.resolve_window_for_thread(
+        user.id, thread_id, message.chat.id
+    )
     if not window_id:
         await safe_reply(
             message,

--- a/src/ccgram/main.py
+++ b/src/ccgram/main.py
@@ -306,7 +306,7 @@ def run_bot() -> None:
     dev = "+dev" if "+unknown" in __version__ or ".dev" in __version__ else ""
     logger.info("Starting ccgram %s%s", __version__, dev)
     # Lazy: main runs `ccgram` startup; defer imports until the relevant subcommand executes
-    from .bot import create_bot
+    from .bot import create_bot, polling_conflict_requires_restart
 
     # Create the loop here so signal handlers can be registered on it before
     # run_polling() blocks. PTB's __run reuses the loop set via set_event_loop.
@@ -323,6 +323,9 @@ def run_bot() -> None:
     if _restart_requested:
         logger.info("Restarting bot via os.execv(%s)", sys.argv)
         os.execv(sys.argv[0], sys.argv)
+
+    if polling_conflict_requires_restart():
+        raise SystemExit(1)
 
     _reraise_shutdown_signal()
 

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -315,8 +315,7 @@ class SessionManager:
         """
         # Collect window_ids that are "in use" (bound or have window_states)
         in_use = set(self.window_states.keys())
-        for bindings in thread_router.thread_bindings.values():
-            in_use.update(bindings.values())
+        in_use.update(thread_router.all_bound_window_ids())
 
         # Prune window_display_names for dead windows not in use and not live
         stale_display = [
@@ -326,10 +325,10 @@ class SessionManager:
         ]
 
         # Collect all bound thread keys "user_id:thread_id"
-        bound_keys: set[str] = set()
-        for user_id, bindings in thread_router.thread_bindings.items():
-            for thread_id in bindings:
-                bound_keys.add(f"{user_id}:{thread_id}")
+        bound_keys: set[str] = {
+            f"{user_id}:{thread_id}"
+            for user_id, thread_id, _ in thread_router.iter_thread_bindings()
+        }
 
         # Prune group_chat_ids for unbound threads (unless skipped)
         stale_chat = (
@@ -411,12 +410,11 @@ class SessionManager:
         bound_window_ids: set[str] = set()
         total_bindings = 0
         live_binding_count = 0
-        for _uid, bindings in thread_router.thread_bindings.items():
-            for _tid, wid in bindings.items():
-                total_bindings += 1
-                bound_window_ids.add(wid)
-                if wid in live_window_ids:
-                    live_binding_count += 1
+        for _uid, _tid, wid in thread_router.iter_thread_bindings():
+            total_bindings += 1
+            bound_window_ids.add(wid)
+            if wid in live_window_ids:
+                live_binding_count += 1
 
         session_map_wids = self._get_session_map_window_ids()
 
@@ -425,8 +423,7 @@ class SessionManager:
         # instead of classifying the old tab/pane locator as a ghost.
         legacy_bindings = {
             wid
-            for bindings in thread_router.thread_bindings.values()
-            for wid in bindings.values()
+            for _uid, _tid, wid in thread_router.iter_thread_bindings()
             if window_store.is_legacy_herdr(wid)
         }
         for wid in sorted(legacy_bindings):
@@ -439,17 +436,16 @@ class SessionManager:
             )
 
         # 2. Ghost bindings (thread → dead window) — fixable (close topic)
-        for uid, bindings in thread_router.thread_bindings.items():
-            for tid, wid in bindings.items():
-                if wid not in live_window_ids and wid not in legacy_bindings:
-                    display = thread_router.get_display_name(wid)
-                    issues.append(
-                        AuditIssue(
-                            category="ghost_binding",
-                            detail=f"user:{uid} thread:{tid} window:{wid} ({display})",
-                            fixable=True,
-                        )
+        for uid, tid, wid in thread_router.iter_thread_bindings():
+            if wid not in live_window_ids and wid not in legacy_bindings:
+                display = thread_router.get_display_name(wid)
+                issues.append(
+                    AuditIssue(
+                        category="ghost_binding",
+                        detail=f"user:{uid} thread:{tid} window:{wid} ({display})",
+                        fixable=True,
                     )
+                )
 
         # 3. Orphaned display names
         in_use = set(self.window_states.keys()) | bound_window_ids
@@ -465,10 +461,10 @@ class SessionManager:
                 )
 
         # 3. Orphaned group_chat_ids
-        bound_keys: set[str] = set()
-        for user_id, bindings in thread_router.thread_bindings.items():
-            for thread_id in bindings:
-                bound_keys.add(f"{user_id}:{thread_id}")
+        bound_keys: set[str] = {
+            f"{user_id}:{thread_id}"
+            for user_id, thread_id, _ in thread_router.iter_thread_bindings()
+        }
         for key in thread_router.group_chat_ids:
             if key not in bound_keys:
                 issues.append(
@@ -545,9 +541,7 @@ class SessionManager:
         Returns True if any changes were made.
         """
         session_map_wids = self._get_session_map_window_ids()
-        bound_window_ids: set[str] = set()
-        for bindings in thread_router.thread_bindings.values():
-            bound_window_ids.update(bindings.values())
+        bound_window_ids = thread_router.all_bound_window_ids()
 
         stale = [
             wid

--- a/src/ccgram/session_query.py
+++ b/src/ccgram/session_query.py
@@ -32,7 +32,9 @@ async def resolve_session_for_window(window_id: str) -> "ClaudeSession | None":
     return await session_resolver.resolve_session_for_window(window_id)
 
 
-def find_users_for_session(session_id: str) -> list[tuple[int, str, int]]:
+def find_users_for_session(
+    session_id: str,
+) -> list[tuple[int, str, int, int | None]]:
     """Return list of (user_id, window_id, thread_id) for all users bound to a session."""
     # Lazy: session_resolver constructed per-call so tests can stub it
     from .session_resolver import session_resolver

--- a/src/ccgram/session_resolver.py
+++ b/src/ccgram/session_resolver.py
@@ -206,12 +206,17 @@ class SessionResolver:
     def find_users_for_session(
         self,
         session_id: str,
-    ) -> list[tuple[int, str, int]]:
+    ) -> list[tuple[int, str, int, int | None]]:
         """Find all users whose thread-bound window maps to the given session_id."""
-        result: list[tuple[int, str, int]] = []
-        for user_id, thread_id, window_id in thread_router.iter_thread_bindings():
+        result: list[tuple[int, str, int, int | None]] = []
+        for (
+            user_id,
+            chat_id,
+            thread_id,
+            window_id,
+        ) in thread_router.iter_thread_bindings_with_chat():
             if identity_state.get_session_id(window_id) == session_id:
-                result.append((user_id, window_id, thread_id))
+                result.append((user_id, window_id, thread_id, chat_id))
         return result
 
     async def get_recent_messages(

--- a/src/ccgram/telegram_request.py
+++ b/src/ccgram/telegram_request.py
@@ -35,8 +35,7 @@ class ResilientPollingHTTPXRequest(HTTPXRequest):
     ) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
         self._on_success = on_success
-        # 0.0 means "no warn yet" — first reset will warn.
-        self._last_reset_warn_ts: float = 0.0
+        self._last_reset_warn_ts: float | None = None
 
     async def _reset_client(self, *, reason: str) -> None:
         old_client = self._client
@@ -54,14 +53,25 @@ class ResilientPollingHTTPXRequest(HTTPXRequest):
 
     def _should_warn_for_reset(self, now: float) -> bool:
         """Throttle: warn once per interval, then debug. Reset by success."""
-        if now - self._last_reset_warn_ts >= _RESET_WARN_INTERVAL_S:
+        if (
+            self._last_reset_warn_ts is None
+            or now - self._last_reset_warn_ts >= _RESET_WARN_INTERVAL_S
+        ):
             self._last_reset_warn_ts = now
             return True
         return False
 
+    async def post(self, *args, **kwargs):  # type: ignore[override]
+        result = await super().post(*args, **kwargs)
+        # BaseRequest.post validates the Bot API response before returning.
+        self._last_reset_warn_ts = None
+        if self._on_success is not None:
+            self._on_success()
+        return result
+
     async def do_request(self, *args, **kwargs):  # type: ignore[override]
         try:
-            result = await super().do_request(*args, **kwargs)
+            return await super().do_request(*args, **kwargs)
         except (TimedOut, NetworkError) as exc:
             await self._reset_client(reason=exc.__class__.__name__)
             log = (
@@ -75,9 +85,3 @@ class ResilientPollingHTTPXRequest(HTTPXRequest):
                 exc,
             )
             raise
-        else:
-            # Successful request — next reset gets to warn again.
-            self._last_reset_warn_ts = 0.0
-            if self._on_success is not None:
-                self._on_success()
-            return result

--- a/src/ccgram/telegram_request.py
+++ b/src/ccgram/telegram_request.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+from collections.abc import Callable
 
 import httpx
 import structlog
@@ -29,8 +30,11 @@ class ResilientPollingHTTPXRequest(HTTPXRequest):
     sustained outages.
     """
 
-    def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    def __init__(
+        self, *args, on_success: Callable[[], None] | None = None, **kwargs
+    ) -> None:  # type: ignore[no-untyped-def]
         super().__init__(*args, **kwargs)
+        self._on_success = on_success
         # 0.0 means "no warn yet" — first reset will warn.
         self._last_reset_warn_ts: float = 0.0
 
@@ -74,4 +78,6 @@ class ResilientPollingHTTPXRequest(HTTPXRequest):
         else:
             # Successful request — next reset gets to warn again.
             self._last_reset_warn_ts = 0.0
+            if self._on_success is not None:
+                self._on_success()
             return result

--- a/src/ccgram/thread_router.py
+++ b/src/ccgram/thread_router.py
@@ -23,11 +23,26 @@ Key data:
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import structlog
 from collections.abc import Callable, Iterator
 from typing import Any, cast
 
 logger = structlog.get_logger()
+
+_active_chat_id: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+    "active_thread_chat_id", default=None
+)
+
+
+@contextlib.contextmanager
+def chat_scope(chat_id: int | None):
+    token = _active_chat_id.set(chat_id)
+    try:
+        yield
+    finally:
+        _active_chat_id.reset(token)
 
 
 class ThreadRouter:
@@ -52,12 +67,15 @@ class ThreadRouter:
         has_window_state: Callable[[str], bool],
     ) -> None:
         self.thread_bindings: dict[int, dict[int, str]] = {}
-        # "user_id:thread_id" -> chat_id (supports multiple groups per user)
+        # Chat-scoped bindings preserve Telegram's chat-local thread identity.
+        self.chat_thread_bindings: dict[tuple[int, int, int], str] = {}
+        # "user_id:thread_id" -> chat_id for legacy/direct-message bindings.
         self.group_chat_ids: dict[str, int] = {}
         # window_id -> display name (window_name)
         self.window_display_names: dict[str, str] = {}
         # Reverse index: (user_id, window_id) -> thread_id for O(1) lookups
         self._window_to_thread: dict[tuple[int, str], int] = {}
+        self._chat_window_to_thread: dict[tuple[int, int, str], int] = {}
         self._schedule_save: Callable[[], None] = schedule_save
         self._has_window_state: Callable[[str], bool] = has_window_state
 
@@ -65,8 +83,10 @@ class ThreadRouter:
         """Clear all state.  Used for test isolation."""
         self.thread_bindings.clear()
         self.group_chat_ids.clear()
+        self.chat_thread_bindings.clear()
         self.window_display_names.clear()
         self._window_to_thread.clear()
+        self._chat_window_to_thread.clear()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -75,9 +95,12 @@ class ThreadRouter:
     def _rebuild_reverse_index(self) -> None:
         """Rebuild _window_to_thread from thread_bindings."""
         self._window_to_thread = {}
+        self._chat_window_to_thread = {}
         for uid, bindings in self.thread_bindings.items():
             for tid, wid in bindings.items():
                 self._window_to_thread[(uid, wid)] = tid
+        for (uid, chat_id, _tid), wid in self.chat_thread_bindings.items():
+            self._chat_window_to_thread[(uid, chat_id, wid)] = _tid
 
     def _dedup_thread_bindings(self) -> None:
         """Enforce 1 window = 1 thread.  Keep highest thread_id per window."""
@@ -111,6 +134,10 @@ class ThreadRouter:
                 for uid, bindings in self.thread_bindings.items()
             },
             "group_chat_ids": self.group_chat_ids,
+            "chat_thread_bindings": {
+                f"{uid}:{chat_id}:{tid}": wid
+                for (uid, chat_id, tid), wid in self.chat_thread_bindings.items()
+            },
             "window_display_names": self.window_display_names,
         }
 
@@ -125,6 +152,10 @@ class ThreadRouter:
             for uid, bindings in data.get("thread_bindings", {}).items()
         }
         self.group_chat_ids = data.get("group_chat_ids", {})
+        self.chat_thread_bindings = {}
+        for key, wid in data.get("chat_thread_bindings", {}).items():
+            uid, chat_id, tid = (int(part) for part in key.split(":", 2))
+            self.chat_thread_bindings[(uid, chat_id, tid)] = wid
         self.window_display_names = data.get("window_display_names", {})
         self._dedup_thread_bindings()
         self._rebuild_reverse_index()
@@ -134,65 +165,97 @@ class ThreadRouter:
     # ------------------------------------------------------------------
 
     def bind_thread(
-        self, user_id: int, thread_id: int, window_id: str, window_name: str = ""
+        self,
+        user_id: int,
+        thread_id: int,
+        window_id: str,
+        window_name: str = "",
+        chat_id: int | None = None,
     ) -> None:
-        """Bind a Telegram topic thread to a tmux window.
-
-        Enforces 1 topic = 1 window: if another thread is already bound to
-        the same window_id, that stale binding is removed first.
-        """
-        if user_id not in self.thread_bindings:
-            self.thread_bindings[user_id] = {}
-
-        # Enforce 1:1 — unbind any OTHER thread pointing to this window
-        stale = [
-            tid
-            for tid, wid in self.thread_bindings[user_id].items()
-            if wid == window_id and tid != thread_id
-        ]
-        for tid in stale:
-            del self.thread_bindings[user_id][tid]
-            logger.info(
-                "Evicted stale binding: thread %d -> window_id %s "
-                "(replaced by thread %d)",
-                tid,
-                window_id,
-                thread_id,
+        """Bind a topic, using chat-scoped identity when ``chat_id`` is known."""
+        if chat_id is not None:
+            key = (user_id, chat_id, thread_id)
+            old_thread = self._chat_window_to_thread.pop(
+                (user_id, chat_id, window_id), None
             )
-
-        # Clean up stale reverse index if this thread was previously bound elsewhere
-        old_window = self.thread_bindings[user_id].get(thread_id)
-        if old_window is not None and old_window != window_id:
-            self._window_to_thread.pop((user_id, old_window), None)
-
-        self.thread_bindings[user_id][thread_id] = window_id
-        self._window_to_thread[(user_id, window_id)] = thread_id
+            if old_thread is not None and old_thread != thread_id:
+                self.chat_thread_bindings.pop((user_id, chat_id, old_thread), None)
+            stale = [
+                candidate
+                for candidate, wid in self.chat_thread_bindings.items()
+                if candidate[0] == user_id
+                and candidate[1] == chat_id
+                and wid == window_id
+                and candidate != key
+            ]
+            for candidate in stale:
+                self.chat_thread_bindings.pop(candidate, None)
+                self._chat_window_to_thread.pop(
+                    (user_id, candidate[1], window_id), None
+                )
+            self.chat_thread_bindings[key] = window_id
+            self._chat_window_to_thread[(user_id, chat_id, window_id)] = thread_id
+        else:
+            if user_id not in self.thread_bindings:
+                self.thread_bindings[user_id] = {}
+            stale = [
+                tid
+                for tid, wid in self.thread_bindings[user_id].items()
+                if wid == window_id and tid != thread_id
+            ]
+            for tid in stale:
+                del self.thread_bindings[user_id][tid]
+            old_window = self.thread_bindings[user_id].get(thread_id)
+            if old_window is not None and old_window != window_id:
+                self._window_to_thread.pop((user_id, old_window), None)
+            self.thread_bindings[user_id][thread_id] = window_id
+            self._window_to_thread[(user_id, window_id)] = thread_id
         if window_name:
             self.window_display_names[window_id] = window_name
         self._schedule_save()
-        display = window_name or self.get_display_name(window_id)
-        logger.info(
-            "Bound thread %d -> window_id %s (%s) for user %d",
-            thread_id,
-            window_id,
-            display,
-            user_id,
-        )
 
-    def unbind_thread(self, user_id: int, thread_id: int) -> str | None:
+    def unbind_thread(
+        self, user_id: int, thread_id: int, chat_id: int | None = None
+    ) -> str | None:
         """Remove a thread binding.  Returns the previously bound window_id.
 
         Cleans up the reverse index and group_chat_id.  Does NOT touch
         display names — the caller (SessionManager) handles display-name
         lifecycle because it requires window_states knowledge.
         """
-        bindings = self.thread_bindings.get(user_id)
-        if not bindings or thread_id not in bindings:
-            return None
-        window_id = bindings.pop(thread_id)
-        self._window_to_thread.pop((user_id, window_id), None)
-        if not bindings:
-            del self.thread_bindings[user_id]
+        if chat_id is not None:
+            key = (user_id, chat_id, thread_id)
+            window_id = self.chat_thread_bindings.pop(key, None)
+            if window_id is None:
+                return None
+            self._chat_window_to_thread.pop((user_id, chat_id, window_id), None)
+            self.group_chat_ids.pop(f"{user_id}:{thread_id}:{chat_id}", None)
+        else:
+            bindings = self.thread_bindings.get(user_id)
+            if not bindings or thread_id not in bindings:
+                candidates = [
+                    (key, wid)
+                    for key, wid in self.chat_thread_bindings.items()
+                    if key[0] == user_id and key[2] == thread_id
+                ]
+                if len(candidates) != 1:
+                    return None
+                key, window_id = candidates[0]
+                self.chat_thread_bindings.pop(key, None)
+                self._chat_window_to_thread.pop((user_id, key[1], window_id), None)
+                self.group_chat_ids.pop(f"{user_id}:{thread_id}:{key[1]}", None)
+            else:
+                window_id = bindings.pop(thread_id)
+                self._window_to_thread.pop((user_id, window_id), None)
+                if not bindings:
+                    del self.thread_bindings[user_id]
+        if chat_id is None and user_id in self.thread_bindings:
+            bindings = self.thread_bindings[user_id]
+            if thread_id not in bindings:
+                # Chat-scoped binding was removed above.
+                bindings = None
+            if bindings is not None and not bindings:
+                del self.thread_bindings[user_id]
         logger.info(
             "Unbound thread %d (was %s) for user %d",
             thread_id,
@@ -201,14 +264,16 @@ class ThreadRouter:
         )
 
         # Clean up group_chat_id for the unbound thread
-        chat_key = f"{user_id}:{thread_id}"
-        self.group_chat_ids.pop(chat_key, None)
+        self.group_chat_ids.pop(f"{user_id}:{thread_id}", None)
 
         # Clean up orphaned display name if nothing references this window
-        still_bound = any(
-            wid == window_id
-            for ub in self.thread_bindings.values()
-            for wid in ub.values()
+        still_bound = (
+            any(
+                wid == window_id
+                for ub in self.thread_bindings.values()
+                for wid in ub.values()
+            )
+            or window_id in self.chat_thread_bindings.values()
         )
         if not still_bound and not self._has_window_state(window_id):
             self.window_display_names.pop(window_id, None)
@@ -216,25 +281,52 @@ class ThreadRouter:
         self._schedule_save()
         return window_id
 
-    def get_window_for_thread(self, user_id: int, thread_id: int) -> str | None:
-        """Look up the window_id bound to a thread."""
-        bindings = self.thread_bindings.get(user_id)
-        if not bindings:
-            return None
-        return bindings.get(thread_id)
+    def get_window_for_thread(
+        self, user_id: int, thread_id: int, chat_id: int | None = None
+    ) -> str | None:
+        """Look up a window, disambiguating chat-scoped Telegram threads."""
+        if chat_id is not None:
+            return self.chat_thread_bindings.get((user_id, chat_id, thread_id))
+        bindings = self.thread_bindings.get(user_id, {})
+        matches = {
+            wid
+            for (uid, _chat, tid), wid in self.chat_thread_bindings.items()
+            if uid == user_id and tid == thread_id
+        }
+        legacy = bindings.get(thread_id)
+        if legacy is not None:
+            matches.add(legacy)
+        return next(iter(matches)) if len(matches) == 1 else None
 
-    def get_thread_for_window(self, user_id: int, window_id: str) -> int | None:
-        """Reverse lookup: get thread_id for a window (O(1) via reverse index)."""
-        return self._window_to_thread.get((user_id, window_id))
+    def get_thread_for_window(
+        self, user_id: int, window_id: str, chat_id: int | None = None
+    ) -> int | None:
+        """Reverse lookup for legacy or chat-scoped bindings."""
+        if chat_id is not None:
+            return self._chat_window_to_thread.get((user_id, chat_id, window_id))
+        legacy = self._window_to_thread.get((user_id, window_id))
+        if legacy is not None:
+            return legacy
+        matches = [
+            tid
+            for (uid, _chat, wid), tid in self._chat_window_to_thread.items()
+            if uid == user_id and wid == window_id
+        ]
+        return matches[0] if len(matches) == 1 else None
 
     def get_all_thread_windows(self, user_id: int) -> dict[int, str]:
-        """Get all thread bindings for a user."""
-        return dict(self.thread_bindings.get(user_id, {}))
+        """Get all thread bindings for a user, including chat-scoped ones."""
+        result = dict(self.thread_bindings.get(user_id, {}))
+        for (uid, _chat_id, thread_id), window_id in self.chat_thread_bindings.items():
+            if uid == user_id:
+                result[thread_id] = window_id
+        return result
 
     def resolve_window_for_thread(
         self,
         user_id: int,
         thread_id: int | None,
+        chat_id: int | None = None,
     ) -> str | None:
         """Resolve the tmux window_id for a user's thread.
 
@@ -242,28 +334,72 @@ class ThreadRouter:
         """
         if thread_id is None:
             return None
-        return self.get_window_for_thread(user_id, thread_id)
+        return self.get_window_for_thread(user_id, thread_id, chat_id)
 
     def has_window(self, window_id: str) -> bool:
         """Check if any user has a binding to this window_id."""
-        return any(wid == window_id for (_, wid) in self._window_to_thread)
+        return (
+            any(wid == window_id for (_, wid) in self._window_to_thread)
+            or window_id in self.chat_thread_bindings.values()
+        )
+
+    def has_window_for_user(self, user_id: int, window_id: str) -> bool:
+        return (
+            any(
+                uid == user_id and wid == window_id
+                for (uid, _chat, _thread), wid in self.chat_thread_bindings.items()
+            )
+            or self._window_to_thread.get((user_id, window_id)) is not None
+        )
+
+    def iter_thread_bindings_with_chat(
+        self,
+    ) -> Iterator[tuple[int, int | None, int, str]]:
+        """Iterate bindings with chat identity when available."""
+        for user_id, bindings in self.thread_bindings.items():
+            for thread_id, window_id in bindings.items():
+                yield (
+                    user_id,
+                    self.group_chat_ids.get(f"{user_id}:{thread_id}"),
+                    thread_id,
+                    window_id,
+                )
+        for (
+            user_id,
+            chat_id,
+            thread_id,
+        ), window_id in self.chat_thread_bindings.items():
+            yield user_id, chat_id, thread_id, window_id
 
     def iter_thread_bindings(self) -> Iterator[tuple[int, int, str]]:
         """Iterate all thread bindings as (user_id, thread_id, window_id)."""
         for user_id, bindings in self.thread_bindings.items():
             for thread_id, window_id in bindings.items():
                 yield user_id, thread_id, window_id
+        for (
+            user_id,
+            _chat_id,
+            thread_id,
+        ), window_id in self.chat_thread_bindings.items():
+            yield user_id, thread_id, window_id
+
+    def all_bound_window_ids(self) -> set[str]:
+        return {window_id for _, _, window_id in self.iter_thread_bindings()}
 
     # ------------------------------------------------------------------
     # Group chat ID management
     # ------------------------------------------------------------------
 
     def set_group_chat_id(self, user_id: int, thread_id: int, chat_id: int) -> None:
-        """Store the group chat ID for a user's thread.
-
-        Uses composite key ``user_id:thread_id`` to support multiple
-        groups per user.
-        """
+        """Store the group chat ID and promote the binding to chat scope."""
+        bindings = self.thread_bindings.get(user_id)
+        if bindings and thread_id in bindings:
+            window_id = bindings.pop(thread_id)
+            if not bindings:
+                self.thread_bindings.pop(user_id, None)
+            self._window_to_thread.pop((user_id, window_id), None)
+            self.chat_thread_bindings[(user_id, chat_id, thread_id)] = window_id
+            self._chat_window_to_thread[(user_id, chat_id, window_id)] = thread_id
         key = f"{user_id}:{thread_id}"
         if self.group_chat_ids.get(key) != chat_id:
             self.group_chat_ids[key] = chat_id
@@ -282,15 +418,40 @@ class ThreadRouter:
         for that specific thread (user_id:thread_id).
         Falls back to user_id for direct messages or if no group_id stored.
         """
+        active_chat_id = _active_chat_id.get()
+        if (
+            active_chat_id is not None
+            and thread_id is not None
+            and (user_id, active_chat_id, thread_id) in self.chat_thread_bindings
+        ):
+            return active_chat_id
         if thread_id is not None:
             key = f"{user_id}:{thread_id}"
             group_id = self.group_chat_ids.get(key)
             if group_id is not None:
                 return group_id
+            chats = {
+                chat_id
+                for (uid, chat_id, tid) in self.chat_thread_bindings
+                if uid == user_id and tid == thread_id
+            }
+            if len(chats) == 1:
+                return next(iter(chats))
         return user_id
 
     def get_window_for_chat_thread(self, chat_id: int, thread_id: int) -> str | None:
         """Resolve window_id for a specific Telegram chat/thread pair."""
+        scoped = [
+            wid
+            for (
+                user_id,
+                bound_chat,
+                bound_thread,
+            ), wid in self.chat_thread_bindings.items()
+            if bound_chat == chat_id and bound_thread == thread_id
+        ]
+        if len(scoped) == 1:
+            return scoped[0]
         for user_id, bindings in self.thread_bindings.items():
             window_id = bindings.get(thread_id)
             if not window_id:

--- a/tests/ccgram/handlers/commands/test_forward.py
+++ b/tests/ccgram/handlers/commands/test_forward.py
@@ -84,12 +84,12 @@ class TestForwardCommandResolution:
             patch(f"{_FW}.window_store", self.mock_ws),
             patch(f"{_FW}.window_query", self.mock_wq),
             patch(
-                f"{_FW}.send_to_window",
+                f"{_FW}.send_telegram_to_window",
                 new_callable=AsyncMock,
                 return_value=(True, ""),
             ) as self.mock_send_to_window,
             patch(
-                f"{_FW}.send_followup_to_window",
+                f"{_FW}.send_telegram_followup_to_window",
                 new_callable=AsyncMock,
                 return_value=(True, ""),
             ) as self.mock_send_followup_to_window,
@@ -130,49 +130,65 @@ class TestForwardCommandResolution:
         update = _make_update(text="/clear")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/clear")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/clear", -100999
+        )
 
     async def test_builtin_with_args(self) -> None:
         update = _make_update(text="/compact focus on auth")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/compact focus on auth")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/compact focus on auth", -100999
+        )
 
     async def test_skill_name_resolved(self) -> None:
         update = _make_update(text="/committing_code")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/committing-code")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/committing-code", -100999
+        )
 
     async def test_custom_command_resolved(self) -> None:
         update = _make_update(text="/spec_work")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/spec:work")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/spec:work", -100999
+        )
 
     async def test_custom_command_with_args(self) -> None:
         update = _make_update(text="/spec_new task auth")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/spec:new task auth")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/spec:new task auth", -100999
+        )
 
     async def test_leading_slash_mapping_not_double_prefixed(self) -> None:
         update = _make_update(text="/status")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/status")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/status", -100999
+        )
 
     async def test_unknown_command_forwarded_as_is(self) -> None:
         update = _make_update(text="/unknown_thing")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/unknown_thing")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/unknown_thing", -100999
+        )
 
     async def test_followup_on_non_pi_provider_forwarded_as_is(self) -> None:
         update = _make_update(text="/followup run tests")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/followup run tests")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/followup run tests", -100999
+        )
         self.mock_send_followup_to_window.assert_not_called()
 
     async def test_pi_followup_queues_followup_message(self) -> None:
@@ -180,7 +196,9 @@ class TestForwardCommandResolution:
         update = _make_update(text="/followup run tests")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_followup_to_window.assert_called_once_with("@1", "run tests")
+        self.mock_send_followup_to_window.assert_called_once_with(
+            100, "@1", 42, "run tests", -100999
+        )
         self.mock_send_to_window.assert_not_called()
         reply_text = update.message.reply_text.call_args[0][0]
         assert reply_text == "⏭️ [project] Follow-up queued."
@@ -200,7 +218,7 @@ class TestForwardCommandResolution:
         update = _make_update(text="/new")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/new")
+        self.mock_send_to_window.assert_called_once_with(100, "@1", 42, "/new", -100999)
         self.mock_ws.clear_window_session.assert_called_once_with("@1")
 
     async def test_pi_clear_alias_forwards_to_new(self) -> None:
@@ -208,7 +226,7 @@ class TestForwardCommandResolution:
         update = _make_update(text="/clear")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/new")
+        self.mock_send_to_window.assert_called_once_with(100, "@1", 42, "/new", -100999)
         self.mock_ws.clear_window_session.assert_called_once_with("@1")
         reply_text = update.message.reply_text.call_args[0][0]
         assert "Sent: /new" in reply_text
@@ -223,7 +241,9 @@ class TestForwardCommandResolution:
         update = _make_update(text="/scoped_models")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/scoped-models")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/scoped-models", -100999
+        )
         reply_text = update.message.reply_text.call_args[0][0]
         assert "drive the picker" in reply_text
 
@@ -231,7 +251,9 @@ class TestForwardCommandResolution:
         update = _make_update(text="/cost")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/cost")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/cost", -100999
+        )
 
     async def test_tui_picker_hint_appended_for_known_picker_command(self) -> None:
         self.mock_provider.capabilities.tui_picker_commands = frozenset({"model"})
@@ -259,7 +281,9 @@ class TestForwardCommandResolution:
         reply_text = update.message.reply_text.call_args[0][0]
         assert "drive the picker" not in reply_text
         assert "/toolbar" not in reply_text
-        self.mock_send_to_window.assert_called_once_with("@1", "/model claude-opus-4-5")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/model claude-opus-4-5", -100999
+        )
 
     async def test_picker_hint_with_botname_mention(self) -> None:
         self.mock_provider.capabilities.tui_picker_commands = frozenset({"model"})
@@ -273,13 +297,17 @@ class TestForwardCommandResolution:
         update = _make_update(text="/clear@mybot")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/clear")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/clear", -100999
+        )
 
     async def test_botname_mention_stripped_with_args(self) -> None:
         update = _make_update(text="/compact@mybot some args")
         await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/compact some args")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/compact some args", -100999
+        )
 
     async def test_confirmation_message_shows_resolved_name(self) -> None:
         update = _make_update(text="/committing_code")
@@ -398,7 +426,9 @@ class TestForwardCommandResolution:
             update = _make_update(text="/status")
             await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/status")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/status", -100999
+        )
         self.mock_probe_ctx.assert_not_called()
         self.mock_probe_spawn.assert_not_called()
         codex_provider.build_status_snapshot.assert_called_once_with(
@@ -428,7 +458,9 @@ class TestForwardCommandResolution:
             update = _make_update(text="/status")
             await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/status")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/status", -100999
+        )
         self.mock_probe_ctx.assert_not_called()
         self.mock_probe_spawn.assert_not_called()
         claude_provider.build_status_snapshot.assert_not_called()
@@ -468,7 +500,9 @@ class TestForwardCommandResolution:
             update = _make_update(text="/status")
             await forward_command_handler(update, _make_context())
 
-        self.mock_send_to_window.assert_called_once_with("@1", "/status")
+        self.mock_send_to_window.assert_called_once_with(
+            100, "@1", 42, "/status", -100999
+        )
         codex_provider.build_status_snapshot.assert_not_called()
         assert update.message.reply_text.call_count == 1
 
@@ -480,7 +514,7 @@ class TestForwardCommandResolution:
             await forward_command_handler(update, _make_context())
 
         self.mock_send_to_window.assert_called_once_with(
-            "@1", "/remote-control project"
+            100, "@1", 42, "/remote-control project", -100999
         )
         mock_arm.assert_called_once()
         args = mock_arm.call_args.args
@@ -518,7 +552,7 @@ class TestForwardCommandResolution:
             await forward_command_handler(update, _make_context())
 
         self.mock_send_to_window.assert_called_once_with(
-            "@1", "/remote-control project"
+            100, "@1", 42, "/remote-control project", -100999
         )
         mock_arm.assert_called_once()
 
@@ -576,7 +610,7 @@ class TestForwardWithRealProvider:
             patch(f"{_FW}.window_store", self.mock_ws),
             patch(f"{_FW}.window_query", self.mock_wq),
             patch(
-                f"{_FW}.send_to_window",
+                f"{_FW}.send_telegram_to_window",
                 new_callable=AsyncMock,
                 return_value=(True, ""),
             ) as self.mock_send_to_window,

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_queue.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_queue.py
@@ -13,6 +13,7 @@ from ccgram.handlers.messaging_pipeline.message_queue import (
     _dispatch,
     _handle_content_task,
     _merge_content_tasks,
+    _process_content_task,
     get_or_create_queue,
     shutdown_workers,
 )
@@ -313,6 +314,34 @@ class TestDispatch:
         assert extra == 0
         mock_flush.assert_awaited_once_with(1, cl, bot)
         mock_clear.assert_awaited_once_with(bot, 1, cl)
+
+
+class TestChatScopedContentDelivery:
+    async def test_content_task_uses_explicit_chat_id(self) -> None:
+        client = FakeTelegramClient()
+        task = ContentTask(
+            window_id="@0",
+            parts=("hello",),
+            thread_id=42,
+            chat_id=-1002,
+        )
+
+        with (
+            patch(
+                "ccgram.handlers.messaging_pipeline.message_queue.convert_status_to_content",
+                new_callable=AsyncMock,
+            ) as mock_convert,
+            patch(
+                "ccgram.handlers.messaging_pipeline.message_queue.rate_limit_send_message",
+                new_callable=AsyncMock,
+                return_value=None,
+            ) as mock_send,
+        ):
+            await _process_content_task(client, 100, task)
+
+        mock_convert.assert_not_awaited()
+        mock_send.assert_awaited_once()
+        assert mock_send.await_args_list[0].args[:2] == (client, -1002)
 
 
 class TestNoBackEdgeImports:

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_routing.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_routing.py
@@ -1,8 +1,13 @@
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from ccgram.handlers.messaging_pipeline.message_routing import handle_new_message
+from ccgram.handlers.telegram_origin import (
+    clear_pending_telegram_injections,
+    remember_telegram_injection,
+)
 from ccgram.session_monitor import NewMessage
 
 
@@ -27,6 +32,13 @@ def _make_msg(
         role=role,
         is_complete=is_complete,
     )
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending_telegram_injections() -> Iterator[None]:
+    clear_pending_telegram_injections()
+    yield
+    clear_pending_telegram_injections()
 
 
 @pytest.fixture
@@ -149,3 +161,30 @@ async def test_complete_message_enqueues_content(bot, mock_deps):
     assert kwargs["user_id"] == 100
     assert kwargs["window_id"] == "@5"
     assert kwargs["thread_id"] == 42
+
+
+async def test_matching_telegram_user_message_is_suppressed(bot, mock_deps):
+    remember_telegram_injection(100, "@5", 42, "hello")
+
+    await handle_new_message(_make_msg(text="hello", role="user"), bot)
+
+    mock_deps["eq"].assert_not_called()
+
+
+async def test_terminal_user_message_is_relayed(bot, mock_deps):
+    await handle_new_message(_make_msg(text="hello", role="user"), bot)
+
+    mock_deps["eq"].assert_called_once()
+
+
+async def test_telegram_echo_is_suppressed_only_for_its_origin_topic(bot, mock_deps):
+    mock_deps["sq"].find_users_for_session.return_value = [
+        (100, "@5", 42),
+        (200, "@5", 43),
+    ]
+    remember_telegram_injection(100, "@5", 42, "hello")
+
+    await handle_new_message(_make_msg(text="hello", role="user"), bot)
+
+    mock_deps["eq"].assert_awaited_once()
+    assert mock_deps["eq"].call_args.kwargs["user_id"] == 200

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_routing.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_routing.py
@@ -83,7 +83,7 @@ def mock_deps():
             "ccgram.handlers.messaging_pipeline.message_routing.user_preferences"
         ) as up,
     ):
-        sq.find_users_for_session.return_value = [(100, "@5", 42)]
+        sq.find_users_for_session.return_value = [(100, "@5", 42, -100)]
         sq.resolve_session_for_window = AsyncMock(return_value=None)
         gmq.return_value = None
         yield {
@@ -161,10 +161,11 @@ async def test_complete_message_enqueues_content(bot, mock_deps):
     assert kwargs["user_id"] == 100
     assert kwargs["window_id"] == "@5"
     assert kwargs["thread_id"] == 42
+    assert kwargs["chat_id"] == -100
 
 
 async def test_matching_telegram_user_message_is_suppressed(bot, mock_deps):
-    remember_telegram_injection(100, "@5", 42, "hello")
+    remember_telegram_injection(100, "@5", 42, "hello", -100)
 
     await handle_new_message(_make_msg(text="hello", role="user"), bot)
 
@@ -179,10 +180,10 @@ async def test_terminal_user_message_is_relayed(bot, mock_deps):
 
 async def test_telegram_echo_is_suppressed_only_for_its_origin_topic(bot, mock_deps):
     mock_deps["sq"].find_users_for_session.return_value = [
-        (100, "@5", 42),
-        (200, "@5", 43),
+        (100, "@5", 42, -100),
+        (200, "@5", 43, -200),
     ]
-    remember_telegram_injection(100, "@5", 42, "hello")
+    remember_telegram_injection(100, "@5", 42, "hello", -100)
 
     await handle_new_message(_make_msg(text="hello", role="user"), bot)
 

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -746,8 +746,8 @@ class TestProbeFailures:
             mock_tm.kill_window = AsyncMock()
             await probe_topic_existence(bot)
         mock_tm.kill_window.assert_not_called()
-        mock_cleanup.assert_called_once_with(1, 42, bot, window_id="@5")
-        mock_tr.unbind_thread.assert_called_once_with(1, 42)
+        mock_cleanup.assert_called_once_with(1, 42, bot, window_id="@5", chat_id=-100)
+        mock_tr.unbind_thread.assert_called_once_with(1, 42, chat_id=-100)
         assert (
             _window_poll_state.get("@5") is None
             or _window_poll_state["@5"].probe_failures == 0
@@ -2242,8 +2242,8 @@ class TestDeadWindowNotification:
             await probe_topic_existence(bot)
 
         mock_tm.kill_window.assert_not_called()
-        mock_cleanup.assert_called_once_with(1, 42, bot, window_id="@5")
-        mock_tr.unbind_thread.assert_called_once_with(1, 42)
+        mock_cleanup.assert_called_once_with(1, 42, bot, window_id="@5", chat_id=-100)
+        mock_tr.unbind_thread.assert_called_once_with(1, 42, chat_id=-100)
 
 
 class TestPaneAlertHelpers:

--- a/tests/ccgram/handlers/recovery/test_recovery_ui.py
+++ b/tests/ccgram/handlers/recovery/test_recovery_ui.py
@@ -517,7 +517,7 @@ class TestBotTextHandlerScopedMenu:
 
             await text_handler(update, ctx)
 
-            mock_tr.resolve_window_for_thread.assert_called_once_with(100, 42)
+            mock_tr.resolve_window_for_thread.assert_called_once_with(100, 42, -100999)
             mock_sync_menu.assert_called_once_with(update.message, 100, provider)
             mock_handle_text.assert_called_once_with(update, ctx)
         finally:
@@ -560,11 +560,11 @@ class TestRecoveryFreshCallback:
             "/tmp/project", agent_args="", launch_command="claude"
         )
         mock_tr.bind_thread.assert_called_once_with(
-            100, 42, "@5", window_name="project"
+            100, 42, "@5", window_name="project", chat_id=-100999
         )
         mock_tr.set_group_chat_id.assert_called_once_with(100, 42, -100999)
 
-    @patch(f"{_RC}.send_to_window", new_callable=AsyncMock)
+    @patch(f"{_RC}.send_telegram_to_window", new_callable=AsyncMock)
     @patch(f"{_RC}.thread_router")
     @patch(f"{_RC}.tmux_manager")
     @patch(f"{_RC}.window_query")
@@ -596,7 +596,7 @@ class TestRecoveryFreshCallback:
             mock_path.return_value.is_dir.return_value = True
             await handle_recovery_callback(query, 100, query.data, update, ctx)
 
-        mock_send_to_window.assert_called_once_with("@5", "hello")
+        mock_send_to_window.assert_called_once_with(100, "@5", 42, "hello", -100999)
         assert PENDING_THREAD_TEXT not in user_data
         assert PENDING_THREAD_ID not in user_data
         assert RECOVERY_WINDOW_ID not in user_data
@@ -700,11 +700,11 @@ class TestRecoveryContinueCallback:
             "/tmp/project", agent_args="--continue", launch_command="claude"
         )
         mock_tr.bind_thread.assert_called_once_with(
-            100, 42, "@5", window_name="project"
+            100, 42, "@5", window_name="project", chat_id=-100999
         )
 
     @patch(f"{_RC}.scan_sessions_for_cwd", return_value=[_SessionEntry("s1", "x")])
-    @patch(f"{_RC}.send_to_window", new_callable=AsyncMock)
+    @patch(f"{_RC}.send_telegram_to_window", new_callable=AsyncMock)
     @patch(f"{_RC}.thread_router")
     @patch(f"{_RC}.tmux_manager")
     @patch(f"{_RC}.window_query")
@@ -737,7 +737,9 @@ class TestRecoveryContinueCallback:
             mock_path.return_value.is_dir.return_value = True
             await handle_recovery_callback(query, 100, query.data, update, ctx)
 
-        mock_send_to_window.assert_called_once_with("@5", "my message")
+        mock_send_to_window.assert_called_once_with(
+            100, "@5", 42, "my message", -100999
+        )
         assert PENDING_THREAD_TEXT not in user_data
 
     @patch(f"{_RC}.tmux_manager")

--- a/tests/ccgram/handlers/shell/test_shell_commands.py
+++ b/tests/ccgram/handlers/shell/test_shell_commands.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from telegram import Bot, CallbackQuery, InlineKeyboardMarkup, Message
@@ -114,7 +114,7 @@ class TestHandleShellMessage:
             mock_tm.capture_pane = AsyncMock(return_value=None)
             await handle_shell_message(bot, 1, 42, "@0", "!ls -la", message)
 
-            mock_send.assert_called_once_with("@0", "ls -la", raw=True)
+            mock_send.assert_called_once_with(1, "@0", 42, "ls -la", ANY, raw=True)
             mock_mark.assert_called_once()
             args = mock_mark.call_args.args
             assert args[:4] == ("@0", "ls -la", 1, 42)
@@ -136,7 +136,7 @@ class TestHandleShellMessage:
         ):
             await handle_shell_message(bot, 1, 42, "@0", "! ls", message)
 
-            mock_send.assert_called_once_with("@0", "ls", raw=True)
+            mock_send.assert_called_once_with(1, "@0", 42, "ls", ANY, raw=True)
 
     async def test_bare_bang_is_ignored(self) -> None:
         bot = AsyncMock(spec=Bot)
@@ -170,7 +170,9 @@ class TestHandleShellMessage:
         ):
             await handle_shell_message(bot, 1, 42, "@0", "find . -name foo", message)
 
-            mock_send.assert_called_once_with("@0", "find . -name foo", raw=True)
+            mock_send.assert_called_once_with(
+                1, "@0", 42, "find . -name foo", ANY, raw=True
+            )
 
     async def test_no_bang_with_llm_calls_completer(self) -> None:
         bot = AsyncMock(spec=Bot)
@@ -346,7 +348,7 @@ class TestHandleShellCallback:
             await handle_shell_callback(query, 1, f"{CB_SHELL_RUN}@0", bot, 42)
 
             query.answer.assert_called_once()
-            mock_send.assert_called_once_with("@0", "ls -la", raw=True)
+            mock_send.assert_called_once_with(1, "@0", 42, "ls -la", ANY, raw=True)
             mock_mark.assert_called_once_with("@0", "ls -la", 1, 42, 0)
             assert _shell_pending.get((-100, 42)) is None
 
@@ -504,7 +506,9 @@ class TestHandleShellCallback:
                 query, 1, f"{CB_SHELL_CONFIRM_DANGER}@0", bot, 42
             )
 
-            mock_send.assert_called_once_with("@0", "rm -rf /tmp/test", raw=True)
+            mock_send.assert_called_once_with(
+                1, "@0", 42, "rm -rf /tmp/test", ANY, raw=True
+            )
             assert _shell_pending.get((-100, 42)) is None
 
 

--- a/tests/ccgram/handlers/status/test_status_recall_callback.py
+++ b/tests/ccgram/handlers/status/test_status_recall_callback.py
@@ -1,6 +1,6 @@
 """Tests for status recall callback handling."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from ccgram.handlers.callback_data import CB_STATUS_RECALL
 from ccgram.handlers.status.status_bar_actions import _handle_status_bar_action  # noqa: F401
@@ -34,7 +34,7 @@ async def test_status_recall_sends_selected_history_command() -> None:
             return_value=["/status", "/clear"],
         ),
         patch(
-            "ccgram.handlers.status.status_bar_actions.send_to_window",
+            "ccgram.handlers.status.status_bar_actions.send_telegram_to_window",
             new_callable=AsyncMock,
             return_value=(True, ""),
         ) as mock_send,
@@ -44,7 +44,7 @@ async def test_status_recall_sends_selected_history_command() -> None:
             query, 100, f"{CB_STATUS_RECALL}@0:1", update, context
         )
 
-    mock_send.assert_awaited_once_with("@0", "/clear")
+    mock_send.assert_awaited_once_with(100, "@0", 42, "/clear", ANY)
     mock_record.assert_called_once_with(100, 42, "/clear")
     query.answer.assert_awaited_once_with("\u21a9 Sent")
 
@@ -67,7 +67,7 @@ async def test_status_recall_rejects_stale_topic_binding() -> None:
             return_value="@9",
         ),
         patch(
-            "ccgram.handlers.status.status_bar_actions.send_to_window",
+            "ccgram.handlers.status.status_bar_actions.send_telegram_to_window",
             new_callable=AsyncMock,
         ) as mock_send,
     ):
@@ -98,7 +98,7 @@ async def test_status_recall_handles_missing_history_entry() -> None:
         ),
         patch("ccgram.handlers.command_history.get_history", return_value=["/status"]),
         patch(
-            "ccgram.handlers.status.status_bar_actions.send_to_window",
+            "ccgram.handlers.status.status_bar_actions.send_telegram_to_window",
             new_callable=AsyncMock,
         ) as mock_send,
     ):

--- a/tests/ccgram/handlers/test_callback_auth.py
+++ b/tests/ccgram/handlers/test_callback_auth.py
@@ -22,6 +22,15 @@ class TestUserOwnsWindow:
             mock_sm.get_all_thread_windows.return_value = {}
             assert not user_owns_window(100, "@0")
 
+    def test_chat_scoped_binding_authorizes_only_its_chat(self) -> None:
+        with patch("ccgram.handlers.callback_helpers.thread_router") as mock_router:
+            mock_router.iter_thread_bindings_with_chat.return_value = [
+                (100, -1001, 42, "@0")
+            ]
+
+            assert user_owns_window(100, "@0", -1001)
+            assert not user_owns_window(100, "@0", -1002)
+
     def test_different_user_does_not_own(self) -> None:
         with patch("ccgram.handlers.callback_helpers.thread_router") as mock_sm:
             mock_sm.get_all_thread_windows.side_effect = lambda uid: (

--- a/tests/ccgram/handlers/test_sync_command.py
+++ b/tests/ccgram/handlers/test_sync_command.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -631,6 +632,7 @@ class TestDeadTopicRecreation:
         with patch(
             "ccgram.handlers.topics.topic_orchestration.handle_new_window",
             new_callable=AsyncMock,
+            return_value=True,
         ) as mock_handle:
             count = await _recreate_dead_topics(mock_bot, issues)
             assert count == 1
@@ -639,6 +641,70 @@ class TestDeadTopicRecreation:
             event = mock_handle.call_args[0][0]
             assert event.window_id == "w2:t2"
             assert event.window_name == "qmd-go"
+            assert mock_handle.call_args.kwargs == {
+                "target_user_id": 100,
+                "target_chat_id": mock_tr.resolve_chat_id.return_value,
+            }
+
+    async def test_recreate_restores_binding_when_creation_returns_false(
+        self, _patch_deps
+    ) -> None:
+        _, _, mock_wq, mock_tr, _, _ = _patch_deps
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="proj"
+        )
+        mock_tr.get_window_for_thread.return_value = "@2"
+        mock_tr.resolve_chat_id.return_value = -999
+        issues = [
+            AuditIssue(
+                "dead_topic",
+                "user:100 thread:42 window:@2 (proj)",
+                fixable=True,
+            ),
+        ]
+
+        with patch(
+            "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            count = await _recreate_dead_topics(AsyncMock(), issues)
+
+        assert count == 0
+        mock_tr.bind_thread.assert_called_once_with(
+            100, 42, "@2", window_name="proj", chat_id=-999
+        )
+        mock_tr.set_group_chat_id.assert_called_once_with(100, 42, -999)
+
+    async def test_recreate_restores_binding_when_cancelled(self, _patch_deps) -> None:
+        _, _, mock_wq, mock_tr, _, _ = _patch_deps
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="proj"
+        )
+        mock_tr.get_window_for_thread.return_value = "@2"
+        mock_tr.resolve_chat_id.return_value = -999
+        issues = [
+            AuditIssue(
+                "dead_topic",
+                "user:100 thread:42 window:@2 (proj)",
+                fixable=True,
+            ),
+        ]
+
+        with (
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+                new_callable=AsyncMock,
+                side_effect=asyncio.CancelledError,
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await _recreate_dead_topics(AsyncMock(), issues)
+
+        mock_tr.bind_thread.assert_called_once_with(
+            100, 42, "@2", window_name="proj", chat_id=-999
+        )
+        mock_tr.set_group_chat_id.assert_called_once_with(100, 42, -999)
 
     async def test_recreate_skips_non_dead_topic_issues(self, _patch_deps) -> None:
         issues = [
@@ -660,6 +726,7 @@ class TestDeadTopicRecreation:
             session_id="s1", cwd="/tmp", window_name="proj"
         )
         mock_tr.get_window_for_thread.return_value = "@2"
+        mock_tr.resolve_chat_id.return_value = -999
 
         issues = [
             AuditIssue(
@@ -680,7 +747,7 @@ class TestDeadTopicRecreation:
             assert count == 0
             mock_tr.unbind_thread.assert_called_once_with(100, 42)
             mock_tr.bind_thread.assert_called_once_with(
-                100, 42, "@2", window_name="proj"
+                100, 42, "@2", window_name="proj", chat_id=-999
             )
 
 

--- a/tests/ccgram/handlers/test_sync_command.py
+++ b/tests/ccgram/handlers/test_sync_command.py
@@ -543,7 +543,15 @@ class TestDeadTopicDetection:
         mock_bot.send_message.return_value = MagicMock(message_id=999)
 
         issues = await _probe_dead_topics(mock_bot)
+
         assert issues == []
+        mock_bot.send_message.assert_awaited_once_with(
+            -999,
+            ".",
+            message_thread_id=42,
+            disable_notification=True,
+        )
+        mock_bot.delete_message.assert_awaited_once_with(-999, 999)
 
     async def test_probe_skips_network_errors(self, _patch_deps) -> None:
         _, _, _, mock_tr, _, _ = _patch_deps

--- a/tests/ccgram/handlers/test_telegram_origin.py
+++ b/tests/ccgram/handlers/test_telegram_origin.py
@@ -1,0 +1,66 @@
+from unittest.mock import patch
+
+from ccgram.handlers.telegram_origin import (
+    _PENDING_INJECTION_TTL_S,
+    clear_pending_telegram_injections,
+    consume_telegram_injection,
+    forget_telegram_injection,
+    remember_telegram_injection,
+)
+
+
+def setup_function() -> None:
+    clear_pending_telegram_injections()
+
+
+def teardown_function() -> None:
+    clear_pending_telegram_injections()
+
+
+def test_matching_injections_are_consumed_once_in_fifo_order() -> None:
+    with patch("ccgram.handlers.telegram_origin.time.monotonic", return_value=100.0):
+        remember_telegram_injection(1, "@1", 42, "same")
+        remember_telegram_injection(1, "@1", 42, "same")
+
+    with patch("ccgram.handlers.telegram_origin.time.monotonic", return_value=101.0):
+        assert consume_telegram_injection(1, "@1", 42, "same") is True
+        assert consume_telegram_injection(1, "@1", 42, "same") is True
+        assert consume_telegram_injection(1, "@1", 42, "same") is False
+
+
+def test_out_of_order_text_does_not_consume_later_injection() -> None:
+    remember_telegram_injection(1, "@1", 42, "first")
+    remember_telegram_injection(1, "@1", 42, "second")
+
+    assert consume_telegram_injection(1, "@1", 42, "second") is False
+    assert consume_telegram_injection(1, "@1", 42, "first") is True
+    assert consume_telegram_injection(1, "@1", 42, "second") is True
+
+
+def test_failed_send_forgets_exact_reservation() -> None:
+    first = remember_telegram_injection(1, "@1", 42, "same")
+    second = remember_telegram_injection(1, "@1", 42, "same")
+
+    forget_telegram_injection(1, "@1", 42, second)
+
+    assert consume_telegram_injection(1, "@1", 42, "same") is True
+    assert consume_telegram_injection(1, "@1", 42, "same") is False
+    forget_telegram_injection(1, "@1", 42, first)
+
+
+def test_expired_injection_does_not_suppress_terminal_input() -> None:
+    with patch("ccgram.handlers.telegram_origin.time.monotonic", return_value=100.0):
+        remember_telegram_injection(1, "@1", 42, "hello")
+
+    with patch(
+        "ccgram.handlers.telegram_origin.time.monotonic",
+        return_value=100.0 + _PENDING_INJECTION_TTL_S,
+    ):
+        assert consume_telegram_injection(1, "@1", 42, "hello") is False
+
+
+def test_injection_is_scoped_to_its_bound_topic() -> None:
+    remember_telegram_injection(1, "@1", 42, "hello")
+
+    assert consume_telegram_injection(1, "@1", 43, "hello") is False
+    assert consume_telegram_injection(1, "@1", 42, "hello") is True

--- a/tests/ccgram/handlers/test_telegram_origin.py
+++ b/tests/ccgram/handlers/test_telegram_origin.py
@@ -1,4 +1,7 @@
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from ccgram.handlers.telegram_origin import (
     _PENDING_INJECTION_TTL_S,
@@ -6,6 +9,7 @@ from ccgram.handlers.telegram_origin import (
     consume_telegram_injection,
     forget_telegram_injection,
     remember_telegram_injection,
+    send_telegram_to_window,
 )
 
 
@@ -28,13 +32,12 @@ def test_matching_injections_are_consumed_once_in_fifo_order() -> None:
         assert consume_telegram_injection(1, "@1", 42, "same") is False
 
 
-def test_out_of_order_text_does_not_consume_later_injection() -> None:
-    remember_telegram_injection(1, "@1", 42, "first")
+def test_matching_skips_unrelated_pending_entries() -> None:
+    remember_telegram_injection(1, "@1", 42, "/local-command")
     remember_telegram_injection(1, "@1", 42, "second")
 
-    assert consume_telegram_injection(1, "@1", 42, "second") is False
-    assert consume_telegram_injection(1, "@1", 42, "first") is True
     assert consume_telegram_injection(1, "@1", 42, "second") is True
+    assert consume_telegram_injection(1, "@1", 42, "/local-command") is True
 
 
 def test_failed_send_forgets_exact_reservation() -> None:
@@ -60,7 +63,87 @@ def test_expired_injection_does_not_suppress_terminal_input() -> None:
 
 
 def test_injection_is_scoped_to_its_bound_topic() -> None:
-    remember_telegram_injection(1, "@1", 42, "hello")
+    remember_telegram_injection(1, "@1", 42, "hello", -100)
 
-    assert consume_telegram_injection(1, "@1", 43, "hello") is False
+    assert consume_telegram_injection(1, "@1", 42, "hello", -200) is False
+    assert consume_telegram_injection(1, "@1", 42, "hello", -100) is True
+
+
+def test_injection_is_scoped_to_chat_when_thread_ids_collide() -> None:
+    remember_telegram_injection(1, "@1", 42, "hello", -100)
+
+    assert consume_telegram_injection(1, "@1", 42, "hello", -200) is False
+    assert consume_telegram_injection(1, "@1", 42, "hello", -100) is True
+
+
+def test_matches_provider_trimmed_user_text() -> None:
+    remember_telegram_injection(1, "@1", 42, "  hello  \n")
+
     assert consume_telegram_injection(1, "@1", 42, "hello") is True
+
+
+@pytest.mark.asyncio
+async def test_origin_aware_send_reserves_before_terminal_injection() -> None:
+    async def send_after_reservation(
+        window_id: str, text: str, *, raw: bool = False
+    ) -> tuple[bool, str]:
+        assert consume_telegram_injection(1, window_id, 42, text) is True
+        return True, "ok"
+
+    with patch(
+        "ccgram.handlers.telegram_origin.send_to_window",
+        AsyncMock(side_effect=send_after_reservation),
+    ):
+        assert await send_telegram_to_window(1, "@1", 42, "hello") == (True, "ok")
+
+
+@pytest.mark.asyncio
+async def test_origin_aware_send_rolls_back_on_false_result() -> None:
+    with patch(
+        "ccgram.handlers.telegram_origin.send_to_window",
+        AsyncMock(return_value=(False, "window gone")),
+    ):
+        assert await send_telegram_to_window(1, "@1", 42, "hello") == (
+            False,
+            "window gone",
+        )
+
+    assert consume_telegram_injection(1, "@1", 42, "hello") is False
+
+
+@pytest.mark.asyncio
+async def test_origin_aware_send_rolls_back_on_cancellation() -> None:
+    with (
+        patch(
+            "ccgram.handlers.telegram_origin.send_to_window",
+            AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await send_telegram_to_window(1, "@1", 42, "hello")
+
+    assert consume_telegram_injection(1, "@1", 42, "hello") is False
+
+
+@pytest.mark.asyncio
+async def test_origin_aware_send_rolls_back_on_exception() -> None:
+    with (
+        patch(
+            "ccgram.handlers.telegram_origin.send_to_window",
+            AsyncMock(side_effect=RuntimeError("send failed")),
+        ),
+        pytest.raises(RuntimeError, match="send failed"),
+    ):
+        await send_telegram_to_window(1, "@1", 42, "hello")
+
+    assert consume_telegram_injection(1, "@1", 42, "hello") is False
+
+
+def test_pending_correlations_are_not_evicted_before_ttl() -> None:
+    for index in range(300):
+        remember_telegram_injection(index, f"@{index}", 42, f"message-{index}")
+    for index in range(20):
+        remember_telegram_injection(999, "@burst", 42, f"burst-{index}")
+
+    assert consume_telegram_injection(0, "@0", 42, "message-0") is True
+    assert consume_telegram_injection(999, "@burst", 42, "burst-0") is True

--- a/tests/ccgram/handlers/text/test_text_handler.py
+++ b/tests/ccgram/handlers/text/test_text_handler.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -455,7 +455,11 @@ class TestShellProviderRouting:
 
 
 class TestForwardMessage:
-    @patch(f"{_TH}.send_to_window", new_callable=AsyncMock, return_value=(True, "ok"))
+    @patch(
+        f"{_TH}.send_telegram_to_window",
+        new_callable=AsyncMock,
+        return_value=(True, "ok"),
+    )
     @patch(f"{_TH}.window_query")
     async def test_sends_to_window(
         self, mock_sm: MagicMock, mock_send: AsyncMock
@@ -463,26 +467,14 @@ class TestForwardMessage:
         bot = AsyncMock()
         message = AsyncMock()
 
-        with (
-            patch(f"{_TH}.get_interactive_window", return_value=None),
-            patch(f"{_TH}.remember_telegram_injection") as mock_remember,
-        ):
-
-            async def send_after_reservation(
-                window_id: str, text: str
-            ) -> tuple[bool, str]:
-                assert mock_remember.called
-                return True, "ok"
-
-            mock_send.side_effect = send_after_reservation
+        with patch(f"{_TH}.get_interactive_window", return_value=None):
             await _forward_message("@0", 100, 42, "hello", bot, message)
 
-        mock_send.assert_called_once_with("@0", "hello")
-        mock_remember.assert_called_once_with(100, "@0", 42, "hello")
+        mock_send.assert_called_once_with(100, "@0", 42, "hello", ANY)
 
     @patch(f"{_TH}.safe_reply", new_callable=AsyncMock)
     @patch(
-        f"{_TH}.send_to_window",
+        f"{_TH}.send_telegram_to_window",
         new_callable=AsyncMock,
         return_value=(False, "Window not found"),
     )
@@ -493,42 +485,18 @@ class TestForwardMessage:
         bot = AsyncMock()
         message = AsyncMock()
 
-        injection = object()
-        with (
-            patch(
-                f"{_TH}.remember_telegram_injection", return_value=injection
-            ) as mock_remember,
-            patch(f"{_TH}.forget_telegram_injection") as mock_forget,
-        ):
-            await _forward_message("@0", 100, 42, "hello", bot, message)
+        await _forward_message("@0", 100, 42, "hello", bot, message)
 
         mock_reply.assert_called_once()
-        mock_remember.assert_called_once_with(100, "@0", 42, "hello")
-        mock_forget.assert_called_once_with(100, "@0", 42, injection)
         assert "Window not found" in mock_reply.call_args.args[1]
-
-    @patch(f"{_TH}.send_to_window", new_callable=AsyncMock)
-    @patch(f"{_TH}.window_query")
-    async def test_send_exception_forgets_reservation(
-        self, _mock_sm: MagicMock, mock_send: AsyncMock
-    ) -> None:
-        bot = AsyncMock()
-        message = AsyncMock()
-        injection = object()
-        mock_send.side_effect = RuntimeError("send failed")
-
-        with (
-            patch(f"{_TH}.remember_telegram_injection", return_value=injection),
-            patch(f"{_TH}.forget_telegram_injection") as mock_forget,
-            pytest.raises(RuntimeError, match="send failed"),
-        ):
-            await _forward_message("@0", 100, 42, "hello", bot, message)
-
-        mock_forget.assert_called_once_with(100, "@0", 42, injection)
 
     @patch(f"{_TH}.get_interactive_window", return_value=None)
     @patch(f"{_TH}._capture_bash_output")
-    @patch(f"{_TH}.send_to_window", new_callable=AsyncMock, return_value=(True, "ok"))
+    @patch(
+        f"{_TH}.send_telegram_to_window",
+        new_callable=AsyncMock,
+        return_value=(True, "ok"),
+    )
     @patch(f"{_TH}.window_query")
     async def test_bash_capture_for_bang_command(
         self,
@@ -552,7 +520,11 @@ class TestForwardMessage:
             await task
 
     @patch(f"{_TH}.get_interactive_window", return_value=None)
-    @patch(f"{_TH}.send_to_window", new_callable=AsyncMock, return_value=(True, "ok"))
+    @patch(
+        f"{_TH}.send_telegram_to_window",
+        new_callable=AsyncMock,
+        return_value=(True, "ok"),
+    )
     @patch(f"{_TH}.window_query")
     async def test_cancels_existing_bash_capture(
         self, mock_sm: MagicMock, _mock_send: AsyncMock, _mock_interactive: MagicMock
@@ -573,7 +545,11 @@ class TestForwardMessage:
 
     @patch(f"{_TH}.handle_interactive_ui", new_callable=AsyncMock)
     @patch(f"{_TH}.get_interactive_window", return_value="@0")
-    @patch(f"{_TH}.send_to_window", new_callable=AsyncMock, return_value=(True, "ok"))
+    @patch(
+        f"{_TH}.send_telegram_to_window",
+        new_callable=AsyncMock,
+        return_value=(True, "ok"),
+    )
     @patch(f"{_TH}.window_query")
     async def test_refreshes_interactive_ui(
         self,
@@ -591,7 +567,11 @@ class TestForwardMessage:
         assert mock_handle_ui.call_args.args[0] is bot
         assert mock_handle_ui.call_args.args[1:] == (100, "@0", 42)
 
-    @patch(f"{_TH}.send_to_window", new_callable=AsyncMock, return_value=(True, "ok"))
+    @patch(
+        f"{_TH}.send_telegram_to_window",
+        new_callable=AsyncMock,
+        return_value=(True, "ok"),
+    )
     @patch(f"{_TH}.window_query")
     async def test_sends_typing_chat_action(
         self, _mock_sm: MagicMock, _mock_send: AsyncMock

--- a/tests/ccgram/handlers/text/test_text_handler.py
+++ b/tests/ccgram/handlers/text/test_text_handler.py
@@ -463,10 +463,22 @@ class TestForwardMessage:
         bot = AsyncMock()
         message = AsyncMock()
 
-        with patch(f"{_TH}.get_interactive_window", return_value=None):
+        with (
+            patch(f"{_TH}.get_interactive_window", return_value=None),
+            patch(f"{_TH}.remember_telegram_injection") as mock_remember,
+        ):
+
+            async def send_after_reservation(
+                window_id: str, text: str
+            ) -> tuple[bool, str]:
+                assert mock_remember.called
+                return True, "ok"
+
+            mock_send.side_effect = send_after_reservation
             await _forward_message("@0", 100, 42, "hello", bot, message)
 
         mock_send.assert_called_once_with("@0", "hello")
+        mock_remember.assert_called_once_with(100, "@0", 42, "hello")
 
     @patch(f"{_TH}.safe_reply", new_callable=AsyncMock)
     @patch(
@@ -481,10 +493,38 @@ class TestForwardMessage:
         bot = AsyncMock()
         message = AsyncMock()
 
-        await _forward_message("@0", 100, 42, "hello", bot, message)
+        injection = object()
+        with (
+            patch(
+                f"{_TH}.remember_telegram_injection", return_value=injection
+            ) as mock_remember,
+            patch(f"{_TH}.forget_telegram_injection") as mock_forget,
+        ):
+            await _forward_message("@0", 100, 42, "hello", bot, message)
 
         mock_reply.assert_called_once()
+        mock_remember.assert_called_once_with(100, "@0", 42, "hello")
+        mock_forget.assert_called_once_with(100, "@0", 42, injection)
         assert "Window not found" in mock_reply.call_args.args[1]
+
+    @patch(f"{_TH}.send_to_window", new_callable=AsyncMock)
+    @patch(f"{_TH}.window_query")
+    async def test_send_exception_forgets_reservation(
+        self, _mock_sm: MagicMock, mock_send: AsyncMock
+    ) -> None:
+        bot = AsyncMock()
+        message = AsyncMock()
+        injection = object()
+        mock_send.side_effect = RuntimeError("send failed")
+
+        with (
+            patch(f"{_TH}.remember_telegram_injection", return_value=injection),
+            patch(f"{_TH}.forget_telegram_injection") as mock_forget,
+            pytest.raises(RuntimeError, match="send failed"),
+        ):
+            await _forward_message("@0", 100, 42, "hello", bot, message)
+
+        mock_forget.assert_called_once_with(100, "@0", 42, injection)
 
     @patch(f"{_TH}.get_interactive_window", return_value=None)
     @patch(f"{_TH}._capture_bash_output")

--- a/tests/ccgram/handlers/toolbar/test_toolbar.py
+++ b/tests/ccgram/handlers/toolbar/test_toolbar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -270,16 +270,67 @@ class TestDispatchText:
             patch(
                 "ccgram.handlers.toolbar.toolbar_callbacks.tmux_manager"
             ) as mock_tmux,
+            patch(
+                "ccgram.handlers.toolbar.toolbar_callbacks.get_thread_id",
+                return_value=42,
+            ),
+            patch(
+                "ccgram.handlers.toolbar.toolbar_callbacks.send_telegram_to_window",
+                new_callable=AsyncMock,
+                return_value=(True, "ok"),
+            ) as mock_send,
         ):
             mock_tmux.find_window_by_id = AsyncMock(
                 return_value=MagicMock(window_id="@5")
             )
-            mock_tmux.send_keys = AsyncMock()
             await handle_toolbar_callback(query, 100, "tb:@5:clear", update, context)
-        mock_tmux.send_keys.assert_awaited_once_with(
-            "@5", "/clear", enter=True, literal=True
-        )
+        mock_send.assert_awaited_once_with(100, "@5", 42, "/clear", ANY)
         query.answer.assert_awaited_once()
+
+    async def test_text_action_reports_send_failure(self) -> None:
+        action = ToolbarAction(
+            name="clear",
+            emoji="🧹",
+            text="Clear",
+            action_type="text",
+            payload="/clear",
+        )
+        cfg = ToolbarConfig(
+            layouts=dict(DEFAULT_LAYOUTS),
+            actions={**BUILTIN_ACTIONS, "clear": action},
+        )
+        query = _make_query("tb:@5:clear")
+        update = _make_update_with_user()
+        with (
+            patch(
+                "ccgram.handlers.toolbar.toolbar_callbacks.get_toolbar_config",
+                return_value=cfg,
+            ),
+            patch(
+                "ccgram.handlers.toolbar.toolbar_callbacks.user_owns_window",
+                return_value=True,
+            ),
+            patch(
+                "ccgram.handlers.toolbar.toolbar_callbacks.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.toolbar.toolbar_callbacks.get_thread_id",
+                return_value=42,
+            ),
+            patch(
+                "ccgram.handlers.toolbar.toolbar_callbacks.send_telegram_to_window",
+                new_callable=AsyncMock,
+                return_value=(False, "window gone"),
+            ),
+        ):
+            mock_tmux.find_window_by_id = AsyncMock(
+                return_value=MagicMock(window_id="@5")
+            )
+            await handle_toolbar_callback(
+                query, 100, "tb:@5:clear", update, _make_context()
+            )
+
+        query.answer.assert_awaited_once_with("window gone", show_alert=True)
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/ccgram/handlers/topics/test_new_window_sync.py
+++ b/tests/ccgram/handlers/topics/test_new_window_sync.py
@@ -173,6 +173,62 @@ class TestNewWindowSyncWithBindings:
         }
         assert called_chats == {group_a, group_b}
 
+    async def test_same_user_does_not_create_orphan_topics_in_multiple_groups(
+        self, monitor: SessionMonitor, sm: SessionManager
+    ) -> None:
+        user_id = 100
+        new_window = "@9"
+        thread_router.thread_bindings = {user_id: {1: "@1", 2: "@2"}}
+        thread_router.group_chat_ids = {
+            f"{user_id}:1": -100100,
+            f"{user_id}:2": -100200,
+        }
+        topic_counter = iter([50, 60])
+        bot = AsyncMock()
+        bot.create_forum_topic = AsyncMock(
+            side_effect=lambda **kw: _make_topic(next(topic_counter))
+        )
+
+        async def on_new_window(event: NewWindowEvent) -> None:
+            with (
+                patch("ccgram.handlers.topics.topic_orchestration.session_manager", sm),
+                patch(
+                    "ccgram.handlers.topics.topic_orchestration.config"
+                ) as mock_config,
+            ):
+                mock_config.group_id = None
+                mock_config.allowed_users = {user_id}
+                await _handle_new_window(event, bot)
+
+        monitor.set_new_window_callback(on_new_window)
+        monitor._last_session_map = {}
+        with patch.object(
+            monitor,
+            "_load_current_session_map",
+            new_callable=AsyncMock,
+            return_value={
+                new_window: {
+                    "session_id": "s1",
+                    "cwd": "/proj",
+                    "window_name": "proj",
+                }
+            },
+        ):
+            await monitor._detect_and_cleanup_changes()
+
+        assert bot.create_forum_topic.call_count == 2
+        for chat_id in (-100100, -100200):
+            matches = [
+                window_id
+                for (bound_chat, _thread_id), window_id in (
+                    (key[1:], value)
+                    for key, value in thread_router.chat_thread_bindings.items()
+                    if key[0] == user_id
+                )
+                if bound_chat == chat_id
+            ]
+            assert matches == [new_window]
+
 
 class TestNewWindowSyncColdStart:
     """Cold-start: no existing bindings, CCGRAM_GROUP_ID drives topic creation."""

--- a/tests/ccgram/handlers/topics/test_selection.py
+++ b/tests/ccgram/handlers/topics/test_selection.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from telegram import InlineKeyboardMarkup
@@ -404,7 +404,7 @@ class TestHandleModeSelect:
         "ccgram.handlers.topics.window_launch_service.safe_edit", new_callable=AsyncMock
     )
     @patch(
-        "ccgram.handlers.topics.window_launch_service.send_to_window",
+        "ccgram.handlers.topics.window_launch_service.send_telegram_to_window",
         new_callable=AsyncMock,
     )
     @patch("ccgram.handlers.topics.window_launch_service.session_manager")
@@ -453,7 +453,7 @@ class TestHandleModeSelect:
             query, 100, f"{CB_MODE_SELECT}claude:normal", update, context
         )
 
-        mock_send_to_window.assert_called_once_with("@1", "hello world")
+        mock_send_to_window.assert_called_once_with(100, "@1", 42, "hello world", ANY)
         assert PENDING_THREAD_TEXT not in user_data
 
 

--- a/tests/ccgram/handlers/topics/test_topic_lifecycle.py
+++ b/tests/ccgram/handlers/topics/test_topic_lifecycle.py
@@ -288,7 +288,7 @@ class TestHerdrKillPaths:
             mock_tmux.kill_window = AsyncMock()
             await probe_topic_existence(bot)
         mock_tmux.kill_window.assert_called_once_with(herdr_id)
-        mock_router.unbind_thread.assert_called_once_with(1, 100)
+        mock_router.unbind_thread.assert_called_once_with(1, 100, chat_id=-100)
 
 
 class TestPruneStaleState:
@@ -325,7 +325,7 @@ class TestProbeTopicExistence:
             mock_wq.view_window.return_value = _window_view("manual_discovered")
             mock_tmux.kill_window = AsyncMock()
             await probe_topic_existence(bot)
-            mock_router.unbind_thread.assert_called_once_with(1, 100)
+            mock_router.unbind_thread.assert_called_once_with(1, 100, chat_id=42)
             mock_tmux.kill_window.assert_not_called()
 
     async def test_suspended_probe_skipped(self):

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -10,6 +11,7 @@ from ccgram.handlers.topics.topic_orchestration import (
     collect_target_chats,
     _is_window_already_bound,
     _topic_create_retry_until,
+    _window_topic_locks,
     adopt_unbound_windows,
     handle_new_window,
 )
@@ -19,8 +21,10 @@ from ccgram.session_monitor import NewWindowEvent
 @pytest.fixture(autouse=True)
 def _clear_retry_state():
     _topic_create_retry_until.clear()
+    _window_topic_locks.clear()
     yield
     _topic_create_retry_until.clear()
+    _window_topic_locks.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -137,6 +141,61 @@ class TestCollectTargetChats:
 
 
 class TestHandleNewWindow:
+    async def test_serializes_concurrent_creation_for_same_window(self) -> None:
+        active = 0
+        max_active = 0
+
+        async def locked_handler(
+            _event: NewWindowEvent, _client: AsyncMock, **_kwargs: object
+        ) -> bool:
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0)
+            active -= 1
+            return True
+
+        event = _make_event()
+        with patch(
+            "ccgram.handlers.topics.topic_orchestration._handle_new_window_locked",
+            side_effect=locked_handler,
+        ):
+            assert await asyncio.gather(
+                handle_new_window(event, AsyncMock()),
+                handle_new_window(event, AsyncMock()),
+            ) == [True, True]
+
+        assert max_active == 1
+        assert _window_topic_locks == {}
+
+    async def test_targeted_creation_ignores_another_users_binding(self) -> None:
+        event = _make_event(window_id="@2", window_name="proj")
+        bot = AsyncMock()
+        bot.create_forum_topic.return_value = _make_topic(thread_id=77)
+
+        with (
+            patch("ccgram.handlers.topics.topic_orchestration.session_manager"),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.thread_router"
+            ) as mock_tr,
+            patch("ccgram.handlers.topics.topic_orchestration.config") as mock_config,
+        ):
+            mock_tr.has_window.return_value = True
+            mock_tr.iter_thread_bindings.return_value = iter([(200, 2, "@2")])
+            mock_config.allowed_users = {100, 200}
+            created = await handle_new_window(
+                event,
+                bot,
+                target_user_id=100,
+                target_chat_id=-100100,
+            )
+
+        assert created is True
+        mock_tr.bind_thread.assert_called_once_with(
+            100, 77, "@2", window_name="proj", chat_id=-100100
+        )
+        mock_tr.set_group_chat_id.assert_called_once_with(100, 77, -100100)
+
     async def test_skips_already_bound(self):
         event = NewWindowEvent(
             window_id="@0", session_id="s1", window_name="test", cwd="/tmp"
@@ -276,7 +335,7 @@ class TestHandleNewWindow:
             await handle_new_window(event, bot)
 
         mock_tr.bind_thread.assert_called_once_with(
-            12345, 42, "@10", window_name="my-project"
+            12345, 42, "@10", window_name="my-project", chat_id=-100500
         )
         mock_tr.set_group_chat_id.assert_called_once_with(12345, 42, -100500)
 
@@ -331,7 +390,7 @@ class TestHandleNewWindow:
             await handle_new_window(event, bot)
 
         mock_tr.bind_thread.assert_called_once_with(
-            100, 77, "@10", window_name="my-project"
+            100, 77, "@10", window_name="my-project", chat_id=-100200
         )
         mock_tr.set_group_chat_id.assert_called_once_with(100, 77, -100200)
 
@@ -398,12 +457,7 @@ class TestHandleNewWindow:
             ),
         ):
             mock_tr.has_window.return_value = False
-            mock_tr.iter_thread_bindings.side_effect = [
-                iter([]),
-                iter([]),
-                iter([]),
-                iter([]),
-            ]
+            mock_tr.iter_thread_bindings.side_effect = [iter([]) for _ in range(6)]
             mock_config.group_id = -100500
             mock_config.allowed_users = {12345}
 
@@ -437,13 +491,7 @@ class TestHandleNewWindow:
             ),
         ):
             mock_tr.has_window.return_value = False
-            mock_tr.iter_thread_bindings.side_effect = [
-                iter([]),
-                iter([]),
-                iter([]),
-                iter([]),
-                iter([]),
-            ]
+            mock_tr.iter_thread_bindings.side_effect = [iter([]) for _ in range(6)]
             mock_tr.resolve_chat_id.return_value = 12345
             mock_config.group_id = -100500
             mock_config.allowed_users = {12345}
@@ -453,7 +501,7 @@ class TestHandleNewWindow:
 
         assert bot.create_forum_topic.call_count == 2
         mock_tr.bind_thread.assert_called_once_with(
-            12345, 42, "@10", window_name="my-project"
+            12345, 42, "@10", window_name="my-project", chat_id=-100500
         )
 
     async def test_uses_group_chat_ids_when_no_bindings(self) -> None:
@@ -506,7 +554,7 @@ class TestHandleNewWindow:
             await handle_new_window(event, bot)
 
         mock_tr.bind_thread.assert_called_once_with(
-            100, 120014, "@3", window_name="reflex-gh"
+            100, 120014, "@3", window_name="reflex-gh", chat_id=-100200
         )
         mock_tr.set_group_chat_id.assert_called_once_with(100, 120014, -100200)
         bot.send_message.assert_awaited_once_with(

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -509,6 +509,13 @@ class TestHandleNewWindow:
             100, 120014, "@3", window_name="reflex-gh"
         )
         mock_tr.set_group_chat_id.assert_called_once_with(100, 120014, -100200)
+        bot.send_message.assert_awaited_once_with(
+            -100200,
+            ".",
+            message_thread_id=120014,
+            disable_notification=True,
+        )
+        bot.delete_message.assert_awaited_once_with(-100200, 555)
         bot.create_forum_topic.assert_not_called()
 
     async def test_dead_same_name_topic_is_unbound_then_new_topic_created(self) -> None:

--- a/tests/ccgram/handlers/topics/test_topic_probe.py
+++ b/tests/ccgram/handlers/topics/test_topic_probe.py
@@ -1,0 +1,45 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telegram.error import BadRequest, TelegramError
+
+from ccgram.handlers.topics.topic_probe import probe_topic_exists
+
+
+async def test_probe_uses_valid_text_and_deletes_message() -> None:
+    client = AsyncMock()
+    client.send_message.return_value = MagicMock(message_id=99)
+
+    assert await probe_topic_exists(client, -100, 42) is True
+
+    client.send_message.assert_awaited_once_with(
+        -100,
+        ".",
+        message_thread_id=42,
+        disable_notification=True,
+    )
+    client.delete_message.assert_awaited_once_with(-100, 99)
+
+
+async def test_probe_reports_deleted_topic() -> None:
+    client = AsyncMock()
+    client.send_message.side_effect = BadRequest("Message thread not found")
+
+    assert await probe_topic_exists(client, -100, 42) is False
+
+
+async def test_probe_reports_unknown_transport_error() -> None:
+    client = AsyncMock()
+    client.send_message.side_effect = TelegramError("network")
+
+    assert await probe_topic_exists(client, -100, 42) is None
+
+
+async def test_probe_logs_cleanup_failure_but_keeps_exists_result() -> None:
+    client = AsyncMock()
+    client.send_message.return_value = MagicMock(message_id=99)
+    client.delete_message.side_effect = TelegramError("delete failed")
+
+    with patch("ccgram.handlers.topics.topic_probe.logger") as mock_logger:
+        assert await probe_topic_exists(client, -100, 42) is True
+
+    mock_logger.warning.assert_called_once()

--- a/tests/ccgram/handlers/topics/test_window_callbacks.py
+++ b/tests/ccgram/handlers/topics/test_window_callbacks.py
@@ -61,7 +61,11 @@ class TestBindWindowCallback:
             await handle_window_callback(query, 100, f"{CB_WIN_BIND}0", update, context)
 
             mock_tr.bind_thread.assert_called_once_with(
-                100, 42, "@5", window_name="my-project"
+                100,
+                42,
+                "@5",
+                window_name="my-project",
+                chat_id=-100999,
             )
             mock_tr.set_group_chat_id.assert_called_once_with(100, 42, -100999)
             mock_edit.assert_called_once()
@@ -142,7 +146,7 @@ class TestBindWindowCallback:
             patch("ccgram.handlers.topics.window_callbacks.safe_edit"),
             patch("ccgram.handlers.topics.window_callbacks.format_topic_name_for_mode"),
             patch(
-                "ccgram.handlers.topics.window_callbacks.send_to_window",
+                "ccgram.handlers.topics.window_callbacks.send_telegram_to_window",
                 new_callable=AsyncMock,
                 return_value=(True, "ok"),
             ) as mock_send,
@@ -151,7 +155,7 @@ class TestBindWindowCallback:
             mock_sm.get_approval_mode.return_value = "normal"
             await handle_window_callback(query, 100, f"{CB_WIN_BIND}0", update, context)
 
-            mock_send.assert_called_once_with("@5", "hello agent")
+            mock_send.assert_called_once_with(100, "@5", 42, "hello agent", -100999)
             assert PENDING_THREAD_TEXT not in context.user_data
 
 
@@ -403,7 +407,10 @@ class TestBindProviderDetection:
         forward_args = mock_forward.call_args.args
         assert forward_args[1:] == (100, 42, "@5", "ls -la", "shell")
         assert forward_args[0].bot is context.bot
-        assert mock_forward.call_args.kwargs == {"is_existing_window": True}
+        assert mock_forward.call_args.kwargs == {
+            "is_existing_window": True,
+            "chat_id": -100999,
+        }
 
 
 class TestForwardPendingText:
@@ -418,7 +425,7 @@ class TestForwardPendingText:
                 new_callable=AsyncMock,
             ) as mock_shell,
             patch(
-                "ccgram.handlers.topics.window_callbacks.send_to_window",
+                "ccgram.handlers.topics.window_callbacks.send_telegram_to_window",
                 new_callable=AsyncMock,
                 return_value=(True, ""),
             ) as mock_send,
@@ -428,7 +435,7 @@ class TestForwardPendingText:
             )
 
         mock_shell.assert_not_awaited()
-        mock_send.assert_called_once_with("@5", "list files")
+        mock_send.assert_called_once_with(1, "@5", 42, "list files", None)
 
     async def test_new_shell_window_routes_through_handler(self) -> None:
         from ccgram.handlers.topics.window_callbacks import _forward_pending_text

--- a/tests/ccgram/handlers/topics/test_window_launch_service.py
+++ b/tests/ccgram/handlers/topics/test_window_launch_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -528,7 +528,7 @@ class TestLaunchWindowSuccess:
             ) as mock_reg,
             patch("ccgram.providers.resolve_launch_command", return_value="claude"),
             patch(
-                "ccgram.handlers.topics.window_launch_service.send_to_window",
+                "ccgram.handlers.topics.window_launch_service.send_telegram_to_window",
                 new_callable=AsyncMock,
                 return_value=(True, "ok"),
             ) as mock_send,
@@ -566,6 +566,6 @@ class TestLaunchWindowSuccess:
                 ),
             )
 
-        mock_send.assert_awaited_once_with("@5", "hello agent")
+        mock_send.assert_awaited_once_with(100, "@5", 42, "hello agent", ANY)
         # Keys consumed after forwarding
         assert PENDING_THREAD_TEXT not in user_data

--- a/tests/ccgram/handlers/voice/test_voice_handler.py
+++ b/tests/ccgram/handlers/voice/test_voice_handler.py
@@ -357,7 +357,7 @@ class TestHandleVoiceMessage:
 
 
 class TestHandleVoiceCallback:
-    @patch(f"{_VC}.send_to_window", new_callable=AsyncMock)
+    @patch(f"{_VC}.send_telegram_to_window", new_callable=AsyncMock)
     @patch(f"{_VC}.thread_router")
     @patch(f"{_VC}.get_thread_id")
     async def test_send_success(
@@ -382,7 +382,9 @@ class TestHandleVoiceCallback:
 
         await voice_callbacks.handle_voice_callback(update, context)
 
-        mock_send_to_window.assert_called_once_with("@0", "hello")
+        mock_send_to_window.assert_called_once_with(
+            100, "@0", 42, "hello", update.callback_query.message.chat.id
+        )
         update.callback_query.message.delete.assert_called_once()
         # Toast replaced with persistent reactions: 👀 on receive, 🔥 on delivery.
         update.callback_query.answer.assert_called_once_with()
@@ -395,7 +397,7 @@ class TestHandleVoiceCallback:
         assert "🔥" in emojis
         assert (999, 42) not in context.user_data.get(VOICE_PENDING, {})
 
-    @patch(f"{_VC}.send_to_window", new_callable=AsyncMock)
+    @patch(f"{_VC}.send_telegram_to_window", new_callable=AsyncMock)
     @patch(f"{_VC}.thread_router")
     @patch(f"{_VC}.get_thread_id")
     async def test_send_success_delete_fails(
@@ -539,7 +541,7 @@ class TestHandleVoiceCallback:
             pytest.param("window not found", id="window_not_found"),
         ],
     )
-    @patch(f"{_VC}.send_to_window", new_callable=AsyncMock)
+    @patch(f"{_VC}.send_telegram_to_window", new_callable=AsyncMock)
     @patch(f"{_VC}.thread_router")
     @patch(f"{_VC}.get_thread_id")
     async def test_send_failure_preserves_pending(
@@ -586,7 +588,7 @@ class TestHandleVoiceCallback:
         update.callback_query.answer.assert_called_once_with("Invalid callback data")
 
     @patch(f"{_VC}.ack_reaction", new_callable=AsyncMock)
-    @patch(f"{_VC}.send_to_window", new_callable=AsyncMock)
+    @patch(f"{_VC}.send_telegram_to_window", new_callable=AsyncMock)
     @patch(f"{_VC}.get_provider_for_window")
     @patch(f"{_VC}.thread_router")
     @patch(f"{_VC}.get_thread_id")
@@ -632,7 +634,7 @@ class TestHandleVoiceCallback:
         update.callback_query.answer.assert_called_once_with()
         mock_ack.assert_called_once()
 
-    @patch(f"{_VC}.send_to_window", new_callable=AsyncMock)
+    @patch(f"{_VC}.send_telegram_to_window", new_callable=AsyncMock)
     @patch(f"{_VC}.get_provider_for_window")
     @patch(f"{_VC}.thread_router")
     @patch(f"{_VC}.get_thread_id")

--- a/tests/ccgram/test_error_handler.py
+++ b/tests/ccgram/test_error_handler.py
@@ -5,9 +5,21 @@ import io
 import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from telegram.error import BadRequest, Conflict, NetworkError, TelegramError
 
-from ccgram.bot import _error_handler, _send_shutdown_notification
+from ccgram.bot import (
+    _error_handler,
+    _record_successful_poll,
+    _reset_polling_conflict_state,
+    _send_shutdown_notification,
+    polling_conflict_requires_restart,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_conflict_state() -> None:
+    _reset_polling_conflict_state()
 
 
 def _make_context(error: BaseException) -> MagicMock:
@@ -65,16 +77,43 @@ class TestErrorHandlerStaleCallback:
 
         mock_logger.error.assert_called_once()
 
-    async def test_conflict_triggers_shutdown(self) -> None:
+    async def test_conflict_retries_during_grace_period(self) -> None:
         ctx = _make_context(Conflict("409 Conflict"))
 
         with (
-            patch("ccgram.bot.logger"),
-            patch("ccgram.bot.os.kill") as mock_kill,
+            patch("ccgram.bot.logger") as mock_logger,
+            patch("ccgram.bot.time.monotonic", return_value=100.0),
         ):
             await _error_handler(None, ctx)
 
-        mock_kill.assert_called_once()
+        ctx.application.stop_running.assert_not_called()
+        assert polling_conflict_requires_restart() is False
+        mock_logger.warning.assert_called_once()
+
+    async def test_sustained_conflict_stops_for_supervisor_restart(self) -> None:
+        ctx = _make_context(Conflict("409 Conflict"))
+
+        with (
+            patch("ccgram.bot.logger") as mock_logger,
+            patch("ccgram.bot.time.monotonic", side_effect=[100.0, 190.0]),
+        ):
+            await _error_handler(None, ctx)
+            await _error_handler(None, ctx)
+
+        ctx.application.stop_running.assert_called_once()
+        assert polling_conflict_requires_restart() is True
+        mock_logger.critical.assert_called_once()
+
+    async def test_successful_poll_resets_conflict_grace_period(self) -> None:
+        ctx = _make_context(Conflict("409 Conflict"))
+
+        with patch("ccgram.bot.time.monotonic", side_effect=[100.0, 1_000.0]):
+            await _error_handler(None, ctx)
+            _record_successful_poll()
+            await _error_handler(None, ctx)
+
+        ctx.application.stop_running.assert_not_called()
+        assert polling_conflict_requires_restart() is False
 
 
 class TestShutdownNotification:

--- a/tests/ccgram/test_error_handler.py
+++ b/tests/ccgram/test_error_handler.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from telegram.error import BadRequest, Conflict, NetworkError, TelegramError
+from telegram.request import HTTPXRequest
 
 from ccgram.bot import (
     _error_handler,
@@ -15,6 +16,7 @@ from ccgram.bot import (
     _send_shutdown_notification,
     polling_conflict_requires_restart,
 )
+from ccgram.telegram_request import ResilientPollingHTTPXRequest
 
 
 @pytest.fixture(autouse=True)
@@ -114,6 +116,27 @@ class TestErrorHandlerStaleCallback:
 
         ctx.application.stop_running.assert_not_called()
         assert polling_conflict_requires_restart() is False
+
+    async def test_raw_conflicts_accumulate_until_shutdown(self) -> None:
+        request = ResilientPollingHTTPXRequest(on_success=_record_successful_poll)
+        response = (
+            409,
+            b'{"ok": false, "error_code": 409, "description": "Conflict"}',
+        )
+        ctx = _make_context(Conflict("placeholder"))
+
+        with (
+            patch.object(HTTPXRequest, "do_request", AsyncMock(return_value=response)),
+            patch("ccgram.bot.time.monotonic", side_effect=[100.0, 190.0]),
+        ):
+            for _ in range(2):
+                with pytest.raises(Conflict) as raised:
+                    await request.post("https://example.com")
+                ctx.error = raised.value
+                await _error_handler(None, ctx)
+
+        ctx.application.stop_running.assert_called_once()
+        assert polling_conflict_requires_restart() is True
 
 
 class TestShutdownNotification:

--- a/tests/ccgram/test_main.py
+++ b/tests/ccgram/test_main.py
@@ -1,0 +1,31 @@
+"""Tests for process exit behavior after bot polling stops."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ccgram.main import run_bot
+
+
+def test_run_bot_exits_nonzero_after_sustained_polling_conflict() -> None:
+    config = MagicMock(
+        allowed_users=set(),
+        claude_projects_path="/tmp/claude",
+        multiplexer_name="herdr",
+    )
+    application = MagicMock()
+
+    with (
+        patch.dict(os.environ, {"TMUX_SESSION_NAME": "test"}),
+        patch("ccgram.main.setup_logging"),
+        patch("ccgram.config.config", config),
+        patch("ccgram.bot.create_bot", return_value=application),
+        patch("ccgram.bot.polling_conflict_requires_restart", return_value=True),
+        patch("ccgram.main._install_signal_handlers"),
+        pytest.raises(SystemExit, match="1") as exc_info,
+    ):
+        run_bot()
+
+    assert exc_info.value.code == 1
+    application.run_polling.assert_called_once()

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -163,7 +163,7 @@ class TestFindUsersForSession:
         thread_router.bind_thread(100, 1, "@1")
         mgr.window_states["@1"] = self._ws("sid-1")
         result = session_resolver.find_users_for_session("sid-1")
-        assert result == [(100, "@1", 1)]
+        assert result == [(100, "@1", 1, None)]
 
     def test_no_match_returns_empty(self, mgr: SessionManager) -> None:
         thread_router.bind_thread(100, 1, "@1")

--- a/tests/ccgram/test_telegram_request.py
+++ b/tests/ccgram/test_telegram_request.py
@@ -49,6 +49,15 @@ class TestResilientPollingHTTPXRequest:
         assert old_client.is_closed
         assert not request._client.is_closed
 
+    async def test_calls_success_callback_after_successful_request(self) -> None:
+        on_success = MagicMock()
+        request = ResilientPollingHTTPXRequest(on_success=on_success)
+
+        with patch.object(HTTPXRequest, "do_request", AsyncMock(return_value=b"ok")):
+            assert await request.do_request("https://example.com", "POST") == b"ok"
+
+        on_success.assert_called_once()
+
 
 def _reset_log_calls(mock_logger, level: str) -> list:
     return [

--- a/tests/ccgram/test_telegram_request.py
+++ b/tests/ccgram/test_telegram_request.py
@@ -5,7 +5,7 @@ import tomllib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from telegram.error import NetworkError, TimedOut
+from telegram.error import Conflict, NetworkError, TimedOut
 from telegram.request import HTTPXRequest
 
 from ccgram.bot import create_bot
@@ -49,14 +49,31 @@ class TestResilientPollingHTTPXRequest:
         assert old_client.is_closed
         assert not request._client.is_closed
 
-    async def test_calls_success_callback_after_successful_request(self) -> None:
+    async def test_calls_success_callback_after_successful_api_response(self) -> None:
         on_success = MagicMock()
         request = ResilientPollingHTTPXRequest(on_success=on_success)
+        response = (200, b'{"ok": true, "result": []}')
 
-        with patch.object(HTTPXRequest, "do_request", AsyncMock(return_value=b"ok")):
-            assert await request.do_request("https://example.com", "POST") == b"ok"
+        with patch.object(HTTPXRequest, "do_request", AsyncMock(return_value=response)):
+            assert await request.post("https://example.com") == []
 
         on_success.assert_called_once()
+
+    async def test_conflict_does_not_call_success_callback(self) -> None:
+        on_success = MagicMock()
+        request = ResilientPollingHTTPXRequest(on_success=on_success)
+        response = (
+            409,
+            b'{"ok": false, "error_code": 409, "description": "Conflict"}',
+        )
+
+        with (
+            patch.object(HTTPXRequest, "do_request", AsyncMock(return_value=response)),
+            pytest.raises(Conflict),
+        ):
+            await request.post("https://example.com")
+
+        on_success.assert_not_called()
 
 
 def _reset_log_calls(mock_logger, level: str) -> list:
@@ -102,20 +119,36 @@ class TestResetWarningRateLimit:
 
     async def test_success_resets_warn_eligibility(self) -> None:
         request = ResilientPollingHTTPXRequest()
-        sentinel = object()
-        mock = AsyncMock(side_effect=[TimedOut("t"), sentinel, TimedOut("t")])
+        response = (200, b'{"ok": true, "result": []}')
+        mock = AsyncMock(side_effect=[TimedOut("t"), response, TimedOut("t")])
 
         with (
             patch.object(HTTPXRequest, "do_request", mock),
             patch("ccgram.telegram_request.logger") as mock_logger,
         ):
             with pytest.raises(TimedOut):
-                await request.do_request("u", "POST")
-            await request.do_request("u", "POST")
+                await request.post("u")
+            await request.post("u")
             with pytest.raises(TimedOut):
-                await request.do_request("u", "POST")
+                await request.post("u")
 
         assert len(_reset_log_calls(mock_logger, "warning")) == 2
+
+    async def test_first_reset_warns_before_monotonic_interval(self) -> None:
+        request = ResilientPollingHTTPXRequest()
+        with (
+            patch.object(
+                HTTPXRequest,
+                "do_request",
+                AsyncMock(side_effect=TimedOut("t")),
+            ),
+            patch("ccgram.telegram_request.time.monotonic", return_value=1.0),
+            patch("ccgram.telegram_request.logger") as mock_logger,
+            pytest.raises(TimedOut),
+        ):
+            await request.do_request("https://example.com", "POST")
+
+        assert len(_reset_log_calls(mock_logger, "warning")) == 1
 
 
 class TestCreateBotPollingRequest:

--- a/tests/ccgram/test_thread_router.py
+++ b/tests/ccgram/test_thread_router.py
@@ -194,6 +194,42 @@ class TestToDictRoundtrip:
         assert router.get_window_for_thread(100, 1) is None
 
 
+class TestChatScopedBindings:
+    def test_same_user_can_bind_same_thread_id_in_two_chats(
+        self, router: ThreadRouter
+    ) -> None:
+        router.bind_thread(100, 7, "@a", window_name="a", chat_id=-1001)
+        router.bind_thread(100, 7, "@b", window_name="b", chat_id=-1002)
+
+        assert router.get_window_for_chat_thread(-1001, 7) == "@a"
+        assert router.get_window_for_chat_thread(-1002, 7) == "@b"
+        assert router.resolve_window_for_thread(100, 7, -1001) == "@a"
+        assert router.resolve_window_for_thread(100, 7, -1002) == "@b"
+        assert {binding[2] for binding in router.iter_thread_bindings()} == {"@a", "@b"}
+
+    def test_chatless_lookup_refuses_legacy_scoped_collision(
+        self, router: ThreadRouter
+    ) -> None:
+        router.bind_thread(100, 7, "@legacy")
+        router.bind_thread(100, 7, "@scoped", chat_id=-1001)
+
+        assert router.get_window_for_thread(100, 7) is None
+        assert router.get_window_for_thread(100, 7, -1001) == "@scoped"
+
+    def test_chat_scoped_bindings_survive_round_trip(
+        self, router: ThreadRouter
+    ) -> None:
+        router.bind_thread(100, 7, "@a", chat_id=-1001)
+        restored = ThreadRouter(
+            schedule_save=lambda: None,
+            has_window_state=lambda _wid: False,
+        )
+        restored.from_dict(router.to_dict())
+
+        assert restored.get_window_for_chat_thread(-1001, 7) == "@a"
+        assert list(restored.iter_thread_bindings()) == [(100, 7, "@a")]
+
+
 class TestReset:
     def test_reset_clears_all(self, router: ThreadRouter) -> None:
         router.bind_thread(100, 1, "@1", window_name="proj")

--- a/tests/ccgram/test_topic_mapping.py
+++ b/tests/ccgram/test_topic_mapping.py
@@ -171,10 +171,10 @@ class TestHerdrSessionRouting:
         )
 
         assert session_resolver.find_users_for_session("sess-A") == [
-            (100, target_a, 11)
+            (100, target_a, 11, None)
         ]
         assert session_resolver.find_users_for_session("sess-B") == [
-            (100, target_b, 12)
+            (100, target_b, 12, None)
         ]
 
     def test_binding_is_keyed_per_session_target(self, mgr: SessionManager) -> None:
@@ -203,6 +203,6 @@ class TestHerdrSessionRouting:
         )
 
         threads_for_a = {
-            t for _, _, t in session_resolver.find_users_for_session("sess-A")
+            t for _, _, t, _ in session_resolver.find_users_for_session("sess-A")
         }
         assert threads_for_a == {11}

--- a/tests/integration/test_message_dispatch.py
+++ b/tests/integration/test_message_dispatch.py
@@ -7,7 +7,7 @@ external dependencies (Bot API, TmuxManager, SessionManager).
 
 import os
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from telegram import Chat, Message, MessageEntity, Update, User
@@ -195,7 +195,7 @@ async def test_new_command_forwarded(app) -> None:
             return_value=MagicMock(window_id="@0"),
         ),
         patch(
-            "ccgram.handlers.commands.forward.send_to_window",
+            "ccgram.handlers.commands.forward.send_telegram_to_window",
             new_callable=AsyncMock,
             return_value=(True, "Sent"),
         ) as mock_send,
@@ -208,7 +208,7 @@ async def test_new_command_forwarded(app) -> None:
     ):
         await app.process_update(update)
 
-    mock_send.assert_awaited_once_with("@0", "/new")
+    mock_send.assert_awaited_once_with(12345, "@0", 42, "/new", ANY)
 
 
 async def test_unknown_command_forwarded(app) -> None:
@@ -229,7 +229,7 @@ async def test_unknown_command_forwarded(app) -> None:
             return_value=MagicMock(window_id="@0"),
         ),
         patch(
-            "ccgram.handlers.commands.forward.send_to_window",
+            "ccgram.handlers.commands.forward.send_telegram_to_window",
             new_callable=AsyncMock,
             return_value=(True, "Sent"),
         ),

--- a/tests/integration/test_shell_flow.py
+++ b/tests/integration/test_shell_flow.py
@@ -5,7 +5,7 @@ and relay back to Telegram. Uses mock bot + mock tmux with real
 shell_commands/shell_capture logic.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from telegram import Bot, Message
@@ -76,7 +76,9 @@ class TestRawCommandFlow:
                 bot, TEST_USER_ID, TEST_THREAD_ID, TEST_WINDOW_ID, "!ls -la", message
             )
 
-            mock_send.assert_called_once_with(TEST_WINDOW_ID, "ls -la", raw=True)
+            mock_send.assert_called_once_with(
+                TEST_USER_ID, TEST_WINDOW_ID, TEST_THREAD_ID, "ls -la", ANY, raw=True
+            )
             mock_mark.assert_called_once()
             args = mock_mark.call_args.args
             assert args[:4] == (
@@ -250,7 +252,12 @@ class TestLlmCommandFlow:
             )
 
             mock_send.assert_called_once_with(
-                TEST_WINDOW_ID, "find . -name foo", raw=True
+                TEST_USER_ID,
+                TEST_WINDOW_ID,
+                TEST_THREAD_ID,
+                "find . -name foo",
+                TEST_CHAT_ID,
+                raw=True,
             )
             mock_mark.assert_called_once()
 

--- a/tests/integration/test_toolbar_dispatch.py
+++ b/tests/integration/test_toolbar_dispatch.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from telegram import CallbackQuery, Chat, Message, Update, User
@@ -217,15 +217,19 @@ class TestDispatchRoundTrip:
             patch(
                 "ccgram.handlers.toolbar.toolbar_callbacks.tmux_manager"
             ) as mock_tmux,
+            patch(
+                "ccgram.handlers.toolbar.toolbar_callbacks.send_telegram_to_window",
+                new_callable=AsyncMock,
+                return_value=(True, "ok"),
+            ) as mock_send,
             patch.object(CallbackQuery, "answer", new_callable=AsyncMock),
         ):
             mock_tmux.find_window_by_id = AsyncMock(
                 return_value=MagicMock(window_id=TEST_WINDOW_ID)
             )
-            mock_tmux.send_keys = AsyncMock()
             await app.process_update(update)
-        mock_tmux.send_keys.assert_awaited_once_with(
-            TEST_WINDOW_ID, "/clear", enter=True, literal=True
+        mock_send.assert_awaited_once_with(
+            TEST_USER_ID, TEST_WINDOW_ID, TEST_THREAD_ID, "/clear", ANY
         )
 
     async def test_builtin_ctrlc_dispatched(self, app: Application) -> None:
@@ -340,15 +344,19 @@ class TestCustomConfigDispatch:
             patch(
                 "ccgram.handlers.toolbar.toolbar_callbacks.tmux_manager"
             ) as mock_tmux,
+            patch(
+                "ccgram.handlers.toolbar.toolbar_callbacks.send_telegram_to_window",
+                new_callable=AsyncMock,
+                return_value=(True, "ok"),
+            ) as mock_send,
             patch.object(CallbackQuery, "answer", new_callable=AsyncMock),
         ):
             mock_tmux.find_window_by_id = AsyncMock(
                 return_value=MagicMock(window_id=TEST_WINDOW_ID)
             )
-            mock_tmux.send_keys = AsyncMock()
             await app.process_update(update)
-        mock_tmux.send_keys.assert_awaited_once_with(
-            TEST_WINDOW_ID, "/summary", enter=True, literal=True
+        mock_send.assert_awaited_once_with(
+            TEST_USER_ID, TEST_WINDOW_ID, TEST_THREAD_ID, "/summary", ANY
         )
 
     async def test_user_overrides_builtin_via_config(self, app: Application) -> None:


### PR DESCRIPTION
## Summary

Fixes three original Telegram reliability issues (#141, #142, #143), plus a comprehensive multi-chat session isolation overhaul uncovered during deep review.

### Issues fixed

- **#141** Replace invalid U+200B topic existence probes with a valid deletable message so same-name topic rebinding and /sync dead-topic detection work correctly.
- **#142** Retry transient Telegram polling conflicts for up to 90 seconds (resetting after a confirmed successful poll), then exit non-zero so `Restart=on-failure` recovers the service. archfit CI pinned to v1.6.0.
- **#143** Suppress Telegram-originated terminal input from being relayed back as a transcript echo, while preserving terminal-originated user input. Origin correlation is now keyed by `(user, chat, window, thread)`.

### Multi-chat identity (discovered during code review)

- **ThreadRouter**: new `chat_thread_bindings` index for chat-local topic identity, with serialization, reverse-index cleanup on rebind, and `iter_thread_bindings_with_chat()`
- **Session resolver**: `find_users_for_session` returns `chat_id` alongside `(user, window, thread)`
- **Message queue**: merge guard now compares `thread_id` and `chat_id`; merged `ContentTask` preserves `chat_id` through delivery
- **Polling**: `chat_scope` wraps each window tick so `resolve_chat_id` uses the known chat
- **Topic lifecycle**: probe/unbind/autoclose use scoped chat identity
- **All Telegram-to-terminal injection paths**: chat context threaded through text, commands, followup, shell, toolbar, voice, file, status recall, and topic launch/bind/recovery
- **Callback authorization**: `user_owns_window` accepts `chat_id`; screenshot, ESC, and key callbacks use it
- **Cleanup/unbind**: `clear_topic_state` and `unbind_thread` carry `chat_id`

### Verification

- `uv run ruff format --check` ✅
- `uv run ruff check` ✅
- `uv run pyright` ✅ (0 errors)
- Lazy-import lint ✅
- archfit v1.6 gate ✅
- 6033 unit tests ✅
- 309 non-LLM integration tests ✅
- Pre-push architecture boundary gate (813 tests) ✅

Closes #141
Closes #142
Closes #143