### PR TITLE
feat(herdr): bind Antigravity sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,14 @@ Open your Telegram group, create a topic, send a message — directory browser a
 
 ### Herdr setup
 
-CCGram supports Herdr socket protocols **14, 15, 16, and 17**. For Pi agents, install Herdr's integration before launching the agent:
+CCGram supports Herdr socket protocols **14–17 and 19**. Install Herdr's integration before launching an agent that needs a native session identity:
 
 ```bash
 herdr integration install pi
+herdr integration install antigravity-cli
 ```
+
+Restart an already-running agent after installation. Antigravity receives a native Herdr session identity after its first prompt creates a conversation.
 
 Start new agents, or restart already-running agents, after installing the integration so they publish their `agent_session` identity. Then set `CCGRAM_MULTIPLEXER=herdr` and run `ccgram hook --install` as usual.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ Generated from code state 2026-05-21.
 
 ## Herdr compatibility
 
-The Herdr adapter accepts socket protocols 14–17 without warnings and continues best-effort for other versions. Pi requires `herdr integration install pi`; agents must be started or restarted after installation to load the integration and publish their `agent_session` identity.
+The Herdr adapter accepts socket protocols 14–17 and 19 without warnings and continues best-effort for other versions. Pi requires `herdr integration install pi`; Antigravity requires `herdr integration install antigravity-cli`. Agents must be started or restarted after installation to load the integration and publish their `agent_session` identity. Antigravity reports its identity after the first prompt creates a conversation.
 
 ## System Overview
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -316,6 +316,16 @@ Transcript brain directories are discovered in order:
 
 CCGram parses structured workspace fields and local `file://` URIs, decodes percent escapes, and compares normalized paths (`Path.expanduser().resolve()`) for exact equality. Sibling and descendant paths never match the topic's target working directory (`cwd`).
 
+### Herdr integration
+
+With `CCGRAM_MULTIPLEXER=herdr`, install Herdr's native Antigravity integration before launching `agy`:
+
+```bash
+herdr integration install antigravity-cli
+```
+
+Herdr reports the real conversation ID after the first prompt creates it. CCGram binds the topic only after that report; if no report arrives, it closes the new tab rather than storing a transient pane ID. Restart already-running `agy` sessions after installing the integration.
+
 ### Resume and Continue
 
 - **Resume**: Uses `agy --conversation <session_id>` (plus `--dangerously-skip-permissions` in YOLO mode).

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -12,7 +12,8 @@ Core responsibilities:
 from __future__ import annotations
 
 import asyncio
-from contextlib import asynccontextmanager
+from collections.abc import Iterator
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 import time
 from pathlib import Path
@@ -144,16 +145,15 @@ _pending_creation_transactions: set[object] = set()
 _PENDING_CREATION_TTL_S = 30.0
 
 
-def begin_pending_creation_transaction() -> object:
+@contextmanager
+def pending_creation_transaction() -> Iterator[None]:
     """Block auto-adoption until a new target has a durable ID."""
     token = object()
     _pending_creation_transactions.add(token)
-    return token
-
-
-def end_pending_creation_transaction(token: object) -> None:
-    """Release a creation transaction (idempotent)."""
-    _pending_creation_transactions.discard(token)
+    try:
+        yield
+    finally:
+        _pending_creation_transactions.discard(token)
 
 
 def register_pending_creation(window_id: str) -> None:

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -140,7 +140,20 @@ def _is_window_already_bound(window_id: str) -> bool:
 # 30s TTL is the safety net in case directory_callbacks crashes before
 # clearing the entry — handle_new_window will eventually reclaim the window.
 _pending_user_creations: dict[str, float] = {}
+_pending_creation_transactions: set[object] = set()
 _PENDING_CREATION_TTL_S = 30.0
+
+
+def begin_pending_creation_transaction() -> object:
+    """Block auto-adoption until a new target has a durable ID."""
+    token = object()
+    _pending_creation_transactions.add(token)
+    return token
+
+
+def end_pending_creation_transaction(token: object) -> None:
+    """Release a creation transaction (idempotent)."""
+    _pending_creation_transactions.discard(token)
 
 
 def register_pending_creation(window_id: str) -> None:
