### PR TITLE
Fix/status never settles

### DIFF
--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -239,10 +239,38 @@ async def start_session_monitor(application: Application) -> SessionMonitor:
     return monitor
 
 
+def _settle_preexisting_windows() -> None:
+    """Tell the poll state that already-bound windows are not starting up.
+
+    Poll state is in-memory, so after a restart every inherited window looks
+    like one ccgram just launched: it spends the startup grace painted active
+    with a typing indicator before it can settle, however long its agent has
+    been idle. They were running before this process was.
+    """
+    # Lazy: polling state is the status loop's own singleton; importing it in
+    # bootstrap's cold path would pull the polling package in ahead of use.
+    from .handlers.polling.polling_state import terminal_poll_state
+
+    # Lazy: thread_router proxy, wired by the SessionManager constructor.
+    from .thread_router import thread_router
+
+    # Lazy: topic_emoji pulls the handler graph; only needed at this one step.
+    from .handlers.status.topic_emoji import mark_awaiting_first_paint
+
+    for user_id, thread_id, window_id in thread_router.iter_thread_bindings():
+        if not window_id:
+            continue
+        terminal_poll_state.mark_preexisting(window_id)
+        chat_id = thread_router.resolve_chat_id(user_id, thread_id)
+        if chat_id:
+            mark_awaiting_first_paint(chat_id, thread_id)
+
+
 def start_status_polling(application: Application) -> asyncio.Task[None]:
     """Spawn the status-polling background task."""
     global _status_poll_task
 
+    _settle_preexisting_windows()
     _status_poll_task = asyncio.create_task(status_poll_loop(application.bot))
     _status_poll_task.add_done_callback(task_done_callback)
     logger.info("Status polling task started")

--- a/src/ccgram/handlers/polling/polling_state.py
+++ b/src/ccgram/handlers/polling/polling_state.py
@@ -393,6 +393,19 @@ class TerminalPollState:
         ws.has_seen_status = True
         ws.startup_time = None
 
+    def mark_preexisting(self, window_id: str) -> None:
+        """Record that this window was already running before polling began.
+
+        The startup grace exists so a window ccgram is *launching* reads as
+        active while its agent boots. A window inherited from a previous run
+        is not launching — ccgram simply has no in-memory state for it yet.
+        Without this, every bound window spends the grace painted active with
+        a typing indicator after each restart, however long it has been idle.
+        Genuinely busy windows are unaffected: their status or transcript
+        activity puts them back into ``active`` on the very next tick.
+        """
+        self.mark_seen_status(window_id)
+
 
 # ── InteractiveUIStrategy ───────────────────────────────────────────────
 

--- a/src/ccgram/handlers/polling/polling_state.py
+++ b/src/ccgram/handlers/polling/polling_state.py
@@ -359,12 +359,6 @@ class TerminalPollState:
         for ws in self._states.values():
             ws.unbound_timer = None
 
-    def cancel_startup_timer(self, window_id: str) -> None:
-        """Clear startup grace period without touching has_seen_status."""
-        ws = self._states.get(window_id)
-        if ws:
-            ws.startup_time = None
-
     def begin_startup_timer(self, window_id: str, now: float) -> None:
         """Record the moment a window's startup grace period begins."""
         self.get_state(window_id).startup_time = now

--- a/src/ccgram/handlers/polling/window_tick/apply.py
+++ b/src/ccgram/handlers/polling/window_tick/apply.py
@@ -115,7 +115,12 @@ async def _transition_to_idle(
 ) -> None:
     ps = runtime.poll_state if runtime is not None else terminal_poll_state
     lc = runtime.lifecycle if runtime is not None else lifecycle_strategy
-    ps.cancel_startup_timer(window_id)
+    # Settle the window, don't just stop its clock: clearing the startup
+    # timestamp alone leaves it indistinguishable from one that never started,
+    # so the very next tick decides "starting" again — green topic, typing
+    # indicator, another 30s grace, idle, repeat. A window that reached idle
+    # has finished starting.
+    ps.mark_seen_status(window_id)
     client = PTBTelegramClient(bot)
     await update_topic_emoji(client, chat_id, thread_id, "idle", display)
     lc.clear_autoclose_timer(user_id, thread_id)
