### PR TITLE
Keep non-Latin filenames when saving an upload

### DIFF
--- a/src/ccgram/handlers/file_handler.py
+++ b/src/ccgram/handlers/file_handler.py
@@ -36,7 +36,7 @@ logger = structlog.get_logger()
 
 _UPLOAD_DIR = ".ccgram-uploads"
 
-_MAX_FILENAME_LEN = 200
+_MAX_FILENAME_BYTES = 200
 
 # Max file size in bytes (50 MB — Telegram Bot API limit for getFile)
 _MAX_FILE_SIZE = 50 * 1024 * 1024
@@ -66,6 +66,11 @@ def _keep_filename_char(char: str) -> bool:
     )
 
 
+def _truncate_utf8(text: str, max_bytes: int) -> str:
+    """Truncate text to a UTF-8 byte limit without splitting a character."""
+    return text.encode()[:max_bytes].decode(errors="ignore")
+
+
 def _sanitize_filename(name: str) -> str:
     """Sanitize a filename: keep letters, digits, marks and ._-, reject path traversal."""
     name = Path(name).name
@@ -75,14 +80,12 @@ def _sanitize_filename(name: str) -> str:
     name = "".join(char if _keep_filename_char(char) else "_" for char in name)
     if not name.strip("."):
         name = "unnamed"
-    # Truncate
-    if len(name) > _MAX_FILENAME_LEN:
+    if len(name.encode()) > _MAX_FILENAME_BYTES:
         suffix = Path(name).suffix
-        # Bound suffix length to avoid negative stem slice
-        if len(suffix) >= _MAX_FILENAME_LEN:
-            suffix = suffix[:10]
-        stem = Path(name).stem[: _MAX_FILENAME_LEN - len(suffix)]
-        name = stem + suffix
+        if len(suffix.encode()) >= _MAX_FILENAME_BYTES:
+            suffix = _truncate_utf8(suffix, 10)
+        stem_bytes = _MAX_FILENAME_BYTES - len(suffix.encode())
+        name = _truncate_utf8(Path(name).stem, stem_bytes) + suffix
     return name or "unnamed"
 
 

--- a/src/ccgram/handlers/file_handler.py
+++ b/src/ccgram/handlers/file_handler.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import structlog
 import re
+import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -40,7 +41,7 @@ _MAX_FILENAME_LEN = 200
 # Max file size in bytes (50 MB — Telegram Bot API limit for getFile)
 _MAX_FILE_SIZE = 50 * 1024 * 1024
 
-_SAFE_FILENAME_RE = re.compile(r"[^a-zA-Z0-9._-]")
+_FILENAME_PUNCT = frozenset("._-")
 
 # Control characters to strip from captions (keep \n and \t)
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
@@ -48,10 +49,30 @@ _CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 _MAX_CAPTION_LEN = 500
 
 
+def _keep_filename_char(char: str) -> bool:
+    """Whether a character may appear in a saved filename.
+
+    Letters and digits of any script, the marks that attach to them, and `._-`.
+    A rule written as ASCII letters replaces every character of a name in
+    another script, so a Cyrillic or Japanese name arrives as a row of
+    underscores and two different names collide. Marks are kept alongside
+    letters because Thai and Devanagari write their vowels as marks, and
+    dropping those cuts holes in the middle of a word.
+    """
+    return (
+        char in _FILENAME_PUNCT
+        or char.isalnum()
+        or unicodedata.category(char).startswith("M")
+    )
+
+
 def _sanitize_filename(name: str) -> str:
-    """Sanitize a filename: allow a-zA-Z0-9._-, reject path traversal."""
+    """Sanitize a filename: keep letters, digits, marks and ._-, reject path traversal."""
     name = Path(name).name
-    name = _SAFE_FILENAME_RE.sub("_", name)
+    # macOS reports decomposed names. Composing first keeps a mark attached to
+    # its letter rather than leaving it to be handled on its own.
+    name = unicodedata.normalize("NFC", name)
+    name = "".join(char if _keep_filename_char(char) else "_" for char in name)
     if not name.strip("."):
         name = "unnamed"
     # Truncate

--- a/tests/ccgram/handlers/test_file_handler.py
+++ b/tests/ccgram/handlers/test_file_handler.py
@@ -103,6 +103,11 @@ class TestSanitizeFilename:
         assert len(result) <= 200
         assert result.endswith(".pdf")
 
+    def test_truncates_multibyte_name_by_encoded_size(self) -> None:
+        result = _sanitize_filename("界" * 200 + ".pdf")
+        assert len(result.encode()) <= 200
+        assert result.endswith(".pdf")
+
 
 class TestUniqueDest:
     def test_returns_original_if_not_exists(self, tmp_path: Path) -> None:

--- a/tests/ccgram/handlers/test_file_handler.py
+++ b/tests/ccgram/handlers/test_file_handler.py
@@ -1,6 +1,7 @@
 """Tests for file_handler helper functions."""
 
 import re
+import unicodedata
 from pathlib import Path
 
 import pytest