@@ -166,6 +179,8 @@ def _is_pending_user_creation(window_id: str) -> bool:
     Expired entries are evicted lazily on read so a crashed directory flow
     can't permanently shadow a window from auto-topic-creation.
     """
+    if _pending_creation_transactions:
+        return True
     expires_at = _pending_user_creations.get(window_id)
     if expires_at is None:
         return False

--- a/src/ccgram/handlers/topics/window_launch_service.py
+++ b/src/ccgram/handlers/topics/window_launch_service.py
@@ -133,9 +133,11 @@ async def _create_topic_window(
     selected_path: str,
     launch_command: str | None,
     chosen_workspace_id: str | None,
+    provider_name: str,
+    initial_input: str | None,
     context: ContextTypes.DEFAULT_TYPE,
-) -> tuple[bool, str, str, str]:
-    """Create the topic's window, returning ``(success, message, name, id)``.
+) -> tuple[bool, str, str, str, bool]:
+    """Create the topic's window, returning ``(success, message, name, id, sent)``.
 
     Native worktree delegation (herdr): when the flow carries a pending worktree
     intent, one ``worktree create`` makes the checkout + grouped workspace + the
@@ -150,35 +152,48 @@ async def _create_topic_window(
         # The native worktree API cannot pin a preselected workspace.  Creating
         # into an implicit workspace would violate the user's selection.
         if chosen_workspace_id:
-            return False, "Selected workspace cannot create a native worktree", "", ""
-        return await tmux_manager.create_worktree_window(
+            return (
+                False,
+                "Selected workspace cannot create a native worktree",
+                "",
+                "",
+                False,
+            )
+        success, message, name, window_id = await tmux_manager.create_worktree_window(
             wt_repo,
             wt_path,
             wt_branch,
             window_name=Path(wt_path).name,
             launch_command=launch_command,
         )
+        return success, message, name, window_id, False
     # Tmux preserves its long-standing creation behavior. Herdr's native
     # agent-status capability selects the guarded-session creation transaction.
     if tmux_manager.capabilities.native_agent_status is not True:
-        return await tmux_manager.create_window(
+        success, message, name, window_id = await tmux_manager.create_window(
             selected_path,
             launch_command=launch_command,
             workspace_id=chosen_workspace_id,
         )
+        return success, message, name, window_id, False
     try:
+        send_initial_input = (
+            provider_name == "antigravity" and initial_input is not None
+        )
         target = await tmux_manager.create_topic_target(
             selected_path,
             launch_command=launch_command,
             workspace_id=chosen_workspace_id,
+            initial_input=initial_input if send_initial_input else None,
         )
     except RuntimeError as exc:
-        return False, str(exc), "", ""
+        return False, str(exc), "", "", False
     return (
         True,
         f"Created topic target '{target.label}'",
         target.label,
         target.target_id,
+        send_initial_input,
     )
 
 
@@ -260,8 +275,19 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         context.user_data.get(PENDING_WORKSPACE_ID) if context.user_data else None
     ) or None
 
-    success, message, created_wname, created_wid = await _create_topic_window(
-        selected_path, launch_command, chosen_workspace_id, context
+    (
+        success,
+        message,
+        created_wname,
+        created_wid,
+        initial_input_sent,
+    ) = await _create_topic_window(
+        selected_path,
+        launch_command,
+        chosen_workspace_id,
+        provider_name,
+        request.pending_text,
+        context,
     )
     if not success:
         await _abort_topic_creation(query, message, context)
@@ -386,7 +412,7 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         f"✅ {message}\n\nBound to this topic. Send messages here.",
     )
 
-    pending_text = request.pending_text
+    pending_text = None if initial_input_sent else request.pending_text
     if pending_text:
         logger.debug(
             "Forwarding pending text to window %s (len=%d)",

--- a/src/ccgram/handlers/topics/window_launch_service.py
+++ b/src/ccgram/handlers/topics/window_launch_service.py
@@ -4,9 +4,8 @@ Extracts the launch sequence from directory_callbacks._create_window_and_bind
 into a self-contained service module.  Callers build a ``WindowLaunchRequest``
 and call ``launch_window``; the result is a ``WindowLaunchResult``.
 
-CRITICAL ordering invariant (MC-2967):
-  create_window() → register_pending_creation(window_id)
-  must have NO await between them.  See the inline comment for full context.
+Creation is protected by a transaction guard until the durable target is
+registered. This keeps the SessionMonitor from adopting it before binding.
 """
 
 from __future__ import annotations
@@ -266,8 +265,7 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         context.user_data.get(PENDING_WORKSPACE_ID) if context.user_data else None
     ) or None
 
-    creation_transaction = topic_orchestration.begin_pending_creation_transaction()
-    try:
+    with topic_orchestration.pending_creation_transaction():
         (
             success,
             message,
@@ -281,8 +279,6 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         )
         if success:
             topic_orchestration.register_pending_creation(created_wid)
-    finally:
-        topic_orchestration.end_pending_creation_transaction(creation_transaction)
 
     if not success:
         await _abort_topic_creation(query, message, context)

--- a/src/ccgram/handlers/topics/window_launch_service.py
+++ b/src/ccgram/handlers/topics/window_launch_service.py
@@ -133,11 +133,9 @@ async def _create_topic_window(
     selected_path: str,
     launch_command: str | None,
     chosen_workspace_id: str | None,
-    provider_name: str,
-    initial_input: str | None,
     context: ContextTypes.DEFAULT_TYPE,
-) -> tuple[bool, str, str, str, bool]:
-    """Create the topic's window, returning ``(success, message, name, id, sent)``.
+) -> tuple[bool, str, str, str]:
+    """Create the topic's window, returning ``(success, message, name, id)``.
 
     Native worktree delegation (herdr): when the flow carries a pending worktree
     intent, one ``worktree create`` makes the checkout + grouped workspace + the