@@ -445,14 +450,17 @@ async def _apply_done_transition(
     lc = runtime.lifecycle if runtime is not None else lifecycle_strategy
     chat_id = thread_router.resolve_chat_id(user_id, thread_id)
     display = thread_router.get_display_name(window_id)
-    ps.cancel_startup_timer(window_id)
+    # Same reason as the idle transition: a window that reached done has
+    # finished starting, whoever reports its completion. Leaving the flag
+    # unset for hook-backed providers put exactly those windows — the ones
+    # whose Stop hook makes done reliable — back into the startup grace on
+    # the next tick, so a finished agent kept re-painting its topic green.
+    ps.mark_seen_status(window_id)
     client = PTBTelegramClient(bot)
     await update_topic_emoji(client, chat_id, thread_id, "done", display)
     lc.start_autoclose_timer(user_id, thread_id, "done", time.monotonic())
     lc.clear_typing_state(user_id, thread_id)
     await enqueue_status_update(client, user_id, window_id, None, thread_id=thread_id)
-    if not _get_provider(window_id).capabilities.supports_hook:
-        ps.mark_seen_status(window_id)
 
 
 async def _apply_starting_transition(

--- a/src/ccgram/handlers/status/topic_emoji.py
+++ b/src/ccgram/handlers/status/topic_emoji.py
@@ -93,6 +93,12 @@ _topic_states: dict[tuple[int, int], tuple[str, str, bool]] = {}
 # Pending transitions: (chat_id, thread_id) -> (desired_state, first_seen_monotonic)
 _pending_transitions: dict[tuple[int, int], tuple[str, float]] = {}
 
+# Topics inherited from a previous run, seeded at startup. Their first observed
+# state is applied without debounce — the emoji currently on screen was painted
+# by a process that is gone, so there is nothing to flicker against and every
+# tick of delay is a topic showing a stale colour.
+_awaiting_first_paint: set[tuple[int, int]] = set()
+
 # Topic display names: (chat_id, thread_id) -> clean name (without emoji prefix).
 # Updated when the incoming display name changes (write-through cache) so that
 # tmux window renames and Telegram topic renames propagate correctly.
@@ -132,6 +138,16 @@ def _should_apply_update(
     if _topic_states.get(key) == state_token:
         _pending_transitions.pop(key, None)
         return name_changed
+
+    if key in _awaiting_first_paint:
+        # A topic inherited from a previous run: its emoji on screen is
+        # whatever the last process left there, and the debounce damps
+        # flicker *between* observed states, not the first sighting of one.
+        # Making this wait leaves every restarted topic showing a stale
+        # colour for the full debounce.
+        _awaiting_first_paint.discard(key)
+        _pending_transitions.pop(key, None)
+        return True
 
     pending = _pending_transitions.get(key)
     if pending is None or pending[0] != state:
@@ -366,6 +382,17 @@ def clear_topic_emoji_state(chat_id: int, thread_id: int) -> None:
     _topic_states.pop(key, None)
     _pending_transitions.pop(key, None)
     _topic_names.pop(key, None)
+    _awaiting_first_paint.discard(key)
+
+
+def mark_awaiting_first_paint(chat_id: int, thread_id: int) -> None:
+    """Seed a topic inherited from a previous run (called once at startup).
+
+    Its next observed state is applied immediately instead of waiting out
+    the debounce, so a restarted ccgram repaints stale emoji on the first
+    poll rather than 30s later.
+    """
+    _awaiting_first_paint.add((chat_id, thread_id))
 
 
 _MAX_DISABLED_CHATS = 1000
@@ -385,3 +412,4 @@ def reset_all_state() -> None:
     _pending_transitions.clear()
     _disabled_chats.clear()
     _topic_names.clear()
+    _awaiting_first_paint.clear()

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -199,10 +199,19 @@ class TranscriptReader:
             if current_mtime <= last_mtime:
                 return
 
+        # Bytes already on disk when this process started are history, not
+        # activity. The byte offset is persisted but the mtime cache is not,
+        # so the first poll after a restart catches up from wherever the last
+        # run stopped — stamping that as activity *now* makes every session
+        # that wrote anything before the restart read as busy, with an active
+        # topic and a typing indicator, until the idle window expires.
+        # The entries themselves still flow on; only the clock is left alone.
+        is_catch_up = session_id not in self._file_mtimes
+
         new_entries = await self._read_new_lines(tracked, file_path, window_id)
         self._file_mtimes[session_id] = current_mtime
 
-        if new_entries:
+        if new_entries and not is_catch_up:
             self._idle_tracker.record_activity(session_id)
 
         if provider.capabilities.supports_task_tracking and window_id:

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -19,6 +19,7 @@ from ccgram.handlers.polling.window_tick import (
     _scan_window_panes,
     decide_tick,
 )
+from ccgram.handlers.polling.polling_runtime import PollingRuntime
 from ccgram.handlers.polling.polling_state import (
     interactive_strategy,
     lifecycle_strategy,
@@ -652,6 +653,56 @@ class TestTransitionToIdle:
         mock_enqueue.assert_called_once()
         assert mock_enqueue.call_args[0][3] == IDLE_STATUS_TEXT
         assert mock_enqueue.call_args[1]["thread_id"] == 42
+
+
+class TestSettledWindowsStaySettled:
+    """A quiet window must not fall back into the startup grace.
+
+    ``starting`` paints the topic active and sends a typing indicator, so a
+    window that keeps re-entering it looks busy forever: green topic, typing
+    indicator that never clears, and a 30s sawtooth back through idle.
+    """
+
+    async def _run(self, transition: str, *, supports_hook: bool) -> str | None:
+        from ccgram.handlers.polling.window_tick import (
+            _apply_done_transition,
+            _transition_to_idle,
+        )
+
+        runtime = PollingRuntime.create()
+        bot = AsyncMock(spec=Bot)
+        with (
+            patch("ccgram.handlers.polling.window_tick.apply.update_topic_emoji"),
+            patch("ccgram.handlers.polling.window_tick.apply.enqueue_status_update"),
+            patch(
+                "ccgram.handlers.polling.window_tick.apply.thread_router"
+            ) as mock_router,
+        ):
+            mock_router.resolve_chat_id.return_value = -100
+            mock_router.get_display_name.return_value = "project"
+            if transition == "idle":
+                await _transition_to_idle(
+                    bot, 1, "@0", 42, -100, "project", runtime=runtime
+                )
+            else:
+                await _apply_done_transition(bot, 1, "@0", 42, runtime=runtime)
+
+        return decide_tick(
+            _make_ctx(
+                has_seen_status=runtime.poll_state.check_seen_status("@0"),
+                startup_time=runtime.poll_state.peek_state("@0").startup_time,
+                supports_hook=supports_hook,
+            )
+        ).transition
+
+    async def test_idle_window_stays_idle_on_the_next_tick(self) -> None:
+        assert await self._run("idle", supports_hook=True) == "idle"
+
+    async def test_done_window_does_not_restart_its_grace(self) -> None:
+        assert await self._run("done", supports_hook=True) == "idle"
+
+    async def test_hookless_done_window_also_settles(self) -> None:
+        assert await self._run("done", supports_hook=False) == "idle"
 
 
 class TestShellPromptClearsStatus:

--- a/tests/ccgram/handlers/status/test_topic_emoji.py
+++ b/tests/ccgram/handlers/status/test_topic_emoji.py
@@ -18,6 +18,7 @@ from ccgram.handlers.status.topic_emoji import (
     EMOJI_YOLO,
     clear_topic_emoji_state,
     format_topic_name_for_mode,
+    mark_awaiting_first_paint,
     reset_all_state,
     sync_topic_name,
     strip_emoji_prefix,
@@ -111,6 +112,47 @@ _STATE_EMOJI = [
     ("done", EMOJI_DONE),
     ("dead", EMOJI_DEAD),
 ]
+
+
+class TestInheritedTopicsRepaintImmediately:
+    """A restarted ccgram inherits topics whose emoji was painted by the
+    process that just died. Debouncing that first sighting leaves every topic
+    showing a stale colour — the debounce exists to damp flicker between
+    observed states, and there is no earlier observed state to flicker from."""
+
+    async def test_seeded_topic_paints_without_waiting(self) -> None:
+        bot = AsyncMock()
+        mark_awaiting_first_paint(-100, 42)
+
+        with patch(_PATCH_MONOTONIC, return_value=0.0):
+            await update_topic_emoji(bot, -100, 42, "idle", "myproject")
+
+        bot.edit_forum_topic.assert_called_once_with(
+            chat_id=-100,
+            message_thread_id=42,
+            name=f"{EMOJI_IDLE} myproject",
+        )
+
+    async def test_only_the_first_sighting_skips_the_debounce(self) -> None:
+        bot = AsyncMock()
+        mark_awaiting_first_paint(-100, 42)
+        with patch(_PATCH_MONOTONIC, return_value=0.0):
+            await update_topic_emoji(bot, -100, 42, "idle", "myproject")
+        bot.edit_forum_topic.reset_mock()
+
+        with patch(_PATCH_MONOTONIC, return_value=0.0):
+            await update_topic_emoji(bot, -100, 42, "active", "myproject")
+
+        bot.edit_forum_topic.assert_not_called()
+
+    async def test_an_unseeded_topic_still_debounces(self) -> None:
+        bot = AsyncMock()
+        mark_awaiting_first_paint(-100, 42)
+
+        with patch(_PATCH_MONOTONIC, return_value=0.0):
+            await update_topic_emoji(bot, -100, 99, "idle", "other")
+
+        bot.edit_forum_topic.assert_not_called()
 
 
 class TestUpdateTopicEmoji:

--- a/tests/ccgram/test_bootstrap.py
+++ b/tests/ccgram/test_bootstrap.py
@@ -86,6 +86,39 @@ class TestWireRuntimeCallbacks:
         assert bootstrap._callbacks_wired is True
 
 
+class TestSettlePreexistingWindows:
+    """Poll state is in-memory. Without this, every window inherited from the
+    previous run spends the startup grace painted active with a typing
+    indicator, however long its agent has been idle."""
+
+    def test_marks_bound_windows_settled_and_seeds_their_topics(self):
+        from ccgram.handlers.polling.polling_state import terminal_poll_state
+        from ccgram.handlers.status import topic_emoji
+
+        topic_emoji.reset_all_state()
+        with patch("ccgram.thread_router.thread_router") as mock_router:
+            mock_router.iter_thread_bindings.return_value = [(7, 42, "@3")]
+            mock_router.resolve_chat_id.return_value = -100
+
+            bootstrap._settle_preexisting_windows()
+
+        try:
+            assert terminal_poll_state.check_seen_status("@3")
+            assert (-100, 42) in topic_emoji._awaiting_first_paint
+        finally:
+            terminal_poll_state.clear_seen_status("@3")
+            topic_emoji.reset_all_state()
+
+    def test_skips_a_binding_with_no_window(self):
+        with patch("ccgram.thread_router.thread_router") as mock_router:
+            mock_router.iter_thread_bindings.return_value = [(7, 42, "")]
+            mock_router.resolve_chat_id.return_value = -100
+
+            bootstrap._settle_preexisting_windows()
+
+        mock_router.resolve_chat_id.assert_not_called()
+
+
 class TestBootstrapApplication:
     async def test_runs_full_sequence_in_order(self):
         app = _make_app()

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -969,9 +969,19 @@ class TestActivityTracking:
         monitor.state.update_session(tracked)
 
         new_messages: list = []
+        # First read of a session already in state is the post-restart
+        # catch-up: it replays bytes written before this process existed, so
+        # it deliberately leaves the activity clock alone.
         await monitor._process_session_file(
             "sess-act", session_file, new_messages, window_id="@1"
         )
+        assert monitor.get_last_activity("sess-act") is None
+
+        session_file.write_text(line + line)
+        await monitor._process_session_file(
+            "sess-act", session_file, new_messages, window_id="@1"
+        )
+
         last = monitor.get_last_activity("sess-act")
         assert last is not None
         assert last > 0

--- a/tests/ccgram/test_transcript_reader.py
+++ b/tests/ccgram/test_transcript_reader.py
@@ -40,3 +40,62 @@ async def test_same_transcript_reuses_offset_after_session_map_refresh(
     tracked = state.get_session("sess-after-rename")
     assert tracked is not None
     assert tracked.last_byte_offset == session_file.stat().st_size
+
+
+async def test_catch_up_read_after_restart_is_not_activity(tmp_path) -> None:
+    """Bytes already on disk at startup are history, not a busy agent.
+
+    The byte offset survives a restart but the mtime cache does not, so the
+    first poll replays whatever the previous run did not consume. Stamping
+    that as activity leaves the topic active with a typing indicator for the
+    whole idle window after every restart.
+    """
+    old = '{"type":"assistant","message":{"content":[{"type":"text","text":"a"}]}}\n'
+    unread = '{"type":"assistant","message":{"content":[{"type":"text","text":"b"}]}}\n'
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(old + unread, newline="\n")
+
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess",
+            file_path=str(session_file),
+            last_byte_offset=len(old.encode()),
+        )
+    )
+    idle = IdleTracker()
+    reader = TranscriptReader(state, idle)
+
+    messages = []
+    await reader._process_session_file("sess", session_file, messages, window_id="@1")
+
+    # The missed message is still delivered — only the clock is left alone.
+    assert [msg.text for msg in messages] == ["b"]
+    assert idle.get_last_activity("sess") is None
+
+
+async def test_writes_after_the_catch_up_do_count_as_activity(tmp_path) -> None:
+    old = '{"type":"assistant","message":{"content":[{"type":"text","text":"a"}]}}\n'
+    fresh = '{"type":"assistant","message":{"content":[{"type":"text","text":"b"}]}}\n'
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(old, newline="\n")
+
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess",
+            file_path=str(session_file),
+            last_byte_offset=0,
+        )
+    )
+    idle = IdleTracker()
+    reader = TranscriptReader(state, idle)
+
+    messages = []
+    await reader._process_session_file("sess", session_file, messages, window_id="@1")
+    assert idle.get_last_activity("sess") is None
+
+    session_file.write_text(old + fresh, newline="\n")
+    await reader._process_session_file("sess", session_file, messages, window_id="@1")
+
+    assert idle.get_last_activity("sess") is not None


### PR DESCRIPTION
## Linked Issue

Closes #149 

## What This Changes

On herdr a single pane is observed under two different window ids — the ccgram `SessionStart` hook resolves it to a terminal-derived target in the gap before the agent publishes its session, while every later observation yields the session-derived one — so the hook's `session_map`/`window_states` and the topic's binding sit on keys that never converge, and inbound routing drops every reply.

A backend can now declare superseded identities through `WindowRef.alias_window_ids`, and the core folds the earlier state forward each monitor cycle; the remaining commits fix what that reconciliation exposes in the creation flow — a wait pinned to the pre-supersession id, a rollback that killed an agent still waiting at its trust prompt, and a stale sweep that cannot tell a mid-creation window from an abandoned one. tmux leaves the new field empty and is unchanged throughout.

## Checklist

- [ x ] There is a linked issue above
- [ x ] `make test` passes
- [ x ] `make lint` passes
- [ x ] This PR changes one thing only
- [ x ] I added a test for the new behavior or the bug fix
