### PR TITLE
feat: add OpenCode CLI provider with SQLite-backed transcripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,12 @@ MONITOR_POLL_INTERVAL=2.0
 # CLAUDE_CONFIG_DIR=~/.claude-custom
 
 # Default provider for new topics (optional, defaults to "claude")
-# Options: claude, codex, gemini, pi, shell
+# Options: claude, codex, gemini, pi, antigravity, opencode, shell
 # CCGRAM_PROVIDER=claude
+
+# OpenCode provider data locations (optional)
+# CCGRAM_OPENCODE_DB=~/.local/share/opencode/opencode.db
+# CCGRAM_OPENCODE_DATA_DIR=~/.ccgram/opencode
 
 # Show hidden (dot) directories in the directory browser (optional, defaults to false)
 # CCGRAM_SHOW_HIDDEN_DIRS=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add support for OpenCode CLI (`opencode`) sessions with SQLite-backed transcript mirroring.
+
 ## [4.5.1] - 2026-08-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Each Telegram topic maps to one tmux window. With Herdr, it maps instead to one 
 ## What You Can Do
 
 - **Bind agents to topics** — one agent per Telegram topic; create via directory browser
-- **Auto-detect providers** — Supports Claude Code, Codex, Gemini, Pi, and Shell simultaneously
+- **Auto-detect providers** — Supports Claude Code, Codex, Gemini, Pi, Antigravity, OpenCode, and Shell simultaneously
 - **Monitor live** — Terminal screenshots on demand or auto-refresh every 5 seconds
 - **Send commands** — Slash commands, voice messages (transcribed via Whisper), or raw shell input
 - **Run multiple agents in parallel** — each topic independent; run different agents at once