@@ -157,7 +155,6 @@ async def _create_topic_window(
                 "Selected workspace cannot create a native worktree",
                 "",
                 "",
-                False,
             )
         success, message, name, window_id = await tmux_manager.create_worktree_window(
             wt_repo,
@@ -166,7 +163,7 @@ async def _create_topic_window(
             window_name=Path(wt_path).name,
             launch_command=launch_command,
         )
-        return success, message, name, window_id, False
+        return success, message, name, window_id
     # Tmux preserves its long-standing creation behavior. Herdr's native
     # agent-status capability selects the guarded-session creation transaction.
     if tmux_manager.capabilities.native_agent_status is not True:
@@ -175,25 +172,20 @@ async def _create_topic_window(
             launch_command=launch_command,
             workspace_id=chosen_workspace_id,
         )
-        return success, message, name, window_id, False
+        return success, message, name, window_id
     try:
-        send_initial_input = (
-            provider_name == "antigravity" and initial_input is not None
-        )
         target = await tmux_manager.create_topic_target(
             selected_path,
             launch_command=launch_command,
             workspace_id=chosen_workspace_id,
-            initial_input=initial_input if send_initial_input else None,
         )
     except RuntimeError as exc:
-        return False, str(exc), "", "", False
+        return False, str(exc), "", ""
     return (
         True,
         f"Created topic target '{target.label}'",
         target.label,
         target.target_id,
-        send_initial_input,
     )
 
 
@@ -254,11 +246,10 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
     Shared by _handle_mode_select (after mode picker) and _handle_provider_select
     (when mode picker is skipped for providers without YOLO flags).
 
-    CRITICAL (MC-2967): ``create_window`` → ``register_pending_creation(wid)``
-    must have NO await between them.  The provider's SessionStart hook fires
-    inside the new pane within seconds; the SessionMonitor's 1 s poll cycle would
-    otherwise see an unbound window and auto-create a duplicate Telegram topic
-    before ``bind_thread`` runs below.
+    CRITICAL (MC-2967): creation starts inside a global transaction guard,
+    then its durable target is registered before the transaction releases. This
+    prevents the SessionMonitor from auto-creating a topic while Herdr publishes
+    a session identity or before ``bind_thread`` runs below.
     """
     # Lazy: providers package heavy bootstrap
     from ccgram.providers import resolve_launch_command
@@ -275,30 +266,27 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         context.user_data.get(PENDING_WORKSPACE_ID) if context.user_data else None
     ) or None
 
-    (
-        success,
-        message,
-        created_wname,
-        created_wid,
-        initial_input_sent,
-    ) = await _create_topic_window(
-        selected_path,
-        launch_command,
-        chosen_workspace_id,
-        provider_name,
-        request.pending_text,
-        context,
-    )
+    creation_transaction = topic_orchestration.begin_pending_creation_transaction()
+    try:
+        (
+            success,
+            message,
+            created_wname,
+            created_wid,
+        ) = await _create_topic_window(
+            selected_path,
+            launch_command,
+            chosen_workspace_id,
+            context,
+        )
+        if success:
+            topic_orchestration.register_pending_creation(created_wid)
+    finally:
+        topic_orchestration.end_pending_creation_transaction(creation_transaction)
+
     if not success:
         await _abort_topic_creation(query, message, context)
         return WindowLaunchResult(success=False, error_message=message)
-
-    # Race-guard: tag this window as "directory flow in progress" BEFORE any
-    # subsequent await. The provider's SessionStart hook fires inside the new
-    # tmux pane within seconds; the SessionMonitor's 1s poll cycle would
-    # otherwise see an unbound window and auto-create a duplicate Telegram
-    # topic before bind_thread() runs below. See MC-2967 for full repro.
-    topic_orchestration.register_pending_creation(created_wid)
 
     user_preferences.update_user_mru(user_id, selected_path)
     session_manager.set_window_origin(created_wid, CCGRAM_CREATED_WINDOW_ORIGIN)
@@ -412,7 +400,7 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         f"✅ {message}\n\nBound to this topic. Send messages here.",
     )
 
-    pending_text = None if initial_input_sent else request.pending_text
+    pending_text = request.pending_text
     if pending_text:
         logger.debug(
             "Forwarding pending text to window %s (len=%d)",

--- a/src/ccgram/multiplexer/base.py
+++ b/src/ccgram/multiplexer/base.py
@@ -332,6 +332,7 @@ class Multiplexer(Protocol):
         workspace_id: str | None,
         window_name: str | None = None,
         agent_args: str = "",
+        initial_input: str | None = None,
     ) -> TopicTargetResult:
         """Create a topic target, pinned to an opaque selected workspace.
 

--- a/src/ccgram/multiplexer/base.py
+++ b/src/ccgram/multiplexer/base.py
@@ -332,7 +332,6 @@ class Multiplexer(Protocol):
         workspace_id: str | None,
         window_name: str | None = None,
         agent_args: str = "",
-        initial_input: str | None = None,
     ) -> TopicTargetResult:
         """Create a topic target, pinned to an opaque selected workspace.
 

--- a/src/ccgram/multiplexer/herdr.py
+++ b/src/ccgram/multiplexer/herdr.py
@@ -989,23 +989,6 @@ class HerdrManager:
             target.target_id,
         )
 
-    async def _await_agent_on_pane(self, pane_id: str) -> None:
-        """Wait until Herdr identifies the newly launched agent pane."""
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + _CREATED_SESSION_DISCOVERY_TIMEOUT_SECONDS
-        while True:
-            result = await self._call_json(["agent", "list"])
-            agents = result.get("agents") if result else None
-            if isinstance(agents, list) and any(
-                isinstance(agent, Mapping) and agent.get("pane_id") == pane_id
-                for agent in agents
-            ):
-                return
-            if loop.time() >= deadline:
-                break
-            await asyncio.sleep(_CREATED_SESSION_POLL_INTERVAL_SECONDS)
-        raise HerdrUnresolvedTargetError("new Herdr pane did not identify an agent")
-
     async def _await_created_session_target(
         self,
         *,

--- a/src/ccgram/multiplexer/herdr.py
+++ b/src/ccgram/multiplexer/herdr.py
@@ -147,7 +147,7 @@ _STREAM_REPRIME_INTERVAL = 5.0
 def _workspace_cwd_from_panes(
     workspace: Mapping[str, object], panes: Sequence[Mapping[str, object]]
 ) -> str | None:
-    """Return the active tab's sole pane CWD from a protocol-19 snapshot."""
+    """Return the active tab's shared stable CWD from a protocol-19 snapshot."""
     workspace_id = workspace.get("workspace_id")
     if not isinstance(workspace_id, str):
         return None
@@ -162,12 +162,23 @@ def _workspace_cwd_from_panes(
             else bool(pane.get("focused"))
         )
     ]
-    if len(candidates) != 1:
-        return None
-    candidate_cwd = candidates[0].get("foreground_cwd")
-    if not isinstance(candidate_cwd, str):
-        candidate_cwd = candidates[0].get("cwd")
-    return candidate_cwd if isinstance(candidate_cwd, str) else None
+
+    def shared_cwd(field: str) -> str | None:
+        cwd: str | None = None
+        for pane in candidates:
+            value = pane.get(field)
+            if not isinstance(value, str) or not value:
+                return None
+            if cwd is None:
+                cwd = value
+            elif cwd != value:
+                return None
+        return cwd
+
+    has_stable_cwd = any(
+        isinstance(pane.get("cwd"), str) and pane.get("cwd") for pane in candidates
+    )
+    return shared_cwd("cwd") if has_stable_cwd else shared_cwd("foreground_cwd")
 
 
 class HerdrError(RuntimeError):
@@ -1032,7 +1043,6 @@ class HerdrManager:
         workspace_id: str | None,
         window_name: str | None = None,
         agent_args: str = "",