@@ -18,21 +19,83 @@ class TestSanitizeFilename:
     @pytest.mark.parametrize(
         ("input_name", "expected"),
         [
+            # ASCII names pass through untouched
             ("document.pdf", "document.pdf"),
             ("file-name_123.txt", "file-name_123.txt"),
+            # path traversal is stripped to the basename
             ("/etc/passwd", "passwd"),
             ("../../../etc/passwd", "passwd"),
             ("../../etc/passwd", "passwd"),
+            # punctuation and whitespace still collapse to underscores
             ("hello world!.txt", "hello_world_.txt"),
             ("file@#$.txt", "file___.txt"),
+            ("quote'and\"double.txt", "quote_and_double.txt"),
+            ("semi;colon&amp.sh", "semi_colon_amp.sh"),
+            ("tab\tand\nnewline.txt", "tab_and_newline.txt"),
+            # names that sanitize down to nothing usable
             ("..", "unnamed"),
             (".", "unnamed"),
             ("...", "unnamed"),
             ("", "unnamed"),
+            # non-Latin scripts survive, which is the point of this test
+            ("Отчёт за 2025.pdf", "Отчёт_за_2025.pdf"),
+            ("договор.docx", "договор.docx"),
+            ("Λογαριασμός.pdf", "Λογαριασμός.pdf"),
+            ("请求书.xlsx", "请求书.xlsx"),
+            ("領収書.pdf", "領収書.pdf"),
+            ("فاتورة.pdf", "فاتورة.pdf"),
+            ("חשבונית.pdf", "חשבונית.pdf"),
+            # Thai writes vowels as combining marks, which are not word
+            # characters, so a \\w-only rule would punch holes in the word
+            ("ใบเสร็จ.pdf", "ใบเสร็จ.pdf"),
+            ("नमस्ते.pdf", "नमस्ते.pdf"),
+            ("송장.pdf", "송장.pdf"),
+            # mixed scripts and digits keep both halves
+            ("invoice-Счёт-2025.pdf", "invoice-Счёт-2025.pdf"),
+            ("café.txt", "café.txt"),
+            # non-word characters go regardless of script
+            ("Счёт №5-2025.pdf", "Счёт__5-2025.pdf"),
+            ("файл (копия).txt", "файл__копия_.txt"),
+            # emoji and other symbols are not word characters
+            ("report📊.pdf", "report_.pdf"),
+            # bidi override cannot be smuggled into the saved name
+            ("safe‮gnp.exe", "safe_gnp.exe"),
+            # a traversal attempt written in Cyrillic is still a basename
+            ("../отчёты/итог.pdf", "итог.pdf"),
         ],
     )
     def test_sanitize(self, input_name: str, expected: str) -> None:
         assert _sanitize_filename(input_name) == expected
+
+    def test_composes_before_substituting(self) -> None:
+        """A decomposed name keeps its accents.
+
+        macOS reports names in NFD, where the combining mark is a separate
+        character and not a word character, so without composing first it
+        would be replaced on its own and leave a bare letter behind.
+        """
+        decomposed = unicodedata.normalize("NFD", "Отчёт.pdf")
+        assert decomposed != "Отчёт.pdf"
+        assert _sanitize_filename(decomposed) == "Отчёт.pdf"
+
+    @pytest.mark.parametrize(
+        ("first", "second"),
+        [
+            ("Отчёт.pdf", "Договор.pdf"),
+            ("请求书.xlsx", "领收书.xlsx"),
+            ("فاتورة.pdf", "ايصال.pdf"),
+        ],
+    )
+    def test_distinct_non_latin_names_stay_distinct(
+        self, first: str, second: str
+    ) -> None:
+        """Two names of equal length used to sanitize to the same underscores.
+
+        The saved file then shadowed the earlier one, and the message quoting
+        the path said nothing about which document it was.
+        """
+        assert _sanitize_filename(first) != _sanitize_filename(second)
+        assert "_" not in _sanitize_filename(first)
 
     def test_truncates_long_names_preserving_extension(self) -> None:
         long = "a" * 250 + ".pdf"


### PR DESCRIPTION
## Linked Issue

Closes #160

## What This Changes

`_sanitize_filename` replaced every character outside `a-zA-Z0-9._-`, so a document named in any other script was saved as a row of underscores and two names of equal length collided. It now keeps letters and digits of any script, the marks that attach to them, and `._-`.

Everything else still becomes an underscore, so path separators, spaces, quotes, control characters and bidi overrides cannot reach the saved name, and `Path(name).name` still strips traversal.

Two details behind the implementation:

- `\w` on its own is not enough. Thai and Devanagari write vowels as combining marks, which are not word characters, so a `\w` rule keeps the consonants and drops the vowels out of the middle of the word. The check therefore accepts marks alongside letters and digits.
- Names are composed to NFC first. macOS reports them decomposed, where a combining mark is a separate character that would be handled on its own and leave a bare letter behind.

The table test now covers Cyrillic, Greek, Chinese, Japanese, Arabic, Hebrew, Thai, Devanagari and Korean names, mixed-script names, and a decomposed name, alongside the existing traversal, punctuation and empty-name cases. Two extra tests pin the behaviour that motivated the change: composition before substitution, and distinct non-Latin names staying distinct.

One note on the checklist below: `tests/ccgram/tts/test_edge.py::test_synthesize_wraps_edge_exceptions_as_tts_error` fails on current `main` for me before this branch touches anything, so I have left it alone. Everything else passes, 6180 tests, and `ruff check src/ tests/` is clean.

## Checklist

- [x] There is a linked issue above
- [x] `make test` passes
- [x] `make lint` passes
- [x] This PR changes one thing only
- [x] I added a test for the new behavior or the bug fix