@@ -102,7 +102,7 @@ Get user ID from [@userinfobot](https://t.me/userinfobot). Get group ID via [@Ra
 ccgram
 ```
 
-Open your Telegram group, create a topic, send a message — directory browser appears. Pick a project directory, choose your agent (Claude, Codex, Gemini, Pi, or Shell), and you're connected.
+Open your Telegram group, create a topic, send a message — directory browser appears. Pick a project directory, choose your agent (Claude, Codex, Gemini, Pi, Antigravity, OpenCode, or Shell), and you're connected.
 
 **Prerequisites:** Python 3.14+, [tmux](https://github.com/tmux/tmux) or [herdr](https://github.com/ogulcancelik/herdr), and one agent CLI. CCGram does not modify agent SDKs.
 
@@ -132,7 +132,7 @@ Native Windows does not provide the Unix file locking, signal handling, and term
 ## Documentation
 
 - **[Guides](docs/guides.md)** — CLI reference, configuration, voice transcription, multi-instance setup, session recovery, testing
-- **[Providers](docs/providers.md)** — Claude Code, Codex, Gemini, Pi, Shell; session modes, LLM config, custom commands, git worktrees
+- **[Providers](docs/providers.md)** — Claude Code, Codex, Gemini, Pi, Antigravity, OpenCode, Shell; session modes, LLM config, custom commands, git worktrees
 
 ---
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -369,3 +369,4 @@ Status detection uses Herdr's native agent status (`working` / `blocked`) as the
 - Assistant text appears in Telegram when a part settles, not as a live stream (parts are written in place while streaming).
 - The SQLite schema is internal to OpenCode and evolves between releases; support is validated against OpenCode 1.18.x and reads fail closed on schema drift.
 - `reasoning` parts are not shown in the transcript to keep topics quiet.
+- Two OpenCode tabs in the **same** working directory share the latest session in the database, so only one topic relays its transcript (run tabs in separate directories for parallel topics).

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -11,20 +11,21 @@ CCGram supports multiple agent CLI backends. Each Telegram topic can use a diffe
 | Gemini CLI  | `gemini`    | Yes         | Yes    | Yes      | JSONL      | Hook AfterAgent + pane title + interactive UI + `/status` snapshot    |
 | Pi          | `pi`        | Yes         | Yes    | Yes      | JSONL (v3) | Hook-runner Stop + transcript activity heuristic                      |
 | Antigravity | `agy`       | No          | Yes    | Yes      | JSONL      | Transcript activity heuristic + `/status` snapshot                    |
+| OpenCode    | `opencode`  | No          | Yes    | Yes      | SQLite → JSONL mirror | herdr native agent status + permission-prompt heuristic            |
 | Shell       | `bash`      | No          | No     | No       | None       | Shell prompt idle detection                                           |
 
-`Resume` in this table means the CLI accepts a known session ID. CCGram's Telegram Resume picker can enumerate sessions for Claude and Antigravity. Codex, Gemini, and Pi currently expose Fresh and Continue recovery actions only.
+`Resume` in this table means the CLI accepts a known session ID. CCGram's Telegram Resume picker can enumerate sessions for Claude, Antigravity, and OpenCode. Codex, Gemini, and Pi currently expose Fresh and Continue recovery actions only.
 
 ## Choosing a Provider
 
-**From Telegram**: When you create a new topic and select a directory, then — if the directory is an eligible git repo — choose whether to use the current branch or create a new worktree on a new branch (non-git directories skip this step), a provider picker appears with Claude (default), Codex, Gemini, Pi, Antigravity, and Shell options. After provider selection, CCGram asks for session mode:
+**From Telegram**: When you create a new topic and select a directory, then — if the directory is an eligible git repo — choose whether to use the current branch or create a new worktree on a new branch (non-git directories skip this step), a provider picker appears with Claude (default), Codex, Gemini, Pi, Antigravity, OpenCode, and Shell options. After provider selection, CCGram asks for session mode:
 
 - `✅ Standard` (normal approvals)
 - `🚀 YOLO` (provider-specific permissive mode)
 
 **From the terminal**: If you create a window manually and start an agent CLI, CCGram auto-detects the provider from the running process name. When the pane command is a JS runtime wrapper (node, bun), it inspects the pane's foreground process to reliably identify the actual CLI. How the foreground process is read is owned by the multiplexer backend — tmux uses `ps -t <tty>`, herdr reads `pane process-info` (no tty needed) — so detection works the same on both. The shell provider uses the same seam to classify a bare shell pane. As a last resort, Gemini pane-title symbols (`✦`, `✋`, `◇`) are checked.
 
-**Default provider**: Set `CCGRAM_PROVIDER=codex` (or `gemini`, `pi`, `antigravity`, `shell`) to change the default. Claude is the default if unset.
+**Default provider**: Set `CCGRAM_PROVIDER=codex` (or `gemini`, `pi`, `antigravity`, `opencode`, `shell`) to change the default. Claude is the default if unset.
 
 ## Session Mode (Standard vs YOLO)
 
@@ -335,3 +336,36 @@ Herdr reports the real conversation ID after the first prompt creates it. CCGram
 
 - **Binary Not Found**: Ensure `agy` is in your `$PATH` or set `CCGRAM_ANTIGRAVITY_COMMAND=/path/to/agy`.
 - **Session Discovery Failure**: Check that transcripts are created under `~/.gemini/antigravity-cli/brain/` or set `CCGRAM_ANTIGRAVITY_DATA_DIR=/path/to/brain`.
+
+## OpenCode CLI (`opencode`)
+
+OpenCode is a terminal AI coding agent (opencode.ai) that persists sessions in a **SQLite database** (`~/.local/share/opencode/opencode.db` on Linux, `~/Library/Application Support/opencode/opencode.db` on macOS). CCGram reads its event-sourced `event` table by per-session `seq` cursor and mirrors normalized entries into a JSONL file under `~/.ccgram/opencode/`, so the standard transcript machinery (byte offsets, mtime caching, `/history`) works unchanged. The database is opened read-only — CCGram never writes to it.
+
+### Data & Mirror Resolution
+
+- **Database**: `CCGRAM_OPENCODE_DB` environment override, then platform defaults.
+- **Mirror root**: `CCGRAM_OPENCODE_DATA_DIR` environment override, else `~/.ccgram/opencode/`.
+
+### Herdr integration
+
+Herdr natively exposes OpenCode sessions (`agent_session`); install the Herdr OpenCode integration so a tab's session identity is published:
+
+```bash
+herdr integration install opencode
+```
+
+Status detection uses Herdr's native agent status (`working` / `blocked`) as the primary signal. A conservative heuristic also surfaces OpenCode TUI permission banners (`! permission requested: ...`) as an interactive `PermissionPrompt` in the topic.
+
+### Launch, Resume, Continue, YOLO
+
+- **Resume**: `opencode --session <session_id>`; the resume picker enumerates sessions from the database (`opencode session list --format json` equivalent).
+- **Continue**: `opencode --continue`.
+- **Fork**: `--fork` can be combined via `CCGRAM_OPENCODE_COMMAND` if you want a branched session.
+- **YOLO**: `--auto` (auto-approve permissions that are not explicitly denied).
+
+### Known Limitations (v1)
+
+- No hooks (OpenCode has no config-file hook mechanism; hooks live in its plugin system) — polling is used instead.
+- Assistant text appears in Telegram when a part settles, not as a live stream (parts are written in place while streaming).
+- The SQLite schema is internal to OpenCode and evolves between releases; support is validated against OpenCode 1.18.x and reads fail closed on schema drift.
+- `reasoning` parts are not shown in the transcript to keep topics quiet.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -339,7 +339,7 @@ Herdr reports the real conversation ID after the first prompt creates it. CCGram
 
 ## OpenCode CLI (`opencode`)
 
-OpenCode is a terminal AI coding agent (opencode.ai) that persists sessions in a **SQLite database** (`~/.local/share/opencode/opencode.db` on Linux, `~/Library/Application Support/opencode/opencode.db` on macOS). CCGram reads its event-sourced `event` table by per-session `seq` cursor and mirrors normalized entries into a JSONL file under `~/.ccgram/opencode/`, so the standard transcript machinery (byte offsets, mtime caching, `/history`) works unchanged. The database is opened read-only — CCGram never writes to it.
+OpenCode is a terminal AI coding agent (opencode.ai) that persists sessions in a **SQLite database** (`~/.local/share/opencode/opencode.db` on every platform — opencode resolves it via `xdg-basedir`, honoring `XDG_DATA_HOME`). CCGram reads its event-sourced `event` table by per-session `seq` cursor and mirrors normalized entries into a JSONL file under `~/.ccgram/opencode/`, so the standard transcript machinery (byte offsets, mtime caching, `/history`) works unchanged. The database is opened read-only — CCGram never writes to it.
 
 ### Data & Mirror Resolution
 

--- a/src/ccgram/handlers/agent_command.py
+++ b/src/ccgram/handlers/agent_command.py
@@ -51,6 +51,7 @@ _PROVIDERS: tuple[tuple[str, str], ...] = (
     ("claude", "Claude"),
     ("codex", "Codex"),
     ("gemini", "Gemini"),
+    ("opencode", "OpenCode"),
     ("pi", "Pi"),
     ("shell", "Shell"),
 )

--- a/src/ccgram/handlers/topics/directory_browser.py
+++ b/src/ccgram/handlers/topics/directory_browser.py
@@ -317,6 +317,7 @@ _PROVIDER_META: dict[str, tuple[str, str]] = {
     "claude": ("Claude", "\U0001f7e0"),
     "codex": ("Codex", "\U0001f9e9"),
     "gemini": ("Gemini", "\u264a"),
+    "opencode": ("OpenCode", "\U0001f7e2"),
     "pi": ("Pi", "\U0001f916"),
     "shell": ("Shell", "\U0001f41a"),
 }

--- a/src/ccgram/multiplexer/herdr.py
+++ b/src/ccgram/multiplexer/herdr.py
@@ -227,10 +227,20 @@ class HerdrLiveRecord:
     pane_id: str
     tab_id: str
     workspace_id: str
+    cwd: str = ""
 
 
 def _session_field(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def _record_cwd(record: Mapping[str, object]) -> str:
+    """Return the agent record's working directory for topic discovery."""
+    for key in ("cwd", "foreground_cwd"):
+        value = record.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
 
 
 def _session_composite(record: Mapping[str, object]) -> HerdrSessionComposite | None:
@@ -304,6 +314,7 @@ def _parse_live_record(record: Mapping[str, object]) -> HerdrLiveRecord | None:
         pane_id=locators["pane_id"] or "",
         tab_id=locators["tab_id"] or "",
         workspace_id=locators["workspace_id"] or "",
+        cwd=_record_cwd(record),
     )
 
 
@@ -551,7 +562,7 @@ class HerdrManager:
         return WindowRef(
             window_id=record.target_id,
             window_name=label,
-            cwd="",
+            cwd=record.cwd,
             pane_current_command=record.composite.agent,
         )
 

--- a/src/ccgram/providers/__init__.py
+++ b/src/ccgram/providers/__init__.py
@@ -35,6 +35,7 @@ _YOLO_FLAGS: dict[str, str] = {
     "claude": "--dangerously-skip-permissions",
     "codex": "--dangerously-bypass-approvals-and-sandbox",
     "gemini": "--yolo",
+    "opencode": "--auto",
 }
 
 
@@ -73,11 +74,15 @@ def _ensure_registered() -> None:
     # Lazy: provider classes register against the registry at import; defer until the registry factory runs
     from ccgram.providers.shell import ShellProvider
 
+    # Lazy: provider classes register against the registry at import; defer until the registry factory runs
+    from ccgram.providers.opencode import OpenCodeProvider
+
     registry.register("antigravity", AntigravityProvider)
     registry.register("claude", ClaudeProvider)
     registry.register("codex", CodexProvider)
     registry.register("gemini", GeminiProvider)
     registry.register("pi", PiProvider)
+    registry.register("opencode", OpenCodeProvider)
     registry.register("shell", ShellProvider)
     _registered = True
 
@@ -147,7 +152,7 @@ def detect_provider_from_command(pane_current_command: str) -> str:
     # Match basename only (first token) to avoid false positives
     # from paths like /home/claude/bin/vim
     basename = os.path.basename(cmd.split()[0])
-    for name in ("antigravity", "claude", "codex", "gemini", "pi"):
+    for name in ("antigravity", "claude", "codex", "gemini", "opencode", "pi"):
         if (
             basename == name
             or (name == "antigravity" and basename == "agy")
@@ -170,6 +175,17 @@ def detect_provider_from_command(pane_current_command: str) -> str:
 _CLAUDE_PROJECTS_RE = re.compile(r"/\.claude[a-z0-9._-]*/projects/")
 
 
+_PATH_MARKERS: tuple[tuple[str, str], ...] = (
+    ("/.gemini/antigravity-cli/brain/", "antigravity"),
+    ("/.antigravity/brain/", "antigravity"),
+    ("/.config/antigravity/brain/", "antigravity"),
+    ("/.local/share/antigravity/brain/", "antigravity"),
+    ("/.ccgram/opencode/", "opencode"),
+    ("/.codex/sessions/", "codex"),
+    ("/.pi/agent/sessions/", "pi"),
+)
+
+
 def detect_provider_from_transcript_path(transcript_path: str) -> str:
     """Infer provider name from a persisted transcript path when possible.
 
@@ -182,24 +198,13 @@ def detect_provider_from_transcript_path(transcript_path: str) -> str:
     normalized = transcript_path.strip().lower().replace("\\", "/")
     if not normalized:
         return ""
-    if any(
-        marker in normalized
-        for marker in (
-            "/.gemini/antigravity-cli/brain/",
-            "/.antigravity/brain/",
-            "/.config/antigravity/brain/",
-            "/.local/share/antigravity/brain/",
-        )
-    ):
-        return "antigravity"
-    if "/.codex/sessions/" in normalized:
-        return "codex"
+    for marker, provider in _PATH_MARKERS:
+        if marker in normalized:
+            return provider
     if _CLAUDE_PROJECTS_RE.search(normalized):
         return "claude"
     if "/.gemini/" in normalized and "/chats/" in normalized:
         return "gemini"
-    if "/.pi/agent/sessions/" in normalized:
-        return "pi"
     return ""
 
 

--- a/src/ccgram/providers/opencode.py
+++ b/src/ccgram/providers/opencode.py
@@ -90,6 +90,12 @@ _MAX_CACHED_SESSIONS = 512
 
 _EVENT_BATCH_SIZE = 500
 
+# Cap on normalized entries returned per read. After downtime a session can
+# have thousands of pending parts; relaying them all in one poll floods
+# Telegram and stalls the monitor's sequential delivery loop. Capping
+# staggers catch-up over several polls instead.
+_MAX_ENTRIES_PER_READ = 1000
+
 # mtime bump: strictly forward so the whole-file poll gate (current_mtime >
 # last_mtime) always advances, even on coarse-mtime filesystems.
 _MTIME_BUMP_SECONDS = 1.0
@@ -241,7 +247,9 @@ def _sync_opencode_events(
                 elif etype == "message.part.updated.1":
                     _handle_part_event(conn, raw, session_id, role_cache, entries)
                 # session.* / message.removed.* events carry no message content.
-            if len(rows) < _EVENT_BATCH_SIZE:
+                if len(entries) >= _MAX_ENTRIES_PER_READ:
+                    break
+            if len(entries) >= _MAX_ENTRIES_PER_READ or len(rows) < _EVENT_BATCH_SIZE:
                 break
             cursor = last_seq
     except (sqlite3.Error, OSError) as exc:

--- a/src/ccgram/providers/opencode.py
+++ b/src/ccgram/providers/opencode.py
@@ -2,7 +2,7 @@
 
 OpenCode (``opencode``) is a terminal AI coding agent that persists sessions
 in a SQLite database (``~/.local/share/opencode/opencode.db`` on Linux,
-``~/Library/Application Support/opencode/opencode.db`` on macOS).  Unlike the
+on every platform — opencode resolves it via ``xdg-basedir``).  Unlike the
 JSONL-based providers (Claude, Codex, Gemini, Pi) its "transcript" is an
 event-sourced table::
 
@@ -105,27 +105,21 @@ _ARCHIVED_FILTER = "(time_archived IS NULL OR time_archived IN (0, ''))"
 
 
 def resolve_opencode_db_path() -> Path:
-    """Resolve the OpenCode SQLite database path with deterministic precedence.
+    """Resolve the OpenCode SQLite database path.
 
-    1. ``CCGRAM_OPENCODE_DB`` environment override
-    2. Platform default candidates (first existing one wins)
-    3. Linux default as final fallback
+    Mirrors opencode's own resolution (packages/core/src/global.ts uses the
+    ``xdg-basedir`` package): ``$XDG_DATA_HOME`` when set, otherwise
+    ``~/.local/share/opencode/opencode.db`` on every platform (xdg-basedir 5.x
+    does not special-case macOS, so there is no Library/Application Support
+    path). ``CCGRAM_OPENCODE_DB`` overrides everything.
     """
     override = os.environ.get("CCGRAM_OPENCODE_DB", "").strip()
     if override:
         return Path(override).expanduser()
-    home = Path.home()
-    candidates = (
-        home / ".local" / "share" / "opencode" / "opencode.db",
-        home / "Library" / "Application Support" / "opencode" / "opencode.db",
-    )
-    for candidate in candidates:
-        try:
-            if candidate.is_file():
-                return candidate
-        except OSError:
-            continue
-    return candidates[0]
+    data_home = os.environ.get("XDG_DATA_HOME", "").strip()
+    if data_home:
+        return Path(data_home) / "opencode" / "opencode.db"
+    return Path.home() / ".local" / "share" / "opencode" / "opencode.db"
 
 
 def resolve_opencode_mirror_root() -> Path:

--- a/src/ccgram/providers/opencode.py
+++ b/src/ccgram/providers/opencode.py
@@ -543,17 +543,17 @@ class OpenCodeProvider(JsonlProvider):
         """Sync new OpenCode events into the mirror and return them.
 
         *last_offset* is the per-session event ``seq`` cursor (not a byte
-        offset); the mirror file is appended to and its mtime bumped so the
-        whole-file poll path keeps running.
+        offset); the mirror file is appended to and its mtime is bumped on
+        EVERY read attempt — even when nothing is new — so the whole-file poll
+        gate (current_mtime > last_mtime) stays open and later events are
+        picked up. Without the unconditional bump the gate closes after the
+        first empty poll and the session is never read again.
         """
         mirror = Path(file_path)
         session_id = mirror.stem
         entries, last_seq = _sync_opencode_events(
             session_id, last_offset, resolve_opencode_db_path()
         )
-        if last_seq <= last_offset and not entries:
-            # DB unreachable or no change — keep poll gate closed.
-            return [], last_offset
         self._append_entries(mirror, session_id, entries)
         self._bump_mtime(mirror)
         return entries, last_seq

--- a/src/ccgram/providers/opencode.py
+++ b/src/ccgram/providers/opencode.py
@@ -1,0 +1,782 @@
+"""OpenCode CLI provider behind the AgentProvider protocol.
+
+OpenCode (``opencode``) is a terminal AI coding agent that persists sessions
+in a SQLite database (``~/.local/share/opencode/opencode.db`` on Linux,
+``~/Library/Application Support/opencode/opencode.db`` on macOS).  Unlike the
+JSONL-based providers (Claude, Codex, Gemini, Pi) its "transcript" is an
+event-sourced table::
+
+    event(aggregate_id = session_id, seq, type, data)
+
+with a per-session monotonic ``seq`` (unique index on ``aggregate_id, seq``).
+
+ccgram reads new events by ``seq`` cursor and mirrors the resulting normalized
+entries into a per-session JSONL file under ``~/.ccgram/opencode/`` so the
+existing file-based transcript machinery (byte offsets, mtime caching,
+``/history`` reads) works unchanged.  The mirror file's mtime is bumped on
+every successful sync so the whole-file poll path stays active.
+
+Known event types (OpenCode 1.18.x):
+
+  - ``session.created.1`` / ``session.updated.1``
+  - ``message.updated.1``       ``data.info`` = message ``{id, role, time, agent, model}``
+  - ``message.part.updated.1``  ``data.part``  = part ``{id, messageID, type, ...}``
+  - ``message.removed.1``
+
+Part types observed: ``text``, ``reasoning``, ``tool``, ``step-start``,
+``step-finish``.  Parts are written in place while streaming, so each part is
+emitted at most once, when it settles (text with ``time.end`` or no ``time``;
+tool with a terminal ``state.status``).
+
+Hooks: none in v1 (OpenCode has no config-file hook mechanism — hooks live in
+its plugin system).  Status detection relies on the multiplexer's native agent
+status (herdr) plus this provider's conservative permission-prompt heuristic.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import structlog
+
+from ccgram.providers._jsonl import JsonlProvider
+from ccgram.providers.base import (
+    AgentMessage,
+    DiscoveredCommand,
+    MessageRole,
+    ProviderCapabilities,
+    RESUME_ID_RE,
+    ResumableSession,
+    SessionStartEvent,
+    StatusUpdate,
+)
+from ccgram.tool_format import compact_arg, format_tool_line
+
+logger = structlog.get_logger()
+
+# ── OpenCode TUI built-in slash commands (bare names, no leading slash) ────
+_OPENCODE_BUILTINS: dict[str, str] = {
+    "compact": "Compact the current session",
+    "connect": "Add a provider and API key",
+    "export": "Export the session",
+    "help": "Show help",
+    "init": "Guided AGENTS.md setup",
+    "models": "Pick a model",
+    "new": "Start a new session",
+    "redo": "Redo the last undone turn",
+    "sessions": "Switch saved sessions",
+    "share": "Share a session link",
+    "undo": "Revert the last turn and files",
+}
+
+# Part state.status values that mean "still in flight".
+_IN_FLIGHT_STATUSES = frozenset({"running", "pending", "in-progress", "streaming"})
+
+# Terminal tool statuses that count as a finished (possibly failed) call.
+_TERMINAL_TOOL_STATUSES = frozenset({"completed", "error", "cancelled", "failed"})
+
+# Mirrored-part bitmask markers.
+_EMITTED_USE = 1
+_EMITTED_RESULT = 2
+
+# Cap on mirrored sessions kept in the in-memory part-id cache.
+_MAX_CACHED_SESSIONS = 512
+
+_EVENT_BATCH_SIZE = 500
+
+# mtime bump: strictly forward so the whole-file poll gate (current_mtime >
+# last_mtime) always advances, even on coarse-mtime filesystems.
+_MTIME_BUMP_SECONDS = 1.0
+
+_ARCHIVED_FILTER = "(time_archived IS NULL OR time_archived IN (0, ''))"
+
+
+def resolve_opencode_db_path() -> Path:
+    """Resolve the OpenCode SQLite database path with deterministic precedence.
+
+    1. ``CCGRAM_OPENCODE_DB`` environment override
+    2. Platform default candidates (first existing one wins)
+    3. Linux default as final fallback
+    """
+    override = os.environ.get("CCGRAM_OPENCODE_DB", "").strip()
+    if override:
+        return Path(override).expanduser()
+    home = Path.home()
+    candidates = (
+        home / ".local" / "share" / "opencode" / "opencode.db",
+        home / "Library" / "Application Support" / "opencode" / "opencode.db",
+    )
+    for candidate in candidates:
+        try:
+            if candidate.is_file():
+                return candidate
+        except OSError:
+            continue
+    return candidates[0]
+
+
+def resolve_opencode_mirror_root() -> Path:
+    """Return the directory holding per-session JSONL mirror files."""
+    override = os.environ.get("CCGRAM_OPENCODE_DATA_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".ccgram" / "opencode"
+
+
+def _mirror_path_for(session_id: str) -> Path:
+    return resolve_opencode_mirror_root() / f"{session_id}.jsonl"
+
+
+def _connect_readonly(db_path: Path) -> sqlite3.Connection:
+    """Open a read-only SQLite connection (never locks OpenCode's writer)."""
+    uri = f"file:{quote(str(db_path))}?mode=ro"
+    return sqlite3.connect(uri, uri=True)
+
+
+def _query_role_for_message(conn: sqlite3.Connection, message_id: str) -> str | None:
+    row = conn.execute(
+        "SELECT json_extract(data, '$.role') FROM message WHERE id = ?", (message_id,)
+    ).fetchone()
+    if not row or not row[0]:
+        return None
+    return str(row[0])
+
+
+def _handle_message_event(raw: str, role_cache: dict[str, str]) -> None:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError, TypeError:
+        return
+    info = payload.get("info")
+    if not isinstance(info, dict):
+        return
+    message_id = info.get("id")
+    role = info.get("role")
+    if message_id and isinstance(role, str):
+        role_cache[message_id] = role
+
+
+def _handle_part_event(
+    conn: sqlite3.Connection,
+    raw: str,
+    session_id: str,  # noqa: ARG001 — part payload carries sessionID
+    role_cache: dict[str, str],
+    entries: list[dict[str, Any]],
+) -> None:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError, TypeError:
+        return
+    part = payload.get("part")
+    if not isinstance(part, dict):
+        return
+    message_id = part.get("messageID")
+    if not isinstance(message_id, str):
+        return
+    role = _resolve_part_role(conn, message_id, role_cache)
+    if role is None:
+        return
+    entries.append(
+        {
+            "type": "opencode_part",
+            "message_id": message_id,
+            "role": role,
+            "part": part,
+        }
+    )
+
+
+def _resolve_part_role(
+    conn: sqlite3.Connection, message_id: str, role_cache: dict[str, str]
+) -> str | None:
+    role = role_cache.get(message_id)
+    if role is None:
+        role = _query_role_for_message(conn, message_id)
+        if role:
+            role_cache[message_id] = role
+    if role not in ("user", "assistant"):
+        return None
+    return role
+
+
+def _sync_opencode_events(
+    session_id: str,
+    since_seq: int,
+    db_path: Path,
+) -> tuple[list[dict[str, Any]], int]:
+    """Fetch OpenCode events for *session_id* after *since_seq*.
+
+    Returns ``(normalized_entries, last_seq)``.  On any database error the
+    call fails closed: ``([], since_seq)`` so polling does not spin.
+    """
+    try:
+        conn = _connect_readonly(db_path)
+    except (sqlite3.Error, OSError) as exc:
+        logger.debug("opencode: cannot open db %s: %s", db_path, exc)
+        return [], since_seq
+
+    entries: list[dict[str, Any]] = []
+    role_cache: dict[str, str] = {}
+    last_seq = since_seq
+    try:
+        cursor = since_seq
+        while True:
+            rows = conn.execute(
+                "SELECT seq, type, data FROM event "
+                "WHERE aggregate_id = ? AND seq > ? ORDER BY seq LIMIT ?",
+                (session_id, cursor, _EVENT_BATCH_SIZE),
+            ).fetchall()
+            if not rows:
+                break
+            for seq, etype, raw in rows:
+                last_seq = seq
+                if etype == "message.updated.1":
+                    _handle_message_event(raw, role_cache)
+                elif etype == "message.part.updated.1":
+                    _handle_part_event(conn, raw, session_id, role_cache, entries)
+                # session.* / message.removed.* events carry no message content.
+            if len(rows) < _EVENT_BATCH_SIZE:
+                break
+            cursor = last_seq
+    except (sqlite3.Error, OSError) as exc:
+        logger.warning("opencode: event sync failed for %s: %s", session_id, exc)
+        return [], since_seq
+    finally:
+        conn.close()
+    return entries, last_seq
+
+
+def _scan_mirror_part_ids(mirror: Path) -> dict[str, int]:
+    """Re-read emitted-part markers from an existing mirror file (restart-safe)."""
+    seen: dict[str, int] = {}
+    if not mirror.exists():
+        return seen
+    try:
+        with mirror.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                part = (
+                    entry.get("part") if entry.get("type") == "opencode_part" else None
+                )
+                if isinstance(part, dict) and part.get("id"):
+                    seen[str(part["id"])] = _EMITTED_USE | _EMITTED_RESULT
+    except OSError:
+        pass
+    return seen
+
+
+def _part_is_settled(part: dict[str, Any]) -> bool:
+    ptype = part.get("type")
+    if ptype == "text":
+        ptime = part.get("time")
+        # Streaming assistant text has time.start but no time.end yet.
+        return not (isinstance(ptime, dict) and "end" not in ptime)
+    if ptype == "tool":
+        state = part.get("state")
+        if isinstance(state, dict):
+            status = str(state.get("status", "")).lower()
+            return status not in _IN_FLIGHT_STATUSES
+        return True
+    return False
+
+
+def _desired_markers(part: dict[str, Any]) -> int:
+    """Bitmask of emissions this part should produce once settled."""
+    if part.get("type") == "tool":
+        desired = _EMITTED_USE
+        if _part_is_settled(part):
+            desired |= _EMITTED_RESULT
+        return desired
+    if _part_is_settled(part):
+        return _EMITTED_USE
+    return 0
+
+    return 0
+
+
+def _entry_line(seen: dict[str, int], entry: dict[str, Any]) -> str | None:
+    """Return the JSON line to mirror for *entry*, or None when already emitted."""
+    part = entry.get("part")
+    if not isinstance(part, dict):
+        return None
+    part_id = part.get("id")
+    if not isinstance(part_id, str):
+        return None
+    wanted = _desired_markers(part) & ~seen.get(part_id, 0)
+    if not wanted:
+        return None
+    seen[part_id] = seen.get(part_id, 0) | wanted
+    return json.dumps(entry, ensure_ascii=False)
+
+
+def _extract_tool_result_summary(part: dict[str, Any], cap: int = 400) -> str:
+    """Short human-readable summary of a settled tool part."""
+    state = part.get("state")
+    if not isinstance(state, dict):
+        return ""
+    output = state.get("output")
+    if isinstance(output, str):
+        return compact_arg(output, cap=cap)
+    if isinstance(output, dict):
+        try:
+            return compact_arg(json.dumps(output, ensure_ascii=False), cap=cap)
+        except TypeError, ValueError:
+            return ""
+    return ""
+
+
+def _part_timestamp(part: dict[str, Any]) -> str | None:
+    ptime = part.get("time")
+    if isinstance(ptime, dict) and ptime.get("end"):
+        return str(ptime["end"])
+    return None
+
+
+def _read_mirror_meta(mirror: Path) -> dict[str, str]:
+    if not mirror.exists():
+        return {}
+    try:
+        with mirror.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("type") == "session_meta":
+                    return {
+                        "session_id": str(entry.get("session_id") or ""),
+                        "cwd": str(entry.get("cwd") or ""),
+                    }
+    except OSError:
+        pass
+    return {}
+
+
+def _session_snapshot_row(
+    session_id: str,
+) -> tuple[str, str, float] | None:
+    """Return ``(title, model, cost)`` for a session id, or None."""
+    try:
+        conn = _connect_readonly(resolve_opencode_db_path())
+    except sqlite3.Error, OSError:
+        return None
+    try:
+        row = conn.execute(
+            "SELECT title, model, cost FROM session WHERE id = ?", (session_id,)
+        ).fetchone()
+    except sqlite3.Error:
+        row = None
+    finally:
+        conn.close()
+    if not row:
+        return None
+    return str(row[0] or ""), str(row[1] or ""), float(row[2] or 0.0)
+
+
+class OpenCodeProvider(JsonlProvider):
+    """Provider for OpenCode CLI (``opencode``) with SQLite-backed transcripts."""
+
+    _CAPS = ProviderCapabilities(
+        name="opencode",
+        launch_command="opencode",
+        supports_hook=False,
+        supports_resume=True,
+        supports_resume_picker=True,
+        supports_continue=True,
+        supports_structured_transcript=True,
+        supports_incremental_read=False,  # DB-backed whole-file JSON path
+        uses_pane_title=False,
+        uses_pyte_status_parsing=False,
+        builtin_commands=tuple(sorted(_OPENCODE_BUILTINS.keys())),
+        supports_user_command_discovery=False,
+        supports_status_snapshot=True,
+        has_yolo_confirmation=False,
+        tui_picker_commands=frozenset(),
+    )
+    _BUILTINS = _OPENCODE_BUILTINS
+
+    def __init__(self) -> None:
+        self._emitted_parts: dict[str, dict[str, int]] = {}
+
+    # ── Launch / resume ────────────────────────────────────────────────────
+
+    def make_launch_args(
+        self,
+        resume_id: str | None = None,
+        use_continue: bool = False,
+    ) -> str:
+        if resume_id:
+            if not RESUME_ID_RE.match(resume_id):
+                raise ValueError(f"Invalid resume_id: {resume_id!r}")
+            return f"--session {resume_id}"
+        if use_continue:
+            return "--continue"
+        return ""
+
+    def discover_resumable_sessions(
+        self,
+        *,
+        cwd: str | None = None,
+        limit: int | None = None,
+    ) -> list[ResumableSession]:
+        query = (
+            "SELECT id, title, directory, time_updated FROM session "
+            f"WHERE {_ARCHIVED_FILTER}"
+        )
+        params: list[Any] = []
+        if cwd:
+            query += " AND directory = ?"
+            params.append(cwd)
+        query += " ORDER BY time_updated DESC"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(limit)
+        try:
+            conn = _connect_readonly(resolve_opencode_db_path())
+        except (sqlite3.Error, OSError) as exc:
+            logger.debug("opencode: cannot open db for resume list: %s", exc)
+            return []
+        try:
+            rows = conn.execute(query, params).fetchall()
+        except sqlite3.Error as exc:
+            logger.warning("opencode: resume list query failed: %s", exc)
+            return []
+        finally:
+            conn.close()
+        sessions: list[ResumableSession] = []
+        for session_id, title, directory, time_updated in rows:
+            summary = (title or session_id[:12]).strip() or session_id[:12]
+            sessions.append(
+                ResumableSession(
+                    session_id=session_id,
+                    summary=summary,
+                    cwd=directory or "",
+                    provider_name="opencode",
+                    mtime=(time_updated or 0) / 1000.0,
+                )
+            )
+        return sessions
+
+    # ── Transcript discovery + reading ─────────────────────────────────────
+
+    def discover_transcript(
+        self,
+        cwd: str,
+        window_key: str,
+        *,
+        max_age: float | None = None,  # noqa: ARG002 — DB lookup, no file age gate
+    ) -> SessionStartEvent | None:
+        resolved_cwd = self._resolve_cwd(cwd)
+        if resolved_cwd is None:
+            return None
+        try:
+            conn = _connect_readonly(resolve_opencode_db_path())
+        except (sqlite3.Error, OSError) as exc:
+            logger.debug("opencode: cannot open db for discovery: %s", exc)
+            return None
+        try:
+            row = conn.execute(
+                "SELECT id FROM session WHERE directory = ? "
+                f"AND {_ARCHIVED_FILTER} "
+                "ORDER BY time_updated DESC LIMIT 1",
+                (resolved_cwd,),
+            ).fetchone()
+        except sqlite3.Error as exc:
+            logger.warning("opencode: discovery query failed: %s", exc)
+            return None
+        finally:
+            conn.close()
+        if not row:
+            return None
+        session_id = str(row[0])
+        mirror = _mirror_path_for(session_id)
+        try:
+            resolve_opencode_mirror_root().mkdir(parents=True, exist_ok=True)
+            if not mirror.exists():
+                mirror.write_text(
+                    json.dumps(
+                        {
+                            "type": "session_meta",
+                            "session_id": session_id,
+                            "cwd": resolved_cwd,
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+        except OSError as exc:
+            logger.warning("opencode: cannot create mirror %s: %s", mirror, exc)
+            return None
+        return SessionStartEvent(
+            session_id=session_id,
+            cwd=resolved_cwd,
+            transcript_path=str(mirror),
+            window_key=window_key,
+        )
+
+    def read_transcript_file(
+        self, file_path: str, last_offset: int
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Sync new OpenCode events into the mirror and return them.
+
+        *last_offset* is the per-session event ``seq`` cursor (not a byte
+        offset); the mirror file is appended to and its mtime bumped so the
+        whole-file poll path keeps running.
+        """
+        mirror = Path(file_path)
+        session_id = mirror.stem
+        entries, last_seq = _sync_opencode_events(
+            session_id, last_offset, resolve_opencode_db_path()
+        )
+        if last_seq <= last_offset and not entries:
+            # DB unreachable or no change — keep poll gate closed.
+            return [], last_offset
+        self._append_entries(mirror, session_id, entries)
+        self._bump_mtime(mirror)
+        return entries, last_seq
+
+    def _append_entries(
+        self, mirror: Path, session_id: str, entries: list[dict[str, Any]]
+    ) -> None:
+        if not entries:
+            return
+        seen = self._emitted_parts.get(session_id)
+        if seen is None:
+            if len(self._emitted_parts) >= _MAX_CACHED_SESSIONS:
+                self._emitted_parts.clear()
+            seen = _scan_mirror_part_ids(mirror)
+            self._emitted_parts[session_id] = seen
+        to_write: list[str] = []
+        for entry in entries:
+            line = _entry_line(seen, entry)
+            if line is not None:
+                to_write.append(line)
+        if not to_write:
+            return
+        try:
+            with mirror.open("a", encoding="utf-8") as fh:
+                for line in to_write:
+                    fh.write(line + "\n")
+        except OSError as exc:
+            logger.warning("opencode: mirror append failed %s: %s", mirror, exc)
+
+    @staticmethod
+    def _bump_mtime(path: Path) -> None:
+        try:
+            now = time.time() + _MTIME_BUMP_SECONDS
+            os.utime(path, (now, now))
+        except OSError:
+            pass
+
+    @staticmethod
+    def _resolve_cwd(cwd: str | None) -> str | None:
+        if not cwd:
+            return None
+        try:
+            return str(Path(cwd).expanduser().resolve())
+        except OSError:
+            return None
+
+    # ── Entry parsing ──────────────────────────────────────────────────────
+
+    def parse_transcript_entries(
+        self,
+        entries: list[dict[str, Any]],
+        pending_tools: dict[str, Any],
+        cwd: str | None = None,  # noqa: ARG002
+    ) -> tuple[list[AgentMessage], dict[str, Any]]:
+        messages: list[AgentMessage] = []
+        pending = dict(pending_tools)
+        for entry in entries:
+            if entry.get("type") != "opencode_part":
+                continue
+            role = entry.get("role")
+            if role not in ("user", "assistant"):
+                continue
+            part = entry.get("part")
+            if not isinstance(part, dict):
+                continue
+            message = self._message_from_part(part, role, pending)
+            if message is not None:
+                messages.append(message)
+        return messages, pending
+
+    def _message_from_part(
+        self,
+        part: dict[str, Any],
+        role: MessageRole,
+        pending: dict[str, Any],
+    ) -> AgentMessage | None:
+        ptype = part.get("type")
+        if ptype == "text":
+            text = str(part.get("text") or "").strip()
+            if not text:
+                return None
+            return AgentMessage(
+                text=text,
+                role=role,
+                content_type="text",
+                timestamp=_part_timestamp(part),
+            )
+        if ptype == "reasoning":
+            return None  # hidden in v1 to keep transcripts quiet
+        if ptype == "tool":
+            return self._tool_message(part, pending)
+        return None  # step-start / step-finish / unknown
+
+    def _tool_message(
+        self, part: dict[str, Any], pending: dict[str, Any]
+    ) -> AgentMessage | None:
+        tool = str(part.get("tool") or "tool")
+        call_id = str(part.get("callID") or part.get("id") or "")
+        state = part.get("state")
+        status = str(state.get("status", "")).lower() if isinstance(state, dict) else ""
+        timestamp = _part_timestamp(part)
+        if status in _IN_FLIGHT_STATUSES:
+            pending[call_id or tool] = tool
+            return AgentMessage(
+                text=format_tool_line(tool, ""),
+                role="assistant",
+                content_type="tool_use",
+                tool_name=tool,
+                tool_use_id=call_id or None,
+                timestamp=timestamp,
+            )
+        if status in _TERMINAL_TOOL_STATUSES or not status:
+            pending.pop(call_id, None)
+            summary = _extract_tool_result_summary(part)
+            if not summary:
+                summary = f"✓ **{tool.lower()}**"
+            return AgentMessage(
+                text=summary,
+                role="assistant",
+                content_type="tool_result",
+                tool_name=tool,
+                tool_use_id=call_id or None,
+                timestamp=timestamp,
+            )
+        return None
+
+    def is_user_transcript_entry(self, entry: dict[str, Any]) -> bool:
+        if entry.get("type") != "opencode_part":
+            return False
+        part = entry.get("part")
+        return (
+            entry.get("role") == "user"
+            and isinstance(part, dict)
+            and part.get("type") == "text"
+        )
+
+    def parse_history_entry(self, entry: dict[str, Any]) -> AgentMessage | None:
+        if entry.get("type") != "opencode_part":
+            return None
+        role = entry.get("role")
+        if role not in ("user", "assistant"):
+            return None
+        part = entry.get("part")
+        if not isinstance(part, dict) or part.get("type") != "text":
+            return None
+        text = str(part.get("text") or "").strip()
+        if not text:
+            return None
+        return AgentMessage(
+            text=text,
+            role=role,
+            content_type="text",
+            timestamp=_part_timestamp(part),
+        )
+
+    # ── Status / snapshot ──────────────────────────────────────────────────
+
+    def parse_terminal_status(
+        self,
+        pane_text: str,
+        *,
+        pane_title: str = "",  # noqa: ARG002
+    ) -> StatusUpdate | None:
+        """Conservatively detect OpenCode TUI permission prompts.
+
+        Full TUI chrome parsing is not attempted in v1; herdr's native agent
+        status covers working/blocked, so only the permission banner that
+        requires a keypress is surfaced here.
+        """
+        if not pane_text:
+            return None
+        lower = pane_text.lower()
+        if "permission" in lower and (
+            "requested" in lower or "required" in lower or "approve" in lower
+        ):
+            lines = [ln.strip() for ln in pane_text.splitlines() if ln.strip()]
+            return StatusUpdate(
+                raw_text="\n".join(lines[-15:]),
+                display_label="PermissionPrompt",
+                is_interactive=True,
+                ui_type="PermissionPrompt",
+            )
+        return None
+
+    def build_status_snapshot(
+        self,
+        transcript_path: str,
+        *,
+        display_name: str = "",
+        session_id: str = "",
+        cwd: str = "",
+    ) -> str | None:
+        """Render a /status snapshot from the session row (or mirror header)."""
+        title = ""
+        model = ""
+        cost = 0.0
+        if session_id:
+            row = _session_snapshot_row(session_id)
+            if row:
+                title, model, cost = row
+        if not title and not session_id:
+            meta = _read_mirror_meta(Path(transcript_path))
+            if meta:
+                session_id = meta.get("session_id", session_id)
+                cwd = meta.get("cwd", cwd)
+        short_id = session_id[:8] if session_id else "unknown"
+        lines = [
+            f"🌀 [{display_name or title or 'OpenCode session'}] OpenCode session active."
+        ]
+        if cwd:
+            lines.append(f"📁 `{cwd}`")
+        lines.append(f"🆔 `{short_id}`")
+        if model:
+            lines.append(f"🤖 `{model}`")
+        if cost:
+            lines.append(f"💵 `${cost:.4f}`")
+        return "\n".join(lines)
+
+    def has_output_since(self, transcript_path: str, offset: int) -> bool:
+        """True when the mirror file grew past *offset* (byte semantics).
+
+        The /status probe records ``transcript_path.stat().st_size`` before
+        sending; any mirrored OpenCode output after that grows the file.
+        """
+        try:
+            return Path(transcript_path).stat().st_size > offset
+        except OSError:
+            return False
+
+    def discover_commands(self, base_dir: str) -> list[DiscoveredCommand]:  # noqa: ARG002
+        return [
+            DiscoveredCommand(name=name, description=desc, source="builtin")
+            for name, desc in _OPENCODE_BUILTINS.items()
+        ]

--- a/src/ccgram/providers/opencode.py
+++ b/src/ccgram/providers/opencode.py
@@ -296,9 +296,9 @@ def _scan_mirror_part_ids(mirror: Path) -> dict[str, int]:
 
 def _part_is_settled(part: dict[str, Any]) -> bool:
     ptype = part.get("type")
-    if ptype == "text":
+    if ptype in ("text", "reasoning"):
         ptime = part.get("time")
-        # Streaming assistant text has time.start but no time.end yet.
+        # Streaming text/reasoning has time.start but no time.end yet.
         return not (isinstance(ptime, dict) and "end" not in ptime)
     if ptype == "tool":
         state = part.get("state")
@@ -651,7 +651,18 @@ class OpenCodeProvider(JsonlProvider):
                 timestamp=_part_timestamp(part),
             )
         if ptype == "reasoning":
-            return None  # hidden in v1 to keep transcripts quiet
+            text = str(part.get("text") or "").strip()
+            if not text:
+                return None
+            # ccgram relays content_type == "thinking" (min length 20,
+            # truncated to 500 chars, hideable via CCGRAM_HIDE_THINKING).
+            return AgentMessage(
+                text=text,
+                role="assistant",
+                content_type="thinking",
+                is_complete=True,
+                timestamp=_part_timestamp(part),
+            )
         if ptype == "tool":
             return self._tool_message(part, pending)
         return None  # step-start / step-finish / unknown

--- a/src/ccgram/providers/opencode.py
+++ b/src/ccgram/providers/opencode.py
@@ -230,6 +230,11 @@ def _sync_opencode_events(
     entries: list[dict[str, Any]] = []
     role_cache: dict[str, str] = {}
     last_seq = since_seq
+    # The relay-burst cap applies only to incremental reads. On discovery
+    # (since_seq == 0) the caller must advance the cursor to the true end of
+    # the event log — otherwise the tail of the history would be re-emitted
+    # as "new" messages over the next polls.
+    max_entries = None if since_seq == 0 else _MAX_ENTRIES_PER_READ
     try:
         cursor = since_seq
         while True:
@@ -247,9 +252,9 @@ def _sync_opencode_events(
                 elif etype == "message.part.updated.1":
                     _handle_part_event(conn, raw, session_id, role_cache, entries)
                 # session.* / message.removed.* events carry no message content.
-                if len(entries) >= _MAX_ENTRIES_PER_READ:
+                if _hit_entry_cap(max_entries, entries):
                     break
-            if len(entries) >= _MAX_ENTRIES_PER_READ or len(rows) < _EVENT_BATCH_SIZE:
+            if _hit_entry_cap(max_entries, entries) or len(rows) < _EVENT_BATCH_SIZE:
                 break
             cursor = last_seq
     except (sqlite3.Error, OSError) as exc:
@@ -258,6 +263,10 @@ def _sync_opencode_events(
     finally:
         conn.close()
     return entries, last_seq
+
+
+def _hit_entry_cap(max_entries: int | None, entries: list[dict[str, Any]]) -> bool:
+    return max_entries is not None and len(entries) >= max_entries
 
 
 def _scan_mirror_part_ids(mirror: Path) -> dict[str, int]:

--- a/src/ccgram/providers/opencode.py
+++ b/src/ccgram/providers/opencode.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sqlite3
 import time
 from pathlib import Path
@@ -405,6 +406,35 @@ def _session_snapshot_row(
     return str(row[0] or ""), str(row[1] or ""), float(row[2] or 0.0)
 
 
+_PERMISSION_MARKER_RE = re.compile(r"permission (required|requested)", re.IGNORECASE)
+_ALLOW_OPTIONS_RE = re.compile(r"allow once", re.IGNORECASE)
+_BORDER_RE = re.compile(r"[\u2503\u2502\u2551]")  # box-drawing borders
+
+
+def _extract_permission_prompt(pane_text: str) -> str | None:
+    """Extract the OpenCode TUI permission banner region, cleaned of borders."""
+    if not pane_text:
+        return None
+    lines = pane_text.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if _PERMISSION_MARKER_RE.search(line)),
+        None,
+    )
+    if start is None:
+        return None
+    end = len(lines)
+    for j in range(start, len(lines)):
+        if _ALLOW_OPTIONS_RE.search(lines[j]):
+            end = j + 1
+            break
+    cleaned = [
+        line
+        for line in (_BORDER_RE.sub("", ln).strip() for ln in lines[start:end])
+        if line
+    ]
+    return "\n".join(cleaned) if cleaned else None
+
+
 class OpenCodeProvider(JsonlProvider):
     """Provider for OpenCode CLI (``opencode``) with SQLite-backed transcripts."""
 
@@ -737,26 +767,22 @@ class OpenCodeProvider(JsonlProvider):
         *,
         pane_title: str = "",  # noqa: ARG002
     ) -> StatusUpdate | None:
-        """Conservatively detect OpenCode TUI permission prompts.
+        """Detect the OpenCode TUI permission banner and extract it cleanly.
 
-        Full TUI chrome parsing is not attempted in v1; herdr's native agent
-        status covers working/blocked, so only the permission banner that
-        requires a keypress is surfaced here.
+        herdr's native agent status covers working/blocked; the only TUI
+        interaction that needs a keypress is the permission banner, which is
+        extracted (border characters stripped) and surfaced as an interactive
+        PermissionPrompt so ccgram shows the navigation keyboard.
         """
-        if not pane_text:
+        banner = _extract_permission_prompt(pane_text)
+        if not banner:
             return None
-        lower = pane_text.lower()
-        if "permission" in lower and (
-            "requested" in lower or "required" in lower or "approve" in lower
-        ):
-            lines = [ln.strip() for ln in pane_text.splitlines() if ln.strip()]
-            return StatusUpdate(
-                raw_text="\n".join(lines[-15:]),
-                display_label="PermissionPrompt",
-                is_interactive=True,
-                ui_type="PermissionPrompt",
-            )
-        return None
+        return StatusUpdate(
+            raw_text=banner,
+            display_label="PermissionPrompt",
+            is_interactive=True,
+            ui_type="PermissionPrompt",
+        )
 
     def build_status_snapshot(
         self,

--- a/src/ccgram/providers/process_detection.py
+++ b/src/ccgram/providers/process_detection.py
@@ -49,6 +49,7 @@ _PROVIDER_BASENAMES: tuple[tuple[frozenset[str], str], ...] = (
     (frozenset({"claude", "ce", "cc-mirror", "zai"}), "claude"),
     (frozenset({"codex"}), "codex"),
     (frozenset({"gemini"}), "gemini"),
+    (frozenset({"opencode"}), "opencode"),
     (frozenset({"pi"}), "pi"),
 )
 

--- a/src/ccgram/toolbar_config.py
+++ b/src/ccgram/toolbar_config.py
@@ -237,6 +237,15 @@ DEFAULT_LAYOUTS: dict[str, ToolbarLayout] = {
             ("last", "getfile", "close"),
         ),
     ),
+    "opencode": ToolbarLayout(
+        style="emoji_text",
+        buttons=(
+            ("screen", "ctrlc", "live"),
+            ("esc", "tab", "enter"),
+            ("up", "down", "last"),
+            ("getfile", "close"),
+        ),
+    ),
     "shell": ToolbarLayout(
         style="emoji_text",
         buttons=(

--- a/tests/ccgram/providers/test_contracts.py
+++ b/tests/ccgram/providers/test_contracts.py
@@ -16,6 +16,7 @@ from ccgram.providers._jsonl import JsonlProvider
 from ccgram.providers.claude import ClaudeProvider
 from ccgram.providers.codex import CodexProvider
 from ccgram.providers.gemini import GeminiProvider
+from ccgram.providers.opencode import OpenCodeProvider
 from ccgram.providers.pi import PiProvider
 from ccgram.providers.shell import ShellProvider
 
@@ -51,6 +52,7 @@ PROVIDER_FIXTURES: list[type] = [
     ClaudeProvider,
     CodexProvider,
     GeminiProvider,
+    OpenCodeProvider,
     PiProvider,
     ShellProvider,
 ]
@@ -145,6 +147,12 @@ def _make_assistant_entry(
         return {"type": "gemini", "content": text}
     if name == "antigravity":
         return {"type": "PLANNER_RESPONSE", "source": "MODEL", "content": text}
+    if name == "opencode":
+        return {
+            "type": "opencode_part",
+            "role": "assistant",
+            "part": {"type": "text", "text": text},
+        }
     return {
         "type": "assistant",
         "message": {"content": [{"type": "text", "text": text}]},
@@ -174,6 +182,17 @@ def _make_tool_use_entry(provider: AgentProvider) -> dict[str, Any]:
             "type": "PLANNER_RESPONSE",
             "source": "MODEL",
             "tool_calls": [{"id": "t1", "name": "Read"}],
+        }
+    if name == "opencode":
+        return {
+            "type": "opencode_part",
+            "role": "assistant",
+            "part": {
+                "type": "tool",
+                "callID": "t1",
+                "tool": "bash",
+                "state": {"status": "running", "input": {"command": "ls"}},
+            },
         }
     if name == "pi":
         return {
@@ -216,6 +235,21 @@ def _make_tool_result_entry(provider: AgentProvider) -> dict[str, Any]:
             "source": "MODEL",
             "tool_call_id": "t1",
             "content": "ok",
+        }
+    if name == "opencode":
+        return {
+            "type": "opencode_part",
+            "role": "assistant",
+            "part": {
+                "type": "tool",
+                "callID": "t1",
+                "tool": "bash",
+                "state": {
+                    "status": "completed",
+                    "input": {"command": "ls"},
+                    "output": "ok",
+                },
+            },
         }
     if name == "pi":
         return {
@@ -326,6 +360,12 @@ class TestIsUserTranscriptEntry:
             entry = {"type": "input_item", "payload": {"role": "user"}}
         elif name == "gemini":
             entry = {"type": "user"}
+        elif name == "opencode":
+            entry = {
+                "type": "opencode_part",
+                "role": "user",
+                "part": {"type": "text", "text": "hi"},
+            }
         else:
             entry = {"type": "user"}
         assert provider.is_user_transcript_entry(entry) is True
@@ -336,6 +376,12 @@ class TestIsUserTranscriptEntry:
             entry = {"type": "response_item", "payload": {"role": "assistant"}}
         elif name == "gemini":
             entry = {"type": "gemini"}
+        elif name == "opencode":
+            entry = {
+                "type": "opencode_part",
+                "role": "assistant",
+                "part": {"type": "text", "text": "hi"},
+            }
         else:
             entry = {"type": "assistant"}
         assert provider.is_user_transcript_entry(entry) is False
@@ -375,6 +421,12 @@ class TestParseHistoryEntry:
                 "source": "USER_EXPLICIT",
                 "content": "my question",
             }
+        elif name == "opencode":
+            entry = {
+                "type": "opencode_part",
+                "role": "user",
+                "part": {"type": "text", "text": "my question"},
+            }
         else:
             entry = {
                 "type": "user",
@@ -397,6 +449,12 @@ class TestParseHistoryEntry:
             entry = {"type": "gemini", "content": ""}
         elif name == "antigravity":
             entry = {"type": "PLANNER_RESPONSE", "source": "MODEL", "content": ""}
+        elif name == "opencode":
+            entry = {
+                "type": "opencode_part",
+                "role": "assistant",
+                "part": {"type": "text", "text": ""},
+            }
         else:
             entry = {"type": "assistant", "message": {"content": []}}
         assert provider.parse_history_entry(entry) is None
@@ -501,7 +559,7 @@ class TestStatusSnapshot:
 
     def test_supports_status_snapshot_flag(self, provider: AgentProvider) -> None:
         caps = provider.capabilities
-        if caps.name in ("antigravity", "codex", "gemini"):
+        if caps.name in ("antigravity", "codex", "gemini", "opencode"):
             assert caps.supports_status_snapshot is True
         else:
             assert caps.supports_status_snapshot is False

--- a/tests/ccgram/providers/test_opencode.py
+++ b/tests/ccgram/providers/test_opencode.py
@@ -437,6 +437,95 @@ class TestTranscriptReading:
         entries, offset = provider.read_transcript_file(str(mirror), 7)
         assert entries == [] and offset == 7
 
+    def _seed_big_session(self, db: Path, parts: int) -> None:
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "INSERT INTO session (id, title, directory, model, cost, time_archived, time_updated) "
+            "VALUES ('ses_big', 'big', '/tmp/repo', NULL, 0, NULL, 1)"
+        )
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('msg_1', 'ses_big', ?)",
+            (json.dumps({"role": "user"}),),
+        )
+        _insert_event(
+            conn,
+            "ses_big",
+            1,
+            "message.updated.1",
+            _message_event("ses_big", "msg_1", "user"),
+        )
+        for i in range(parts):
+            _insert_event(
+                conn,
+                "ses_big",
+                i + 2,
+                "message.part.updated.1",
+                _part_event(
+                    "ses_big",
+                    {
+                        "id": f"prt_{i}",
+                        "sessionID": "ses_big",
+                        "messageID": "msg_1",
+                        "type": "text",
+                        "text": f"part {i}",
+                    },
+                ),
+            )
+        conn.commit()
+        conn.close()
+
+    def test_discovery_read_is_not_capped(self, provider_env: tuple) -> None:
+        # The relay-burst cap must not apply to discovery (offset 0): the cursor
+        # has to advance to the end of the event log, otherwise the history tail
+        # would be re-emitted as new messages.
+        provider, db, mirror_root = provider_env
+        self._seed_big_session(db, parts=1100)
+        mirror = mirror_root / "ses_big.jsonl"
+        mirror.parent.mkdir(parents=True, exist_ok=True)
+        mirror.write_text(
+            json.dumps(
+                {"type": "session_meta", "session_id": "ses_big", "cwd": "/tmp/repo"}
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        entries, offset = provider.read_transcript_file(str(mirror), 0)
+        assert offset == 1101  # advanced to the end, not capped at 1000
+        assert len(entries) == 1100
+
+    def test_incremental_read_is_capped(self, provider_env: tuple) -> None:
+        provider, db, mirror_root = provider_env
+        self._seed_big_session(db, parts=500)
+        mirror = mirror_root / "ses_big.jsonl"
+        mirror.parent.mkdir(parents=True, exist_ok=True)
+        mirror.write_text("", encoding="utf-8")
+        # discovery first (cursor to end), then a burst of new parts
+        entries, offset = provider.read_transcript_file(str(mirror), 0)
+        assert offset == 501
+        conn = sqlite3.connect(db)
+        for i in range(1200):
+            _insert_event(
+                conn,
+                "ses_big",
+                i + 502,
+                "message.part.updated.1",
+                _part_event(
+                    "ses_big",
+                    {
+                        "id": f"prt_new_{i}",
+                        "sessionID": "ses_big",
+                        "messageID": "msg_1",
+                        "type": "text",
+                        "text": f"new {i}",
+                    },
+                ),
+            )
+        conn.commit()
+        conn.close()
+        entries2, offset2 = provider.read_transcript_file(str(mirror), offset)
+        assert len(entries2) <= 1000  # incremental reads are capped
+        assert offset2 > offset
+
 
 class TestEntryHelpers:
     def test_is_user_entry(self) -> None:

--- a/tests/ccgram/providers/test_opencode.py
+++ b/tests/ccgram/providers/test_opencode.py
@@ -1,0 +1,542 @@
+"""Unit tests for the OpenCode provider (SQLite-backed transcripts)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ccgram.providers import (
+    detect_provider_from_command,
+    detect_provider_from_transcript_path,
+    has_yolo_mode,
+    resolve_launch_command,
+)
+from ccgram.providers.base import AgentMessage, StatusUpdate
+from ccgram.providers.opencode import (
+    OpenCodeProvider,
+    resolve_opencode_db_path,
+    resolve_opencode_mirror_root,
+)
+from ccgram.providers.process_detection import classify_provider_from_args
+
+
+def _make_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE session (
+            id TEXT PRIMARY KEY, title TEXT, directory TEXT, model TEXT,
+            cost REAL, time_archived INTEGER, time_updated INTEGER
+        );
+        CREATE TABLE message (
+            id TEXT PRIMARY KEY, session_id TEXT, data TEXT
+        );
+        CREATE TABLE part (
+            id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, data TEXT
+        );
+        CREATE TABLE event (
+            id TEXT PRIMARY KEY, aggregate_id TEXT, seq INTEGER,
+            type TEXT, data TEXT
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_event(
+    conn: sqlite3.Connection,
+    session_id: str,
+    seq: int,
+    etype: str,
+    data: dict[str, Any],
+) -> None:
+    conn.execute(
+        "INSERT INTO event (id, aggregate_id, seq, type, data) VALUES (?, ?, ?, ?, ?)",
+        (f"evt_{seq}", session_id, seq, etype, json.dumps(data, ensure_ascii=False)),
+    )
+
+
+def _message_event(session_id: str, message_id: str, role: str) -> dict[str, Any]:
+    return {
+        "sessionID": session_id,
+        "info": {"id": message_id, "sessionID": session_id, "role": role},
+    }
+
+
+def _part_event(session_id: str, part: dict[str, Any]) -> dict[str, Any]:
+    return {"sessionID": session_id, "part": part}
+
+
+def _seed_session(
+    db: Path,
+    session_id: str,
+    *,
+    cwd: str = "/tmp/repo",
+    title: str = "Fix tests",
+) -> sqlite3.Connection:
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO session (id, title, directory, model, cost, time_archived, time_updated) "
+        "VALUES (?, ?, ?, ?, ?, NULL, ?)",
+        (
+            session_id,
+            title,
+            cwd,
+            "anthropic/claude-sonnet-4-5",
+            0.0123,
+            1_700_000_000_000,
+        ),
+    )
+    conn.commit()
+    return conn
+
+
+def _seed_events(conn: sqlite3.Connection, session_id: str) -> None:
+    # user message + text part (no time — user prompt)
+    _insert_event(
+        conn,
+        session_id,
+        1,
+        "message.updated.1",
+        _message_event(session_id, "msg_user", "user"),
+    )
+    conn.execute(
+        "INSERT INTO message (id, session_id, data) VALUES (?, ?, ?)",
+        ("msg_user", session_id, json.dumps({"role": "user"})),
+    )
+    _insert_event(
+        conn,
+        session_id,
+        2,
+        "message.part.updated.1",
+        _part_event(
+            session_id,
+            {
+                "id": "prt_user",
+                "sessionID": session_id,
+                "messageID": "msg_user",
+                "type": "text",
+                "text": "explain this",
+            },
+        ),
+    )
+    # assistant message + settled text part (with time.end)
+    _insert_event(
+        conn,
+        session_id,
+        3,
+        "message.updated.1",
+        _message_event(session_id, "msg_asst", "assistant"),
+    )
+    conn.execute(
+        "INSERT INTO message (id, session_id, data) VALUES (?, ?, ?)",
+        ("msg_asst", session_id, json.dumps({"role": "assistant"})),
+    )
+    _insert_event(
+        conn,
+        session_id,
+        4,
+        "message.part.updated.1",
+        _part_event(
+            session_id,
+            {
+                "id": "prt_asst",
+                "sessionID": session_id,
+                "messageID": "msg_asst",
+                "type": "text",
+                "text": "sure thing",
+                "time": {"start": 1, "end": 2},
+            },
+        ),
+    )
+    # assistant reasoning part (should be skipped)
+    _insert_event(
+        conn,
+        session_id,
+        5,
+        "message.part.updated.1",
+        _part_event(
+            session_id,
+            {
+                "id": "prt_reason",
+                "sessionID": session_id,
+                "messageID": "msg_asst",
+                "type": "reasoning",
+                "text": "hmm",
+            },
+        ),
+    )
+    # tool part: running then completed
+    _insert_event(
+        conn,
+        session_id,
+        6,
+        "message.part.updated.1",
+        _part_event(
+            session_id,
+            {
+                "id": "prt_tool",
+                "sessionID": session_id,
+                "messageID": "msg_asst",
+                "type": "tool",
+                "callID": "call_1",
+                "tool": "bash",
+                "state": {"status": "running", "input": {"command": "ls"}},
+            },
+        ),
+    )
+    _insert_event(
+        conn,
+        session_id,
+        7,
+        "message.part.updated.1",
+        _part_event(
+            session_id,
+            {
+                "id": "prt_tool",
+                "sessionID": session_id,
+                "messageID": "msg_asst",
+                "type": "tool",
+                "callID": "call_1",
+                "tool": "bash",
+                "state": {
+                    "status": "completed",
+                    "input": {"command": "ls"},
+                    "output": "total 42",
+                },
+            },
+        ),
+    )
+    # step boundaries (should be skipped)
+    _insert_event(
+        conn,
+        session_id,
+        8,
+        "message.part.updated.1",
+        _part_event(
+            session_id,
+            {
+                "id": "prt_step",
+                "sessionID": session_id,
+                "messageID": "msg_asst",
+                "type": "step-start",
+            },
+        ),
+    )
+    conn.commit()
+
+
+@pytest.fixture()
+def provider_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[OpenCodeProvider, Path, Path]:
+    db = tmp_path / "opencode.db"
+    _make_db(db)
+    mirror_root = tmp_path / "mirrors"
+    monkeypatch.setenv("CCGRAM_OPENCODE_DB", str(db))
+    monkeypatch.setenv("CCGRAM_OPENCODE_DATA_DIR", str(mirror_root))
+    return OpenCodeProvider(), db, mirror_root
+
+
+def _provider(db: Path, mirror_root: Path) -> OpenCodeProvider:
+    return OpenCodeProvider()
+
+
+class TestCapabilities:
+    def test_caps(self) -> None:
+        caps = OpenCodeProvider().capabilities
+        assert caps.name == "opencode"
+        assert caps.launch_command == "opencode"
+        assert caps.supports_hook is False
+        assert caps.supports_resume is True
+        assert caps.supports_continue is True
+        assert caps.supports_status_snapshot is True
+        assert caps.supports_incremental_read is False
+        assert caps.uses_pyte_status_parsing is False
+        assert caps.has_yolo_confirmation is False
+        assert "/" not in "".join(caps.builtin_commands)
+
+    def test_yolo_flag_registered(self) -> None:
+        assert has_yolo_mode("opencode") is True
+        assert (
+            resolve_launch_command("opencode", approval_mode="yolo")
+            == "opencode --auto"
+        )
+        assert resolve_launch_command("opencode") == "opencode"
+
+    def test_detection(self) -> None:
+        assert detect_provider_from_command("opencode") == "opencode"
+        assert classify_provider_from_args("opencode") == "opencode"
+        assert (
+            detect_provider_from_transcript_path(
+                "/home/user/.ccgram/opencode/ses_abc123.jsonl"
+            )
+            == "opencode"
+        )
+
+
+class TestLaunchArgs:
+    def test_fresh(self) -> None:
+        assert OpenCodeProvider().make_launch_args() == ""
+
+    def test_resume(self) -> None:
+        assert (
+            OpenCodeProvider().make_launch_args(resume_id="ses_abc123")
+            == "--session ses_abc123"
+        )
+
+    def test_resume_invalid_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            OpenCodeProvider().make_launch_args(resume_id="rm -rf /")
+
+    def test_continue(self) -> None:
+        assert OpenCodeProvider().make_launch_args(use_continue=True) == "--continue"
+
+
+class TestDiscover:
+    def test_no_match_returns_none(self, provider_env: tuple) -> None:
+        provider, _db, _mirror = provider_env
+        assert provider.discover_transcript("/nonexistent", "ccgram:@0") is None
+
+    def test_discover_creates_mirror_with_meta(self, provider_env: tuple) -> None:
+        provider, db, mirror_root = provider_env
+        conn = _seed_session(db, "ses_1", cwd="/tmp/repo")
+        conn.close()
+        event = provider.discover_transcript("/tmp/repo", "ccgram:@1")
+        assert event is not None
+        assert event.session_id == "ses_1"
+        assert event.cwd == "/tmp/repo"
+        mirror = mirror_root / "ses_1.jsonl"
+        assert mirror.exists()
+        first = json.loads(mirror.read_text(encoding="utf-8").splitlines()[0])
+        assert first["type"] == "session_meta"
+        assert first["session_id"] == "ses_1"
+
+    def test_resumable_sessions_filter_cwd(self, provider_env: tuple) -> None:
+        provider, db, _mirror = provider_env
+        conn = sqlite3.connect(db)
+        for i, cwd in enumerate(("/tmp/repo", "/tmp/other", "/tmp/repo")):
+            conn.execute(
+                "INSERT INTO session (id, title, directory, model, cost, time_archived, time_updated) "
+                "VALUES (?, ?, ?, NULL, 0, NULL, ?)",
+                (f"ses_{i}", f"title {i}", cwd, 1_700_000_000_000 + i),
+            )
+        conn.execute(
+            "INSERT INTO session (id, title, directory, model, cost, time_archived, time_updated) "
+            "VALUES (?, ?, ?, NULL, 0, 1, 1)",
+            ("ses_archived", "archived", "/tmp/repo"),
+        )
+        conn.commit()
+        conn.close()
+        all_sessions = provider.discover_resumable_sessions()
+        assert [s.session_id for s in all_sessions] == ["ses_2", "ses_1", "ses_0"]
+        assert "ses_archived" not in [s.session_id for s in all_sessions]
+        repo_only = provider.discover_resumable_sessions(cwd="/tmp/repo")
+        assert [s.session_id for s in repo_only] == ["ses_2", "ses_0"]
+        limited = provider.discover_resumable_sessions(limit=1)
+        assert len(limited) == 1 and limited[0].session_id == "ses_2"
+
+
+class TestTranscriptReading:
+    def test_sync_and_parse(self, provider_env: tuple) -> None:
+        provider, db, mirror_root = provider_env
+        conn = _seed_session(db, "ses_1")
+        _seed_events(conn, "ses_1")
+        conn.close()
+        mirror = mirror_root / "ses_1.jsonl"
+
+        # initial full sync consumes history without emitting messages
+        entries, offset = provider.read_transcript_file(str(mirror), 0)
+        assert offset == 8
+        assert {e["type"] for e in entries} == {"opencode_part"}
+
+        # parse the synced entries
+        messages, pending = provider.parse_transcript_entries(entries, {})
+        texts = [(m.role, m.content_type, m.text) for m in messages]
+        assert ("user", "text", "explain this") in texts
+        assert ("assistant", "text", "sure thing") in texts
+        # reasoning and step parts are skipped
+        assert not any(t == "hmm" for _r, _t, t in texts)
+        # tool use emitted on running, result on completed
+        tool_msgs = [(m.content_type, m.tool_name, m.tool_use_id) for m in messages]
+        assert ("tool_use", "bash", "call_1") in tool_msgs
+        assert ("tool_result", "bash", "call_1") in tool_msgs
+        assert "call_1" not in pending
+
+    def test_incremental_and_dedupe(self, provider_env: tuple) -> None:
+        provider, db, mirror_root = provider_env
+        conn = _seed_session(db, "ses_1")
+        _seed_events(conn, "ses_1")
+        conn.commit()
+        mirror = mirror_root / "ses_1.jsonl"
+        mirror.parent.mkdir(parents=True, exist_ok=True)
+        mirror.write_text(
+            json.dumps(
+                {"type": "session_meta", "session_id": "ses_1", "cwd": "/tmp/repo"}
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        entries, offset = provider.read_transcript_file(str(mirror), 0)
+        assert offset == 8
+        first_messages, _ = provider.parse_transcript_entries(entries, {})
+        assert len(first_messages) >= 4
+
+        # same events re-read: no duplicates
+        entries2, offset2 = provider.read_transcript_file(str(mirror), offset)
+        assert entries2 == [] and offset2 == offset
+        messages2, _ = provider.parse_transcript_entries(entries2, {})
+        assert messages2 == []
+
+        # new event after cursor
+        _insert_event(
+            conn,
+            "ses_1",
+            9,
+            "message.part.updated.1",
+            _part_event(
+                "ses_1",
+                {
+                    "id": "prt_new",
+                    "sessionID": "ses_1",
+                    "messageID": "msg_asst",
+                    "type": "text",
+                    "text": "more",
+                    "time": {"start": 1, "end": 2},
+                },
+            ),
+        )
+        conn.commit()
+        entries3, offset3 = provider.read_transcript_file(str(mirror), offset2)
+        assert offset3 == 9
+        messages3, _ = provider.parse_transcript_entries(entries3, {})
+        assert len(messages3) == 1
+        assert messages3[0].text == "more"
+
+    def test_missing_db_fails_closed(self, provider_env: tuple) -> None:
+        provider, db, mirror_root = provider_env
+        mirror = mirror_root / "ses_x.jsonl"
+        mirror.parent.mkdir(parents=True, exist_ok=True)
+        mirror.write_text("", encoding="utf-8")
+        # db deleted → no spin, no crash
+        db.unlink()
+        entries, offset = provider.read_transcript_file(str(mirror), 7)
+        assert entries == [] and offset == 7
+
+
+class TestEntryHelpers:
+    def test_is_user_entry(self) -> None:
+        provider = OpenCodeProvider()
+        assert (
+            provider.is_user_transcript_entry(
+                {
+                    "type": "opencode_part",
+                    "role": "user",
+                    "part": {"type": "text", "text": "hi"},
+                }
+            )
+            is True
+        )
+        assert (
+            provider.is_user_transcript_entry(
+                {
+                    "type": "opencode_part",
+                    "role": "assistant",
+                    "part": {"type": "text", "text": "hi"},
+                }
+            )
+            is False
+        )
+        assert provider.is_user_transcript_entry({}) is False
+
+    def test_history_entry(self) -> None:
+        provider = OpenCodeProvider()
+        msg = provider.parse_history_entry(
+            {
+                "type": "opencode_part",
+                "role": "user",
+                "part": {"type": "text", "text": "question"},
+            }
+        )
+        assert msg is not None
+        assert isinstance(msg, AgentMessage)
+        assert msg.role == "user" and msg.text == "question"
+        assert provider.parse_history_entry({"type": "summary"}) is None
+        assert (
+            provider.parse_history_entry(
+                {
+                    "type": "opencode_part",
+                    "role": "assistant",
+                    "part": {"type": "reasoning", "text": "think"},
+                }
+            )
+            is None
+        )
+
+
+class TestStatus:
+    def test_permission_prompt_detected(self) -> None:
+        provider = OpenCodeProvider()
+        status = provider.parse_terminal_status(
+            "some output\n! permission requested: bash (ls)\nplease approve or deny"
+        )
+        assert status is not None
+        assert isinstance(status, StatusUpdate)
+        assert status.is_interactive is True
+        assert status.ui_type == "PermissionPrompt"
+
+    def test_plain_text_not_interactive(self) -> None:
+        provider = OpenCodeProvider()
+        assert provider.parse_terminal_status("ordinary output\n> prompt") is None
+
+    def test_snapshot_from_db(self, provider_env: tuple) -> None:
+        provider, db, _mirror = provider_env
+        conn = _seed_session(db, "ses_1")
+        conn.close()
+        snapshot = provider.build_status_snapshot(
+            "/tmp/nonexistent.jsonl",
+            display_name="repo",
+            session_id="ses_1",
+            cwd="/tmp/repo",
+        )
+        assert snapshot is not None
+        assert "repo" in snapshot
+        assert "ses_1" in snapshot
+
+    def test_snapshot_missing_db_safe(self, provider_env: tuple) -> None:
+        provider, db, _mirror = provider_env
+        db.unlink()
+        snapshot = provider.build_status_snapshot(
+            "/tmp/nonexistent.jsonl", display_name="test"
+        )
+        assert snapshot is None or "test" in snapshot
+
+    def test_has_output_since_file_semantics(self, tmp_path: Path) -> None:
+        provider = OpenCodeProvider()
+        transcript = tmp_path / "mirror.jsonl"
+        transcript.write_text("line\n", encoding="utf-8")
+        assert provider.has_output_since(str(transcript), 0) is True
+        size = transcript.stat().st_size
+        assert provider.has_output_since(str(transcript), size) is False
+        assert provider.has_output_since("/tmp/nonexistent.jsonl", 0) is False
+
+
+class TestPathResolution:
+    def test_db_override(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        db = tmp_path / "custom.db"
+        db.write_text("")
+        monkeypatch.setenv("CCGRAM_OPENCODE_DB", str(db))
+        assert resolve_opencode_db_path() == db
+
+    def test_mirror_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "mirrors"
+        monkeypatch.setenv("CCGRAM_OPENCODE_DATA_DIR", str(root))
+        assert resolve_opencode_mirror_root() == root

--- a/tests/ccgram/providers/test_opencode.py
+++ b/tests/ccgram/providers/test_opencode.py
@@ -665,6 +665,27 @@ class TestPathResolution:
         monkeypatch.setenv("CCGRAM_OPENCODE_DB", str(db))
         assert resolve_opencode_db_path() == db
 
+    def test_xdg_data_home_honored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # opencode resolves the data dir via xdg-basedir: $XDG_DATA_HOME wins.
+        data_home = tmp_path / "xdg-data"
+        data_home.mkdir()
+        monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+        assert resolve_opencode_db_path() == data_home / "opencode" / "opencode.db"
+
+    def test_default_path_is_xdg_basedir_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # xdg-basedir 5.x does not special-case macOS: the default data dir is
+        # ~/.local/share on every platform.
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.delenv("CCGRAM_OPENCODE_DB", raising=False)
+        monkeypatch.setattr("pathlib.Path.home", lambda: Path("/home/me"))
+        assert resolve_opencode_db_path() == Path(
+            "/home/me/.local/share/opencode/opencode.db"
+        )
+
     def test_mirror_override(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/ccgram/providers/test_opencode.py
+++ b/tests/ccgram/providers/test_opencode.py
@@ -583,11 +583,42 @@ class TestEntryHelpers:
 class TestStatus:
     def test_permission_prompt_detected(self) -> None:
         provider = OpenCodeProvider()
-        status = provider.parse_terminal_status(
-            "some output\n! permission requested: bash (ls)\nplease approve or deny"
+        # Realistic OpenCode TUI permission banner inside a full screen dump.
+        screen = "\n".join(
+            [
+                "↑↓ select · Enter confirm · Esc cancel · type to enter text",
+                '✱ Glob "**/*.ts" in ~/dev/pets/clipcave-latest',
+                "┃  △ Permission required",
+                "┃    ← Access external directory ~/dev/pets",
+                "┃  Patterns",
+                "┃  - /home/al/dev/pets/*",
+                "┃   Allow once   Allow always   Reject     ⇆ select  enter confirm",
+                "▣  Vv-Controller · VV Codex GPT-5.6 Sol XHigh",
+                "~/dev/clipcave:main",
+                "• OpenCode 1.18.16",
+            ]
         )
+        status = provider.parse_terminal_status(screen)
         assert status is not None
         assert isinstance(status, StatusUpdate)
+        assert status.is_interactive is True
+        assert status.ui_type == "PermissionPrompt"
+        assert "Permission required" in status.raw_text
+        assert "Access external directory" in status.raw_text
+        assert "Allow once" in status.raw_text
+        # only the banner region is extracted — no unrelated screen chrome
+        assert "Vv-Controller" not in status.raw_text
+        assert "OpenCode 1.18.16" not in status.raw_text
+        assert "clipcave-latest" not in status.raw_text
+        # border characters are stripped
+        assert "┃" not in status.raw_text
+
+    def test_permission_prompt_in_run_mode_logs(self) -> None:
+        provider = OpenCodeProvider()
+        status = provider.parse_terminal_status(
+            "some output\n! permission requested: bash (ls)\nplease approve or deny",
+        )
+        assert status is not None
         assert status.is_interactive is True
         assert status.ui_type == "PermissionPrompt"
 

--- a/tests/ccgram/providers/test_opencode.py
+++ b/tests/ccgram/providers/test_opencode.py
@@ -394,6 +394,14 @@ class TestTranscriptReading:
         messages2, _ = provider.parse_transcript_entries(entries2, {})
         assert messages2 == []
 
+        # regression: even an empty read must advance mirror mtime, otherwise
+        # TranscriptReader's whole-file gate (current_mtime > last_mtime)
+        # closes forever and later events are never polled
+        mtime_before = mirror.stat().st_mtime
+        entries_noop, _ = provider.read_transcript_file(str(mirror), offset2)
+        assert entries_noop == []
+        assert mirror.stat().st_mtime > mtime_before
+
         # new event after cursor
         _insert_event(
             conn,

--- a/tests/ccgram/providers/test_opencode.py
+++ b/tests/ccgram/providers/test_opencode.py
@@ -360,8 +360,11 @@ class TestTranscriptReading:
         texts = [(m.role, m.content_type, m.text) for m in messages]
         assert ("user", "text", "explain this") in texts
         assert ("assistant", "text", "sure thing") in texts
-        # reasoning and step parts are skipped
-        assert not any(t == "hmm" for _r, _t, t in texts)
+        # reasoning parts are relayed as thinking; step parts are skipped
+        thinking = [m for m in messages if m.content_type == "thinking"]
+        assert any(m.text == "hmm" for m in thinking)
+        assert all(m.role == "assistant" for m in thinking)
+        assert not any(m.content_type == "text" and m.text == "hmm" for m in messages)
         # tool use emitted on running, result on completed
         tool_msgs = [(m.content_type, m.tool_name, m.tool_use_id) for m in messages]
         assert ("tool_use", "bash", "call_1") in tool_msgs

--- a/tests/ccgram/test_herdr_backend.py
+++ b/tests/ccgram/test_herdr_backend.py
@@ -171,6 +171,23 @@ async def test_list_windows_exposes_all_detected_agent_targets() -> None:
     assert all("w2:" not in win.window_id for win in windows)
 
 
+async def test_list_windows_carries_agent_cwd_for_transcript_discovery() -> None:
+    live = _agent(cwd="/tmp/proj-a", foreground_cwd="/tmp/proj-a")
+    sessionless = {
+        "terminal_id": "term-b",
+        "pane_id": "w2:p2",
+        "tab_id": "w2:t9",
+        "workspace_id": "w2",
+        "agent": "claude",
+        "cwd": "/tmp/proj-b",
+    }
+    bare = _agent(cwd="")
+    windows = await _manager(_live_fake(live, sessionless, bare)).list_windows()
+    cwds = [win.cwd for win in windows]
+    assert "/tmp/proj-a" in cwds
+    assert "/tmp/proj-b" in cwds
+
+
 async def test_sessionless_agent_target_resolves_through_fresh_snapshot() -> None:
     sessionless = {
         "terminal_id": "term-b",

--- a/tests/ccgram/test_herdr_identity_audit.py
+++ b/tests/ccgram/test_herdr_identity_audit.py
@@ -13,8 +13,11 @@ def test_one_canonical_digest_owner_and_no_layout_identity() -> None:
     assert source.count("def herdr_session_target_id(") == 1
     assert "def canonical_session_bytes(" in source
     # Identity comes from the complete agent_session composite, not layout data.
+    # Only the composite→digest functions are audited: layout fields (cwd,
+    # titles) legitimately ride along in HerdrLiveRecord as locator data for
+    # topic discovery, but they must never influence the identity digest.
     identity_section = source[
-        source.index("def _session_composite") : source.index("class HerdrManager")
+        source.index("def _session_composite") : source.index("def _parse_live_record")
     ]
     for forbidden in ("focused", "title", "cwd", "directory", "screen", "layout"):
         assert forbidden not in identity_section

--- a/tests/e2e/test_opencode_lifecycle.py
+++ b/tests/e2e/test_opencode_lifecycle.py
@@ -1,0 +1,244 @@
+"""E2E lifecycle test for the OpenCode provider.
+
+Spawns a real ``opencode --pure`` TUI in a PTY inside an isolated
+``XDG_DATA_HOME`` (so the real user database is never touched), drives a
+prompt through the interactive input box, and verifies that the OpenCode
+provider discovers the session, reads the event-sourced transcript, and
+parses user / assistant / tool messages from it.
+
+Local only: requires an ``opencode`` binary on PATH, a configured model
+provider (the isolated config pins ``deepseek/deepseek-v4-flash``) and
+credentials (``~/.local/share/opencode/auth.json``). Skips when those are
+unavailable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import fcntl
+import json
+import os
+import pty
+import select
+import signal
+import sqlite3
+import struct
+import subprocess
+import termios
+import time
+from pathlib import Path
+
+import pytest
+
+from ccgram.providers.opencode import OpenCodeProvider
+
+_SMOKE_PROMPT = "Reply with exactly the word DONE"
+_DB_POLL_SECONDS = 120
+_BOX_READY_SECONDS = 30
+
+
+def _opencode_binary() -> str | None:
+    import shutil
+
+    return shutil.which("opencode")
+
+
+def _has_auth() -> bool:
+    return (Path.home() / ".local" / "share" / "opencode" / "auth.json").exists()
+
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        _opencode_binary() is None, reason="opencode binary not on PATH"
+    ),
+    pytest.mark.skipif(not _has_auth(), reason="opencode auth.json not found"),
+]
+
+
+def _strip_ansi(text: str) -> str:
+    import re
+
+    text = re.sub(r"\x1b\[[0-9;?]*[a-zA-Z]", "", text)
+    text = re.sub(r"\x1b[()][A-Z0-9]", "", text)
+    text = re.sub(r"\x1b\][^\x07]*\x07", "", text)
+    return text
+
+
+class _TuiProcess:
+    """A real opencode TUI running in a PTY with an accumulating capture."""
+
+    def __init__(self, workdir: Path, xdg_data: Path, config_dir: Path) -> None:
+        self.master_fd, slave_fd = pty.openpty()
+        fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 120, 0, 0))
+        env = dict(os.environ)
+        env["TERM"] = "xterm-256color"
+        env["XDG_DATA_HOME"] = str(xdg_data)
+        env["OPENCODE_CONFIG_DIR"] = str(config_dir)
+        env["OPENCODE_CONFIG_CONTENT"] = json.dumps(
+            {
+                "model": "deepseek/deepseek-v4-flash",
+                "autoupdate": False,
+                "default_agent": "build",
+            }
+        )
+        self.proc = subprocess.Popen(
+            ["opencode", "--pure"],
+            cwd=str(workdir),
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            env=env,
+            close_fds=True,
+            start_new_session=True,
+        )
+        os.close(slave_fd)
+        self._buffer = b""
+
+    def read_available(self, timeout: float = 0.2) -> None:
+        end = time.time() + timeout
+        while time.time() < end:
+            r, _, _ = select.select([self.master_fd], [], [], 0.1)
+            if not r:
+                continue
+            try:
+                chunk = os.read(self.master_fd, 65536)
+            except OSError as exc:
+                if exc.errno == errno.EIO:
+                    return
+                raise
+            if not chunk:
+                return
+            self._buffer += chunk
+
+    def text(self) -> str:
+        return _strip_ansi(self._buffer.decode("utf-8", "replace"))
+
+    def type(self, text: str) -> None:
+        os.write(self.master_fd, text.encode())
+
+    def close(self) -> None:
+        with contextlib.suppress(OSError):
+            os.write(self.master_fd, b"\x03")
+        self.proc.terminate()
+        try:
+            self.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+            self.proc.wait()
+        with contextlib.suppress(OSError):
+            os.close(self.master_fd)
+
+
+@pytest.fixture()
+def isolated_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolated opencode DB + config + mirror root, all in tmp_path."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    xdg_data = tmp_path / "xdg"
+    xdg_data.mkdir()
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    mirror_root = tmp_path / "mirrors"
+    monkeypatch.setenv("CCGRAM_OPENCODE_DB", str(xdg_data / "opencode" / "opencode.db"))
+    monkeypatch.setenv("CCGRAM_OPENCODE_DATA_DIR", str(mirror_root))
+    return workdir, xdg_data, config_dir, mirror_root
+
+
+def _wait_for_assistant_text(db_path: Path, deadline: float) -> str | None:
+    """Poll the isolated DB until an assistant text part appears."""
+    while time.time() < deadline:
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        except sqlite3.Error:
+            time.sleep(1)
+            continue
+        try:
+            row = conn.execute(
+                "SELECT p.data FROM part p JOIN message m ON p.message_id = m.id "
+                "WHERE json_extract(p.data, '$.type') = 'text' "
+                "AND json_extract(m.data, '$.role') = 'assistant' "
+                "AND length(json_extract(p.data, '$.text')) > 0 "
+                "ORDER BY p.time_created LIMIT 1"
+            ).fetchone()
+        except sqlite3.Error:
+            row = None
+        finally:
+            conn.close()
+        if row:
+            try:
+                return str(json.loads(row[0]).get("text") or "")
+            except json.JSONDecodeError, TypeError:
+                return ""
+        time.sleep(1)
+    return None
+
+
+def test_opencode_lifecycle_poll_and_parse(isolated_env: tuple) -> None:
+    workdir, xdg_data, config_dir, mirror_root = isolated_env
+    tui = _TuiProcess(workdir, xdg_data, config_dir)
+    try:
+        deadline = time.time() + _BOX_READY_SECONDS
+        while time.time() < deadline:
+            tui.read_available()
+            if "Ask anything" in tui.text():
+                break
+            time.sleep(0.3)
+        else:
+            pytest.fail(
+                "opencode TUI input box never appeared; output: " + tui.text()[-400:]
+            )
+
+        tui.type(_SMOKE_PROMPT)
+        time.sleep(1.5)
+        tui.read_available()
+        if _SMOKE_PROMPT not in tui.text():
+            pytest.fail("typed prompt was not echoed by the TUI")
+        tui.type("\r")
+
+        db_path = xdg_data / "opencode" / "opencode.db"
+        text = _wait_for_assistant_text(db_path, time.time() + _DB_POLL_SECONDS)
+        if not text:
+            pytest.fail(
+                "opencode never wrote an assistant text part; tail: "
+                + tui.text()[-400:]
+            )
+
+        # ── Provider round-trip ────────────────────────────────────────────
+        provider = OpenCodeProvider()
+        event = provider.discover_transcript(str(workdir), "ccgram:@e2e")
+        assert event is not None, "provider could not discover the live session"
+        assert event.cwd == str(workdir.resolve())
+
+        mirror = Path(event.transcript_path)
+        assert mirror.exists()
+
+        entries, offset = provider.read_transcript_file(str(mirror), 0)
+        assert offset > 0
+        messages, _ = provider.parse_transcript_entries(entries, {})
+        texts = [(m.role, m.text) for m in messages]
+        assert any(role == "user" and _SMOKE_PROMPT in t for role, t in texts)
+        assert any(role == "assistant" and "DONE" in t for role, t in texts)
+        # reasoning parts stay hidden
+        assert not any("The user wants me" in t for _role, t in texts)
+
+        # incremental read does not duplicate
+        entries2, offset2 = provider.read_transcript_file(str(mirror), offset)
+        assert offset2 >= offset
+        messages2, _ = provider.parse_transcript_entries(entries2, {})
+        assert messages2 == []
+
+        # resume picker sees the session
+        resumable = provider.discover_resumable_sessions(cwd=str(workdir.resolve()))
+        assert any(r.session_id == event.session_id for r in resumable)
+
+        # history parsing works for the user prompt
+        hist = [
+            provider.parse_history_entry(e)
+            for e in entries
+            if provider.is_user_transcript_entry(e)
+        ]
+        assert any(m is not None and _SMOKE_PROMPT in m.text for m in hist)
+    finally:
+        tui.close()


### PR DESCRIPTION
## Linked Issue

Closes #152

## What This Changes

Adds an `OpenCodeProvider` (SQLite event-log → JSONL mirror) with resume/continue/YOLO, a database-backed resume picker, thinking relay, and permission-banner extraction, plus the herdr `cwd` propagation it requires — so OpenCode sessions running in tmux/herdr can be driven from Telegram.

## Checklist

- [x] There is a linked issue above
- [x] `make test` passes (6203 passed; 22 pre-existing environmental worktree-test errors on the dev machine, present on untouched main)
- [x] `make lint` passes
- [x] This PR changes one thing only (OpenCode provider support, including its herdr prerequisite)
- [x] I added a test for the new behavior or the bug fix

---

### Design

- Transcript = per-session events in `opencode.db`, read with read-only sqlite connections
- A per-session JSONL mirror under `~/.ccgram/opencode/` reuses the existing file-based polling/history code; the mirror mtime is bumped on every read so the poll gate stays open
- Parts emit once, when settled; reasoning → `thinking`; discovery advances the cursor to the log end (no history replay)
- Interactive prompts: the TUI permission banner is extracted and surfaced as a `PermissionPrompt` with ccgram's navigation keyboard
- Includes the herdr `cwd` fix (see issue)

### Tests

- `tests/ccgram/providers/test_opencode.py` — unit tests on a fixture SQLite DB (discovery, incremental reads, dedupe, caps, resume, snapshot, thinking, permission extraction, path resolution, detection)
- `tests/ccgram/test_herdr_backend.py` + `test_herdr_identity_audit.py` — cwd propagation + narrowed identity audit
- `tests/e2e/test_opencode_lifecycle.py` — local e2e driving a real opencode TUI in a PTY (isolated XDG_DATA_HOME, skips without the binary)
- Contract tests extended for the new provider

**Verification:** `make check` green apart from pre-existing environmental errors (git GPG signing on the dev machine); `make arch-guard` 819 passed; live e2e passes locally (~24 s).