-        initial_input: str | None = None,
     ) -> TopicTargetResult:
         """Create an agent tab and return its guarded session target.
 
@@ -1093,10 +1103,6 @@ class HerdrManager:
                 command = f"{launch_command} {agent_args}".strip()
                 if not await self._call_ok(["pane", "run", pane_id, command]):
                     raise HerdrError("Failed to start agent in Herdr tab")
-            if initial_input is not None:
-                await self._await_agent_on_pane(pane_id)
-                if not await self._call_ok(["pane", "run", pane_id, initial_input]):
-                    raise HerdrError("Failed to send initial agent message")
             record = await self._await_created_session_target(
                 tab_id=tab_id, pane_id=pane_id, workspace_id=workspace_id
             )

--- a/src/ccgram/multiplexer/herdr.py
+++ b/src/ccgram/multiplexer/herdr.py
@@ -87,9 +87,9 @@ __all__ = [
 logger = structlog.get_logger()
 
 # Supported herdr socket protocols (``herdr status`` → ``server.protocol``).
-# 14–17 are accepted without warnings. Other versions are attempted with a
-# warning so ccgram remains usable across herdr upgrades and downgrades.
-HERDR_SUPPORTED_PROTOCOLS = frozenset({14, 15, 16, 17})
+# 14–17 and 19 are supported. Other versions are attempted with a warning so
+# ccgram remains usable across herdr upgrades and downgrades.
+HERDR_SUPPORTED_PROTOCOLS = frozenset({14, 15, 16, 17, 19})
 HERDR_PROTOCOL_VERSION = max(HERDR_SUPPORTED_PROTOCOLS)
 
 # Static capability declaration for the herdr backend (design Task 7).
@@ -142,6 +142,32 @@ _STREAM_BACKOFF_MAX = 30.0
 # A live stream has no locator-change notification. Re-prime periodically so a
 # target that moved to another pane receives a fresh per-pane subscription.
 _STREAM_REPRIME_INTERVAL = 5.0
+
+
+def _workspace_cwd_from_panes(
+    workspace: Mapping[str, object], panes: Sequence[Mapping[str, object]]
+) -> str | None:
+    """Return the active tab's sole pane CWD from a protocol-19 snapshot."""
+    workspace_id = workspace.get("workspace_id")
+    if not isinstance(workspace_id, str):
+        return None
+    active_tab_id = workspace.get("active_tab_id")
+    candidates = [
+        pane
+        for pane in panes
+        if pane.get("workspace_id") == workspace_id
+        and (
+            pane.get("tab_id") == active_tab_id
+            if isinstance(active_tab_id, str)
+            else bool(pane.get("focused"))
+        )
+    ]
+    if len(candidates) != 1:
+        return None
+    candidate_cwd = candidates[0].get("foreground_cwd")
+    if not isinstance(candidate_cwd, str):
+        candidate_cwd = candidates[0].get("cwd")
+    return candidate_cwd if isinstance(candidate_cwd, str) else None
 
 
 class HerdrError(RuntimeError):
@@ -431,7 +457,11 @@ class HerdrManager:
         is_supported_protocol = (
             is_supported_protocol and proto in HERDR_SUPPORTED_PROTOCOLS
         )
-        if not is_supported_protocol or cli_server_compatible is False:
+        if cli_server_compatible is False:
+            raise HerdrProtocolError(
+                "Herdr client and server protocols are incompatible; restart Herdr"
+            )
+        if not is_supported_protocol:
             logger.warning(
                 "herdr protocol is unverified; continuing",
                 server_protocol=proto,
@@ -879,6 +909,7 @@ class HerdrManager:
         workspaces = result.get("workspaces") if result else None
         if not isinstance(workspaces, list):
             return []
+        panes: list[Mapping[str, object]] | None = None
         refs: list[WorkspaceRef] = []
         for workspace in workspaces:
             if not isinstance(workspace, Mapping):
@@ -890,9 +921,20 @@ class HerdrManager:
                 isinstance(workspace_id, str)
                 and workspace_id
                 and isinstance(label, str)
-                and isinstance(cwd, str)
             ):
                 return []
+            if not isinstance(cwd, str):
+                if panes is None:
+                    pane_result = await self._call_json(["pane", "list"])
+                    raw_panes = pane_result.get("panes") if pane_result else None
+                    if not isinstance(raw_panes, list) or not all(
+                        isinstance(pane, Mapping) for pane in raw_panes
+                    ):
+                        return []
+                    panes = raw_panes
+                cwd = _workspace_cwd_from_panes(workspace, panes)
+                if cwd is None:
+                    return []
             refs.append(WorkspaceRef(workspace_id, label, cwd))
         return refs
 
@@ -936,6 +978,23 @@ class HerdrManager:
             target.target_id,
         )
 
+    async def _await_agent_on_pane(self, pane_id: str) -> None:
+        """Wait until Herdr identifies the newly launched agent pane."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _CREATED_SESSION_DISCOVERY_TIMEOUT_SECONDS
+        while True:
+            result = await self._call_json(["agent", "list"])
+            agents = result.get("agents") if result else None
+            if isinstance(agents, list) and any(
+                isinstance(agent, Mapping) and agent.get("pane_id") == pane_id
+                for agent in agents
+            ):
+                return
+            if loop.time() >= deadline:
+                break
+            await asyncio.sleep(_CREATED_SESSION_POLL_INTERVAL_SECONDS)
+        raise HerdrUnresolvedTargetError("new Herdr pane did not identify an agent")
+
     async def _await_created_session_target(
         self,
         *,
@@ -973,6 +1032,7 @@ class HerdrManager:
         workspace_id: str | None,
         window_name: str | None = None,
         agent_args: str = "",
+        initial_input: str | None = None,
     ) -> TopicTargetResult:
         """Create an agent tab and return its guarded session target.
 
@@ -1033,6 +1093,10 @@ class HerdrManager:
                 command = f"{launch_command} {agent_args}".strip()
                 if not await self._call_ok(["pane", "run", pane_id, command]):
                     raise HerdrError("Failed to start agent in Herdr tab")
+            if initial_input is not None:
+                await self._await_agent_on_pane(pane_id)
+                if not await self._call_ok(["pane", "run", pane_id, initial_input]):
+                    raise HerdrError("Failed to send initial agent message")
             record = await self._await_created_session_target(
                 tab_id=tab_id, pane_id=pane_id, workspace_id=workspace_id
             )

--- a/src/ccgram/providers/antigravity.py
+++ b/src/ccgram/providers/antigravity.py
@@ -258,6 +258,39 @@ def _resolve_workspace_path(raw_path: str) -> str | None:
         return None
 
 
+def _read_last_conversations(brain_dir: Path) -> dict[str, str]:
+    """Return unambiguous exact workspace-to-conversation mappings."""
+    cache_file = brain_dir.parent / "cache" / "last_conversations.json"
+    try:
+        payload = json.loads(cache_file.read_text(encoding="utf-8"))
+    except OSError, json.JSONDecodeError, ValueError:
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+
+    conversations: dict[str, str] = {}
+    ambiguous_workspaces: set[str] = set()
+    for raw_cwd, raw_session_id in payload.items():
+        if not isinstance(raw_cwd, str) or not isinstance(raw_session_id, str):
+            continue
+        if RESUME_ID_RE.fullmatch(raw_session_id) is None:
+            continue
+        resolved_cwd = _resolve_workspace_path(raw_cwd)
+        if resolved_cwd is None or resolved_cwd in ambiguous_workspaces:
+            continue
+        previous = conversations.get(resolved_cwd)
+        if previous is not None and previous != raw_session_id:
+            conversations.pop(resolved_cwd, None)
+            ambiguous_workspaces.add(resolved_cwd)
+            continue
+        conversations[resolved_cwd] = raw_session_id
+    return conversations
+
+
+def _conversation_transcript(brain_dir: Path, session_id: str) -> Path:
+    return brain_dir / session_id / ".system_generated" / "logs" / "transcript.jsonl"
+
+
 def _read_antigravity_workspace_cwd(
     log_file: Path,
     *,
@@ -321,6 +354,62 @@ def _collect_brain_candidates(
         except OSError:
             continue
     return candidates
+
+
+def _cached_resumable_sessions(
+    brain_dir: Path,
+    resolved_cwd: str | None,
+    seen_ids: set[str],
+) -> list[tuple[float, ResumableSession]]:
+    sessions: list[tuple[float, ResumableSession]] = []
+    for workspace_cwd, session_id in _read_last_conversations(brain_dir).items():
+        if resolved_cwd is not None and workspace_cwd != resolved_cwd:
+            continue
+        if resolved_cwd is None and not Path(workspace_cwd).is_dir():
+            continue
+        log_file = _conversation_transcript(brain_dir, session_id)
+        try:
+            mtime = log_file.stat().st_mtime
+        except OSError:
+            continue
+        if session_id in seen_ids:
+            continue
+        seen_ids.add(session_id)
+        sessions.append(
+            (
+                mtime,
+                ResumableSession(
+                    session_id=session_id,
+                    summary=session_id[:12],
+                    cwd=workspace_cwd,
+                    provider_name="antigravity",
+                    mtime=mtime,
+                ),
+            )
+        )
+    return sessions
+
+
+def _mapped_transcript_candidate(
+    brain_dirs: list[Path],
+    resolved_cwd: str,
+    age_limit: float,
+    now: float,
+) -> tuple[bool, tuple[float, Path, str] | None]:
+    candidates: list[tuple[float, Path, str]] = []
+    for brain_dir in brain_dirs:
+        session_id = _read_last_conversations(brain_dir).get(resolved_cwd)
+        if session_id is None:
+            continue
+        log_file = _conversation_transcript(brain_dir, session_id)
+        try:
+            mtime = log_file.stat().st_mtime
+        except OSError:
+            continue
+        if age_limit > 0 and now - mtime > age_limit:
+            continue
+        candidates.append((mtime, log_file, session_id))
+    return len(candidates) > 1, candidates[0] if len(candidates) == 1 else None
 
 
 class AntigravityProvider(JsonlProvider):
@@ -389,6 +478,9 @@ class AntigravityProvider(JsonlProvider):
         candidates: list[tuple[float, ResumableSession]] = []
         seen_ids: set[str] = set()
         for brain_dir in get_antigravity_brain_dirs():
+            candidates.extend(
+                _cached_resumable_sessions(brain_dir, resolved_cwd, seen_ids)
+            )
             for mtime, log_file, session_id in _collect_brain_candidates(
                 brain_dir, 0, time.time()
             ):
@@ -426,7 +518,8 @@ class AntigravityProvider(JsonlProvider):
         max_age: float | None = None,
     ) -> SessionStartEvent | None:
         """Discover latest Antigravity CLI transcript on disk matching window."""
-        if not cwd:
+        resolved_cwd = _resolve_workspace_path(cwd) if cwd else None
+        if resolved_cwd is None:
             return None
 
         brain_dirs = get_antigravity_brain_dirs()
@@ -436,27 +529,32 @@ class AntigravityProvider(JsonlProvider):
         age_limit = _TRANSCRIPT_MAX_AGE_SECS if max_age is None else max_age
         now = time.time()
 
-        candidates: list[tuple[float, Path, str]] = []
-        for brain_dir in brain_dirs:
-            candidates.extend(_collect_brain_candidates(brain_dir, age_limit, now))
-
-        if not candidates:
+        ambiguous_mapping, selected = _mapped_transcript_candidate(
+            brain_dirs, resolved_cwd, age_limit, now
+        )
+        if ambiguous_mapping:
             return None
-
-        candidates.sort(reverse=True)
-        selected: tuple[float, Path, str] | None = None
-        for cand in candidates:
-            if _match_antigravity_cwd(cand[1], cwd):
-                selected = cand
-                break
         if selected is None:
-            return None
+            candidates: list[tuple[float, Path, str]] = []
+            for brain_dir in brain_dirs:
+                candidates.extend(_collect_brain_candidates(brain_dir, age_limit, now))
+            candidates.sort(reverse=True)
+            selected = next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if _match_antigravity_cwd(candidate[1], resolved_cwd)
+                ),
+                None,
+            )
+            if selected is None:
+                return None
 
         _, latest_file, session_id = selected
 
         return SessionStartEvent(
             session_id=session_id,
-            cwd=str(Path(cwd).resolve()),
+            cwd=resolved_cwd,
             transcript_path=str(latest_file),
             window_key=window_key,
         )

--- a/tests/ccgram/handlers/topics/test_pending_creation_race.py
+++ b/tests/ccgram/handlers/topics/test_pending_creation_race.py
@@ -18,9 +18,8 @@ from ccgram.handlers.topics.topic_orchestration import (  # noqa: E501
     _is_pending_user_creation,
     _pending_creation_transactions,
     _pending_user_creations,
-    begin_pending_creation_transaction,
     clear_pending_creation,
-    end_pending_creation_transaction,
+    pending_creation_transaction,
     handle_new_window,
     register_pending_creation,
 )
@@ -79,9 +78,14 @@ def test_clear_pending_creation_is_idempotent():
 
 
 def test_creation_transaction_defers_unbound_window_adoption():
-    token = begin_pending_creation_transaction()
-    assert _is_pending_user_creation("unrelated-window")
-    end_pending_creation_transaction(token)
+    with pending_creation_transaction():
+        assert _is_pending_user_creation("unrelated-window")
+    assert not _is_pending_user_creation("unrelated-window")
+
+
+def test_creation_transaction_releases_on_exception():
+    with pytest.raises(RuntimeError, match="launch failed"), pending_creation_transaction():
+        raise RuntimeError("launch failed")
     assert not _is_pending_user_creation("unrelated-window")
 
 

--- a/tests/ccgram/handlers/topics/test_pending_creation_race.py
+++ b/tests/ccgram/handlers/topics/test_pending_creation_race.py
@@ -84,7 +84,10 @@ def test_creation_transaction_defers_unbound_window_adoption():
 
 
 def test_creation_transaction_releases_on_exception():
-    with pytest.raises(RuntimeError, match="launch failed"), pending_creation_transaction():
+    with (
+        pytest.raises(RuntimeError, match="launch failed"),
+        pending_creation_transaction(),
+    ):
         raise RuntimeError("launch failed")
     assert not _is_pending_user_creation("unrelated-window")
 

--- a/tests/ccgram/handlers/topics/test_pending_creation_race.py
+++ b/tests/ccgram/handlers/topics/test_pending_creation_race.py
@@ -16,8 +16,11 @@ import pytest
 
 from ccgram.handlers.topics.topic_orchestration import (  # noqa: E501
     _is_pending_user_creation,
+    _pending_creation_transactions,
     _pending_user_creations,
+    begin_pending_creation_transaction,
     clear_pending_creation,
+    end_pending_creation_transaction,
     handle_new_window,
     register_pending_creation,
 )
@@ -28,8 +31,10 @@ from ccgram.session_monitor import NewWindowEvent
 @pytest.fixture(autouse=True)
 def _clear_pending_state():
     _pending_user_creations.clear()
+    _pending_creation_transactions.clear()
     yield
     _pending_user_creations.clear()
+    _pending_creation_transactions.clear()
 
 
 def _make_event(window_id: str = "@42") -> NewWindowEvent:
@@ -71,6 +76,13 @@ def test_pending_creation_expires_after_ttl(monkeypatch):
 
 def test_clear_pending_creation_is_idempotent():
     clear_pending_creation("@nonexistent")  # should not raise
+
+
+def test_creation_transaction_defers_unbound_window_adoption():
+    token = begin_pending_creation_transaction()
+    assert _is_pending_user_creation("unrelated-window")
+    end_pending_creation_transaction(token)
+    assert not _is_pending_user_creation("unrelated-window")
 
 
 def test_register_pending_creation_ignores_blank_window_id():

--- a/tests/ccgram/handlers/topics/test_window_launch_service.py
+++ b/tests/ccgram/handlers/topics/test_window_launch_service.py
@@ -221,6 +221,7 @@ class TestLaunchWindowSuccess:
 
         mock_mux.create_topic_target.assert_awaited_once()
         mock_tr.bind_thread.assert_called_once()
+        mock_orch.pending_creation_transaction.assert_called_once_with()
         mock_orch.register_pending_creation.assert_called_once_with("@5")
         mock_orch.clear_pending_creation.assert_called_once_with("@5")
         mock_edit.assert_awaited_once()

--- a/tests/ccgram/handlers/topics/test_window_launch_service.py
+++ b/tests/ccgram/handlers/topics/test_window_launch_service.py
@@ -495,8 +495,10 @@ class TestLaunchWindowSuccess:
         mock_edit.assert_awaited_once()
         assert "❌" in mock_edit.call_args[0][1]
 
-    async def test_pending_text_forwarded_via_send_to_window(self, tmp_path) -> None:
-        """PENDING_THREAD_TEXT is forwarded to the new window after bind."""
+    async def test_antigravity_pending_text_is_forwarded_after_binding(
+        self, tmp_path
+    ) -> None:
+        """Antigravity's first prompt uses the bound-window send path."""
         user_data = {
             PENDING_THREAD_ID: 42,
             PENDING_THREAD_TEXT: "hello agent",
@@ -526,7 +528,7 @@ class TestLaunchWindowSuccess:
             patch(
                 "ccgram.handlers.topics.window_launch_service.provider_registry"
             ) as mock_reg,
-            patch("ccgram.providers.resolve_launch_command", return_value="claude"),
+            patch("ccgram.providers.resolve_launch_command", return_value="agy"),
             patch(
                 "ccgram.handlers.topics.window_launch_service.send_telegram_to_window",
                 new_callable=AsyncMock,
@@ -559,13 +561,16 @@ class TestLaunchWindowSuccess:
                 WindowLaunchRequest(
                     user_id=100,
                     thread_id=42,
-                    provider_name="claude",
+                    provider_name="antigravity",
                     cwd=str(tmp_path),
                     mode="normal",
                     pending_text="hello agent",
                 ),
             )
 
+        mock_mux.create_topic_target.assert_awaited_once_with(
+            str(tmp_path), launch_command="agy", workspace_id=None
+        )
         mock_send.assert_awaited_once_with(100, "@5", 42, "hello agent", ANY)
         # Keys consumed after forwarding
         assert PENDING_THREAD_TEXT not in user_data

--- a/tests/ccgram/providers/test_antigravity.py
+++ b/tests/ccgram/providers/test_antigravity.py
@@ -191,6 +191,82 @@ class TestAntigravityCwdMatching:
         assert event is not None
         assert event.session_id == "test-session-id"
 
+    def test_discovers_real_cli_layout_from_last_conversations(
+        self, tmp_path, monkeypatch
+    ):
+        provider = AntigravityProvider()
+        data_root = tmp_path / ".gemini" / "antigravity-cli"
+        brain = data_root / "brain"
+        session_id = "a4186fac-9bf9-40d2-b655-02bdd21cf0dd"
+        session_dir = brain / session_id / ".system_generated" / "logs"
+        session_dir.mkdir(parents=True)
+        (session_dir / "transcript.jsonl").write_text(
+            json.dumps(
+                {
+                    "type": "USER_INPUT",
+                    "source": "USER_EXPLICIT",
+                    "content": "hello",
+                }
+            )
+            + "\n"
+        )
+        project = tmp_path / "project"
+        project.mkdir()
+        cache = data_root / "cache" / "last_conversations.json"
+        cache.parent.mkdir()
+        cache.write_text(json.dumps({str(project): session_id}))
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        event = provider.discover_transcript(str(project), "shared:@0")
+
+        assert event is not None
+        assert event.session_id == session_id
+        assert event.cwd == str(project.resolve())
+
+    def test_last_conversations_requires_exact_workspace(self, tmp_path, monkeypatch):
+        provider = AntigravityProvider()
+        data_root = tmp_path / ".gemini" / "antigravity-cli"
+        session_id = "a4186fac-9bf9-40d2-b655-02bdd21cf0dd"
+        session_dir = data_root / "brain" / session_id / ".system_generated" / "logs"
+        session_dir.mkdir(parents=True)
+        (session_dir / "transcript.jsonl").write_text('{"type":"USER_INPUT"}\n')
+        project = tmp_path / "app"
+        project.mkdir()
+        sibling = tmp_path / "app-other"
+        sibling.mkdir()
+        cache = data_root / "cache" / "last_conversations.json"
+        cache.parent.mkdir()
+        cache.write_text(json.dumps({str(sibling): session_id}))
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        assert provider.discover_transcript(str(project), "shared:@0") is None
+
+    def test_ambiguous_canonical_workspace_mapping_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        provider = AntigravityProvider()
+        data_root = tmp_path / ".gemini" / "antigravity-cli"
+        project = tmp_path / "project"
+        project.mkdir()
+        alias = tmp_path / "project-alias"
+        alias.symlink_to(project, target_is_directory=True)
+        session_ids = (
+            "a4186fac-9bf9-40d2-b655-02bdd21cf0dd",
+            "b4186fac-9bf9-40d2-b655-02bdd21cf0dd",
+        )
+        for session_id in session_ids:
+            log_dir = data_root / "brain" / session_id / ".system_generated" / "logs"
+            log_dir.mkdir(parents=True)
+            (log_dir / "transcript.jsonl").write_text('{"type":"USER_INPUT"}\n')
+        cache = data_root / "cache" / "last_conversations.json"
+        cache.parent.mkdir()
+        cache.write_text(
+            json.dumps({str(project): session_ids[0], str(alias): session_ids[1]})
+        )
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        assert provider.discover_transcript(str(project), "shared:@0") is None
+
     def test_discover_transcript_requires_cwd(self, tmp_path, monkeypatch):
         provider = AntigravityProvider()
         brain = tmp_path / ".gemini" / "antigravity-cli" / "brain"

--- a/tests/ccgram/providers/test_antigravity_resume_integration.py
+++ b/tests/ccgram/providers/test_antigravity_resume_integration.py
@@ -40,6 +40,37 @@ class TestAntigravityWorkspaceDiscovery:
             ("conversation-1", str(workspace.resolve()))
         ]
 
+    def test_discovers_real_cli_layout_from_last_conversations(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        brain = tmp_path / "brain"
+        session_id = "a4186fac-9bf9-40d2-b655-02bdd21cf0dd"
+        log_dir = brain / session_id / ".system_generated" / "logs"
+        log_dir.mkdir(parents=True)
+        (log_dir / "transcript.jsonl").write_text(
+            json.dumps(
+                {
+                    "type": "USER_INPUT",
+                    "source": "USER_EXPLICIT",
+                    "content": "hello",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        cache = tmp_path / "cache" / "last_conversations.json"
+        cache.parent.mkdir()
+        cache.write_text(json.dumps({str(workspace): session_id}), encoding="utf-8")
+        monkeypatch.setenv("CCGRAM_ANTIGRAVITY_DATA_DIR", str(brain))
+
+        sessions = AntigravityProvider().discover_resumable_sessions(cwd=str(workspace))
+
+        assert [(session.session_id, session.cwd) for session in sessions] == [
+            (session_id, str(workspace.resolve()))
+        ]
+
     def test_discovery_ignores_pytest_environment_marker(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/ccgram/test_herdr_backend.py
+++ b/tests/ccgram/test_herdr_backend.py
@@ -28,6 +28,7 @@ from ccgram.multiplexer.herdr import (
     HerdrProtocolError,
     HerdrSessionComposite,
     HerdrUnresolvedTargetError,
+    _workspace_cwd_from_panes,
     canonical_session_bytes,
     herdr_session_target_id,
 )
@@ -553,7 +554,30 @@ async def test_create_topic_target_uses_selected_workspace_and_returns_session_t
     ]
 
 
-async def test_create_topic_target_sends_initial_input_before_waiting_for_session(
+def test_workspace_cwd_prefers_stable_pane_cwd_and_accepts_matching_split_panes() -> (
+    None
+):
+    workspace = {"workspace_id": "w2", "active_tab_id": "w2:t1"}
+    panes = [
+        {
+            "workspace_id": "w2",
+            "tab_id": "w2:t1",
+            "cwd": "/repo",
+            "foreground_cwd": "/repo/.venv/bin",
+        },
+        {
+            "workspace_id": "w2",
+            "tab_id": "w2:t1",
+            "cwd": "/repo",
+            "foreground_cwd": "/repo/.venv/bin",
+        },
+    ]
+    assert _workspace_cwd_from_panes(workspace, panes) == "/repo"
+    panes[1].pop("cwd")
+    assert _workspace_cwd_from_panes(workspace, panes) is None
+
+
+async def test_create_topic_target_does_not_send_initial_input(
     tmp_path: Path,
 ) -> None:
     fake = (
@@ -573,10 +597,9 @@ async def test_create_topic_target_sends_initial_input_before_waiting_for_sessio
         str(tmp_path),
         launch_command="agy",
         workspace_id="selected",
-        initial_input="hello",
     )
     assert target.target_id == _target()
-    assert ["pane", "run", "w9:p1", "hello"] in fake.calls
+    assert ["pane", "run", "w9:p1", "hello"] not in fake.calls
 
 
 async def test_created_session_discovery_waits_for_delayed_pi_report(

--- a/tests/ccgram/test_herdr_backend.py
+++ b/tests/ccgram/test_herdr_backend.py
@@ -25,6 +25,7 @@ from ccgram.multiplexer.herdr import (
     HerdrError,
     HerdrMalformedRecordError,
     HerdrManager,
+    HerdrProtocolError,
     HerdrSessionComposite,
     HerdrUnresolvedTargetError,
     canonical_session_bytes,
@@ -552,6 +553,32 @@ async def test_create_topic_target_uses_selected_workspace_and_returns_session_t
     ]
 
 
+async def test_create_topic_target_sends_initial_input_before_waiting_for_session(
+    tmp_path: Path,
+) -> None:
+    fake = (
+        FakeHerdr()
+        .on("workspace", "list", out=_workspace("selected", tmp_path))
+        .on("tab", "create", out=_created())
+        .on("pane", "run", out=_result(type="ok"))
+        .on(
+            "agent",
+            "list",
+            out=_agents(
+                _agent(pane_id="w9:p1", tab_id="w9:t1", workspace_id="selected")
+            ),
+        )
+    )
+    target = await _manager(fake).create_topic_target(
+        str(tmp_path),
+        launch_command="agy",
+        workspace_id="selected",
+        initial_input="hello",
+    )
+    assert target.target_id == _target()
+    assert ["pane", "run", "w9:p1", "hello"] in fake.calls
+
+
 async def test_created_session_discovery_waits_for_delayed_pi_report(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -958,7 +985,7 @@ async def test_subprocess_run_maps_timeout(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 async def test_ensure_session_accepts_protocol_and_rejects_unavailable_server() -> None:
-    assert frozenset({14, 15, 16, 17}) == HERDR_SUPPORTED_PROTOCOLS
+    assert frozenset({14, 15, 16, 17, 19}) == HERDR_SUPPORTED_PROTOCOLS
     good = json.dumps(
         {
             "server": {
@@ -969,5 +996,10 @@ async def test_ensure_session_accepts_protocol_and_rejects_unavailable_server() 
         }
     )
     await _manager(FakeHerdr().on("status", out=good)).ensure_session()
+    incompatible = json.dumps(
+        {"server": {"running": True, "protocol": 17, "compatible": False}}
+    )
+    with pytest.raises(HerdrProtocolError, match="restart Herdr"):
+        await _manager(FakeHerdr().on("status", out=incompatible)).ensure_session()
     with pytest.raises(HerdrError):
         await _manager(FakeHerdr().on("status", out="not json")).ensure_session()

--- a/tests/ccgram/test_herdr_backend.py
+++ b/tests/ccgram/test_herdr_backend.py
@@ -577,6 +577,40 @@ def test_workspace_cwd_prefers_stable_pane_cwd_and_accepts_matching_split_panes(
     assert _workspace_cwd_from_panes(workspace, panes) is None
 
 
+async def test_list_workspaces_resolves_cwdless_workspaces_from_panes_once() -> None:
+    fake = (
+        FakeHerdr()
+        .on(
+            "workspace",
+            "list",
+            out=_result(
+                workspaces=[
+                    {"workspace_id": "w1", "label": "one", "active_tab_id": "w1:t1"},
+                    {"workspace_id": "w2", "label": "two", "active_tab_id": "w2:t1"},
+                ]
+            ),
+        )
+        .on(
+            "pane",
+            "list",
+            out=_result(
+                panes=[
+                    {"workspace_id": "w1", "tab_id": "w1:t1", "cwd": "/one"},
+                    {"workspace_id": "w2", "tab_id": "w2:t1", "cwd": "/two"},
+                ]
+            ),
+        )
+    )
+
+    workspaces = await _manager(fake).list_workspaces()
+
+    assert [(item.workspace_id, item.label, item.cwd) for item in workspaces] == [
+        ("w1", "one", "/one"),
+        ("w2", "two", "/two"),
+    ]
+    assert fake.calls == [["workspace", "list"], ["pane", "list"]]
+
+
 async def test_create_topic_target_does_not_send_initial_input(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- discover real Antigravity sessions from the CLI cache when transcripts omit workspace metadata
- support Herdr protocol 19 and bind a fresh Antigravity topic after its first message creates a native session
- document the required `herdr integration install antigravity-cli` setup

## Validation
- `make test` — 6150 passed, 30 skipped
- `ruff check .`
- `ruff format --check .`
- `git diff --check`
- verified ccgram status and doctor against a temporary Herdr protocol-19 server