### PR TITLE
fix: settle topic status correctly after restart

### DIFF
--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -239,10 +239,36 @@ async def start_session_monitor(application: Application) -> SessionMonitor:
     return monitor
 
 
+def _settle_preexisting_windows() -> None:
+    """Seed already-bound windows for an immediate, settled first poll."""
+    # Lazy: these status and routing singletons are wired before polling starts.
+    from .handlers.polling.polling_state import terminal_poll_state
+    from .handlers.status.topic_emoji import mark_awaiting_first_paint
+    from .thread_router import thread_router
+
+    for (
+        user_id,
+        chat_id,
+        thread_id,
+        window_id,
+    ) in thread_router.iter_thread_bindings_with_chat():
+        if not window_id:
+            continue
+        terminal_poll_state.mark_seen_status(window_id)
+        resolved_chat_id = (
+            chat_id
+            if chat_id is not None
+            else thread_router.resolve_chat_id(user_id, thread_id)
+        )
+        if resolved_chat_id:
+            mark_awaiting_first_paint(resolved_chat_id, thread_id)
+
+
 def start_status_polling(application: Application) -> asyncio.Task[None]:
     """Spawn the status-polling background task."""
     global _status_poll_task
 
+    _settle_preexisting_windows()
     _status_poll_task = asyncio.create_task(status_poll_loop(application.bot))
     _status_poll_task.add_done_callback(task_done_callback)
     logger.info("Status polling task started")

--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -32,7 +32,9 @@ from .handlers.hook_events import dispatch_hook_event
 from .handlers.messaging_pipeline.message_queue import shutdown_workers
 from .handlers.messaging_pipeline.message_routing import handle_new_message
 from .handlers.polling.polling_coordinator import status_poll_loop
+from .handlers.polling.polling_state import terminal_poll_state
 from .handlers.shell import register_approval_callback, show_command_approval
+from .handlers.status.topic_emoji import mark_awaiting_first_paint
 from .handlers.topics.topic_orchestration import (
     adopt_unbound_windows as _adopt_unbound_windows,
 )
@@ -43,6 +45,7 @@ from .multiplexer import get_multiplexer, install_multiplexer, multiplexer
 from .providers import get_provider
 from .session import session_manager
 from .telegram_client import PTBTelegramClient
+from .thread_router import thread_router
 from .session_monitor import (
     NewMessage,
     NewWindowEvent,
@@ -241,11 +244,6 @@ async def start_session_monitor(application: Application) -> SessionMonitor:
 
 def _settle_preexisting_windows() -> None:
     """Seed already-bound windows for an immediate, settled first poll."""
-    # Lazy: these status and routing singletons are wired before polling starts.
-    from .handlers.polling.polling_state import terminal_poll_state
-    from .handlers.status.topic_emoji import mark_awaiting_first_paint
-    from .thread_router import thread_router
-
     for (
         user_id,
         chat_id,

--- a/src/ccgram/handlers/polling/polling_state.py
+++ b/src/ccgram/handlers/polling/polling_state.py
@@ -359,12 +359,6 @@ class TerminalPollState:
         for ws in self._states.values():
             ws.unbound_timer = None
 
-    def cancel_startup_timer(self, window_id: str) -> None:
-        """Clear startup grace period without touching has_seen_status."""
-        ws = self._states.get(window_id)
-        if ws:
-            ws.startup_time = None
-
     def begin_startup_timer(self, window_id: str, now: float) -> None:
         """Record the moment a window's startup grace period begins."""
         self.get_state(window_id).startup_time = now

--- a/src/ccgram/handlers/polling/window_tick/apply.py
+++ b/src/ccgram/handlers/polling/window_tick/apply.py
@@ -115,7 +115,12 @@ async def _transition_to_idle(
 ) -> None:
     ps = runtime.poll_state if runtime is not None else terminal_poll_state
     lc = runtime.lifecycle if runtime is not None else lifecycle_strategy
-    ps.cancel_startup_timer(window_id)
+    # Settle the window, don't just stop its clock: clearing the startup
+    # timestamp alone leaves it indistinguishable from one that never started,
+    # so the very next tick decides "starting" again — green topic, typing
+    # indicator, another 30s grace, idle, repeat. A window that reached idle
+    # has finished starting.
+    ps.mark_seen_status(window_id)
     client = PTBTelegramClient(bot)
     await update_topic_emoji(client, chat_id, thread_id, "idle", display)
     lc.clear_autoclose_timer(user_id, thread_id)
@@ -445,14 +450,17 @@ async def _apply_done_transition(
     lc = runtime.lifecycle if runtime is not None else lifecycle_strategy
     chat_id = thread_router.resolve_chat_id(user_id, thread_id)
     display = thread_router.get_display_name(window_id)
-    ps.cancel_startup_timer(window_id)
+    # Same reason as the idle transition: a window that reached done has
+    # finished starting, whoever reports its completion. Leaving the flag
+    # unset for hook-backed providers put exactly those windows — the ones
+    # whose Stop hook makes done reliable — back into the startup grace on
+    # the next tick, so a finished agent kept re-painting its topic green.
+    ps.mark_seen_status(window_id)
     client = PTBTelegramClient(bot)
     await update_topic_emoji(client, chat_id, thread_id, "done", display)
     lc.start_autoclose_timer(user_id, thread_id, "done", time.monotonic())
     lc.clear_typing_state(user_id, thread_id)
     await enqueue_status_update(client, user_id, window_id, None, thread_id=thread_id)
-    if not _get_provider(window_id).capabilities.supports_hook:
-        ps.mark_seen_status(window_id)
 
 
 async def _apply_starting_transition(

--- a/src/ccgram/handlers/status/topic_emoji.py
+++ b/src/ccgram/handlers/status/topic_emoji.py
@@ -93,6 +93,10 @@ _topic_states: dict[tuple[int, int], tuple[str, str, bool]] = {}
 # Pending transitions: (chat_id, thread_id) -> (desired_state, first_seen_monotonic)
 _pending_transitions: dict[tuple[int, int], tuple[str, float]] = {}
 
+# Topics inherited at process startup. Their first observed state replaces the
+# stale state left by the previous process without waiting for debounce.
+_awaiting_first_paint: set[tuple[int, int]] = set()
+
 # Topic display names: (chat_id, thread_id) -> clean name (without emoji prefix).
 # Updated when the incoming display name changes (write-through cache) so that
 # tmux window renames and Telegram topic renames propagate correctly.
@@ -132,6 +136,11 @@ def _should_apply_update(
     if _topic_states.get(key) == state_token:
         _pending_transitions.pop(key, None)
         return name_changed
+
+    if key in _awaiting_first_paint:
+        _awaiting_first_paint.discard(key)
+        _pending_transitions.pop(key, None)
+        return True
 
     pending = _pending_transitions.get(key)
     if pending is None or pending[0] != state:
@@ -366,6 +375,12 @@ def clear_topic_emoji_state(chat_id: int, thread_id: int) -> None:
     _topic_states.pop(key, None)
     _pending_transitions.pop(key, None)
     _topic_names.pop(key, None)
+    _awaiting_first_paint.discard(key)
+
+
+def mark_awaiting_first_paint(chat_id: int, thread_id: int) -> None:
+    """Let an inherited topic apply its next observed state without debounce."""
+    _awaiting_first_paint.add((chat_id, thread_id))
 
 
 _MAX_DISABLED_CHATS = 1000
@@ -383,5 +398,6 @@ def reset_all_state() -> None:
     """Reset all tracking state (for testing)."""
     _topic_states.clear()
     _pending_transitions.clear()
+    _awaiting_first_paint.clear()
     _disabled_chats.clear()
     _topic_names.clear()

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import aiofiles
 import structlog
@@ -36,6 +36,12 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 _PathResolveError = (OSError, ValueError)
+
+
+class _StartupBoundary(NamedTuple):
+    size: int
+    device: int
+    inode: int
 
 
 def _resolve_provider_for_file(window_id: str, file_path: Path) -> Any:
@@ -93,12 +99,71 @@ class TranscriptReader:
         self._idle_tracker = idle_tracker
         self._pending_tools: dict[str, dict[str, Any]] = {}
         self._file_mtimes: dict[str, float] = {}
+        self._file_generations = self._snapshot_file_generations()
+        self._startup_file_boundaries = self._snapshot_startup_boundaries()
+
+    def _snapshot_file_generations(self) -> dict[str, tuple[int, int]]:
+        generations: dict[str, tuple[int, int]] = {}
+        for session_id, tracked in self._state.tracked_sessions.items():
+            try:
+                st = Path(tracked.file_path).stat()
+            except OSError:
+                continue
+            generations[session_id] = (st.st_dev, st.st_ino)
+        return generations
+
+    def _snapshot_startup_boundaries(self) -> dict[str, _StartupBoundary]:
+        """Capture each tracked transcript generation and its pre-start EOF."""
+        boundaries: dict[str, _StartupBoundary] = {}
+        for session_id, tracked in self._state.tracked_sessions.items():
+            try:
+                st = Path(tracked.file_path).stat()
+            except OSError:
+                continue
+            boundaries[session_id] = _StartupBoundary(
+                size=st.st_size,
+                device=st.st_dev,
+                inode=st.st_ino,
+            )
+        return boundaries
+
+    def _prepare_startup_boundary(
+        self, session_id: str, tracked: TrackedSession, st: Any
+    ) -> _StartupBoundary | None:
+        """Reset post-start replacements and return the activity boundary."""
+        boundary = self._startup_file_boundaries.get(session_id)
+        if boundary is None:
+            return None
+        generation_changed = (st.st_dev, st.st_ino) != (
+            boundary.device,
+            boundary.inode,
+        )
+        if generation_changed or st.st_size < boundary.size:
+            tracked.last_byte_offset = 0
+            boundary = _StartupBoundary(
+                size=0,
+                device=st.st_dev,
+                inode=st.st_ino,
+            )
+            self._startup_file_boundaries[session_id] = boundary
+        return boundary
+
+    async def _read_session_entries(
+        self, tracked: TrackedSession, file_path: Path, window_id: str
+    ) -> list[dict] | None:
+        """Read once, preserving startup state when the file is unavailable."""
+        try:
+            return await self._read_new_lines(tracked, file_path, window_id)
+        except OSError:
+            return None
 
     def clear_session(self, session_id: str) -> None:
         """Remove all per-session state for a cleaned-up session."""
         self._state.remove_session(session_id)
         self._file_mtimes.pop(session_id, None)
         self._pending_tools.pop(session_id, None)
+        self._file_generations.pop(session_id, None)
+        self._startup_file_boundaries.pop(session_id, None)
         log_throttle_reset(f"partial-jsonl:{session_id}")
 
     def _adopt_tracking_for_file(
@@ -129,9 +194,17 @@ class TranscriptReader:
             self._state.update_session(tracked)
             if old_session_id in self._file_mtimes:
                 self._file_mtimes[session_id] = self._file_mtimes.pop(old_session_id)
+            if old_session_id in self._file_generations:
+                self._file_generations[session_id] = self._file_generations.pop(
+                    old_session_id
+                )
             if old_session_id in self._pending_tools:
                 self._pending_tools[session_id] = self._pending_tools.pop(
                     old_session_id
+                )
+            if old_session_id in self._startup_file_boundaries:
+                self._startup_file_boundaries[session_id] = (
+                    self._startup_file_boundaries.pop(old_session_id)
                 )
             log_throttle_reset(f"partial-jsonl:{old_session_id}")
             logger.debug(
@@ -165,6 +238,9 @@ class TranscriptReader:
             except OSError:
                 file_size = 0
                 current_mtime = 0.0
+                generation = None
+            else:
+                generation = (st.st_dev, st.st_ino)
 
             if provider.capabilities.supports_incremental_read:
                 initial_offset = file_size
@@ -180,6 +256,8 @@ class TranscriptReader:
             )
             self._state.update_session(tracked)
             self._file_mtimes[session_id] = current_mtime
+            if generation is not None:
+                self._file_generations[session_id] = generation
             if provider.capabilities.supports_task_tracking and window_id:
                 await provider.seed_task_state(window_id, session_id, str(file_path))
             logger.debug("Started tracking session: %s", session_id)
@@ -191,6 +269,16 @@ class TranscriptReader:
         except OSError:
             return
 
+        generation = (st.st_dev, st.st_ino)
+        previous_generation = self._file_generations.get(session_id)
+        generation_changed = (
+            previous_generation is not None and previous_generation != generation
+        )
+        if generation_changed:
+            tracked.last_byte_offset = 0
+            self._startup_file_boundaries.pop(session_id, None)
+        self._file_generations[session_id] = generation
+
         last_mtime = self._file_mtimes.get(session_id, 0.0)
         if provider.capabilities.supports_incremental_read:
             if current_mtime <= last_mtime and current_size <= tracked.last_byte_offset:
@@ -199,50 +287,79 @@ class TranscriptReader:
             if current_mtime <= last_mtime:
                 return
 
-        new_entries = await self._read_new_lines(tracked, file_path, window_id)
+        startup_boundary = (
+            None
+            if generation_changed or not provider.capabilities.supports_incremental_read
+            else self._prepare_startup_boundary(session_id, tracked, st)
+        )
+        new_entries = await self._read_session_entries(tracked, file_path, window_id)
+        if new_entries is None:
+            return
         self._file_mtimes[session_id] = current_mtime
 
-        if new_entries:
+        # Deliver pre-start unread history, but count activity only when a
+        # complete entry advances beyond the startup file-size boundary.
+        has_live_entries = startup_boundary is None or (
+            tracked.last_byte_offset > startup_boundary.size
+        )
+        if startup_boundary is not None and (
+            tracked.last_byte_offset >= startup_boundary.size
+        ):
+            self._startup_file_boundaries.pop(session_id, None)
+        if new_entries and has_live_entries:
             self._idle_tracker.record_activity(session_id)
+        self._append_provider_messages(
+            session_id,
+            new_entries,
+            provider,
+            current_map,
+            window_id,
+            new_messages,
+        )
+        self._state.update_session(tracked)
 
+    def _append_provider_messages(
+        self,
+        session_id: str,
+        new_entries: list[dict],
+        provider: Any,
+        current_map: dict[str, dict[str, Any]] | None,
+        window_id: str,
+        new_messages: list[NewMessage],
+    ) -> None:
         if provider.capabilities.supports_task_tracking and window_id:
             provider.apply_task_entries(window_id, session_id, new_entries)
-
-        carry = self._pending_tools.get(session_id, {})
-        session_cwd: str | None = None
-        if current_map:
-            for wkey, details in current_map.items():
-                if details.get("session_id") == session_id:
-                    session_cwd = details.get("cwd")
-                    break
-
+        session_cwd = next(
+            (
+                details.get("cwd")
+                for details in (current_map or {}).values()
+                if details.get("session_id") == session_id
+            ),
+            None,
+        )
         agent_messages, remaining = provider.parse_transcript_entries(
             new_entries,
-            pending_tools=carry,
+            pending_tools=self._pending_tools.get(session_id, {}),
             cwd=session_cwd,
         )
         if remaining:
             self._pending_tools[session_id] = remaining
         else:
             self._pending_tools.pop(session_id, None)
-
-        for entry in agent_messages:
-            if not entry.text:
-                continue
-            new_messages.append(
-                NewMessage(
-                    session_id=session_id,
-                    text=entry.text,
-                    is_complete=entry.is_complete,
-                    content_type=entry.content_type,
-                    phase=entry.phase,
-                    tool_use_id=entry.tool_use_id,
-                    role=entry.role,
-                    tool_name=entry.tool_name,
-                )
+        new_messages.extend(
+            NewMessage(
+                session_id=session_id,
+                text=entry.text,
+                is_complete=entry.is_complete,
+                content_type=entry.content_type,
+                phase=entry.phase,
+                tool_use_id=entry.tool_use_id,
+                role=entry.role,
+                tool_name=entry.tool_name,
             )
-
-        self._state.update_session(tracked)
+            for entry in agent_messages
+            if entry.text
+        )
 
     async def _read_new_lines(
         self, session: TrackedSession, file_path: Path, window_id: str = ""
@@ -307,6 +424,7 @@ class TranscriptReader:
 
         except OSError:
             logger.exception("Error reading session file %s", file_path)
+            raise
         return new_entries
 
     async def _read_whole_file(
@@ -326,7 +444,7 @@ class TranscriptReader:
             return new_entries
         except OSError:
             logger.exception("Error reading transcript file %s", file_path)
-            return []
+            raise
 
     async def _get_active_cwds(self) -> set[str]:
         """Get normalized cwds of all active tmux windows."""

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -281,11 +281,14 @@ class TranscriptReader:
 
         last_mtime = self._file_mtimes.get(session_id, 0.0)
         if provider.capabilities.supports_incremental_read:
-            if current_mtime <= last_mtime and current_size <= tracked.last_byte_offset:
+            if (
+                not generation_changed
+                and current_mtime <= last_mtime
+                and current_size <= tracked.last_byte_offset
+            ):
                 return
-        else:
-            if current_mtime <= last_mtime:
-                return
+        elif not generation_changed and current_mtime <= last_mtime:
+            return
 
         startup_boundary = (
             None

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -19,6 +19,7 @@ from ccgram.handlers.polling.window_tick import (
     _scan_window_panes,
     decide_tick,
 )
+from ccgram.handlers.polling.polling_runtime import PollingRuntime
 from ccgram.handlers.polling.polling_state import (
     interactive_strategy,
     lifecycle_strategy,
@@ -652,6 +653,58 @@ class TestTransitionToIdle:
         mock_enqueue.assert_called_once()
         assert mock_enqueue.call_args[0][3] == IDLE_STATUS_TEXT
         assert mock_enqueue.call_args[1]["thread_id"] == 42
+
+
+class TestSettledWindowsStaySettled:
+    """A quiet window must not fall back into the startup grace.
+
+    ``starting`` paints the topic active and sends a typing indicator, so a
+    window that keeps re-entering it looks busy forever: green topic, typing
+    indicator that never clears, and a 30s sawtooth back through idle.
+    """
+
+    async def _run(self, transition: str, *, supports_hook: bool) -> str | None:
+        from ccgram.handlers.polling.window_tick import (
+            _apply_done_transition,
+            _transition_to_idle,
+        )
+
+        runtime = PollingRuntime.create()
+        bot = AsyncMock(spec=Bot)
+        with (
+            patch("ccgram.handlers.polling.window_tick.apply.update_topic_emoji"),
+            patch("ccgram.handlers.polling.window_tick.apply.enqueue_status_update"),
+            patch(
+                "ccgram.handlers.polling.window_tick.apply.thread_router"
+            ) as mock_router,
+        ):
+            mock_router.resolve_chat_id.return_value = -100
+            mock_router.get_display_name.return_value = "project"
+            if transition == "idle":
+                await _transition_to_idle(
+                    bot, 1, "@0", 42, -100, "project", runtime=runtime
+                )
+            else:
+                await _apply_done_transition(bot, 1, "@0", 42, runtime=runtime)
+
+        poll_state = runtime.poll_state.peek_state("@0")
+        assert poll_state is not None
+        return decide_tick(
+            _make_ctx(
+                has_seen_status=runtime.poll_state.check_seen_status("@0"),
+                startup_time=poll_state.startup_time,
+                supports_hook=supports_hook,
+            )
+        ).transition
+
+    async def test_idle_window_stays_idle_on_the_next_tick(self) -> None:
+        assert await self._run("idle", supports_hook=True) == "idle"
+
+    async def test_done_window_does_not_restart_its_grace(self) -> None:
+        assert await self._run("done", supports_hook=True) == "idle"
+
+    async def test_hookless_done_window_also_settles(self) -> None:
+        assert await self._run("done", supports_hook=False) == "idle"
 
 
 class TestShellPromptClearsStatus:

--- a/tests/ccgram/handlers/status/test_topic_emoji.py
+++ b/tests/ccgram/handlers/status/test_topic_emoji.py
@@ -18,6 +18,7 @@ from ccgram.handlers.status.topic_emoji import (
     EMOJI_YOLO,
     clear_topic_emoji_state,
     format_topic_name_for_mode,
+    mark_awaiting_first_paint,
     reset_all_state,
     sync_topic_name,
     strip_emoji_prefix,
@@ -103,6 +104,42 @@ async def _debounced_update(
         await update_topic_emoji(bot, chat_id, thread_id, state, display_name)
         mock_monotonic.return_value = _debounce_for(state) + 0.1
         await update_topic_emoji(bot, chat_id, thread_id, state, display_name)
+
+
+class TestInheritedTopicsRepaintImmediately:
+    async def test_seeded_topic_paints_without_waiting(self) -> None:
+        bot = AsyncMock()
+        mark_awaiting_first_paint(-100, 42)
+
+        with patch(_PATCH_MONOTONIC, return_value=0.0):
+            await update_topic_emoji(bot, -100, 42, "idle", "myproject")
+
+        bot.edit_forum_topic.assert_called_once_with(
+            chat_id=-100,
+            message_thread_id=42,
+            name=f"{EMOJI_IDLE} myproject",
+        )
+
+    async def test_only_the_first_sighting_skips_the_debounce(self) -> None:
+        bot = AsyncMock()
+        mark_awaiting_first_paint(-100, 42)
+        with patch(_PATCH_MONOTONIC, return_value=0.0):
+            await update_topic_emoji(bot, -100, 42, "idle", "myproject")
+        bot.edit_forum_topic.reset_mock()
+
+        with patch(_PATCH_MONOTONIC, return_value=0.0):
+            await update_topic_emoji(bot, -100, 42, "active", "myproject")
+
+        bot.edit_forum_topic.assert_not_called()
+
+    async def test_unseeded_topic_still_debounces(self) -> None:
+        bot = AsyncMock()
+        mark_awaiting_first_paint(-100, 42)
+
+        with patch(_PATCH_MONOTONIC, return_value=0.0):
+            await update_topic_emoji(bot, -100, 99, "idle", "other")
+
+        bot.edit_forum_topic.assert_not_called()
 
 
 _STATE_EMOJI = [

--- a/tests/ccgram/test_bootstrap.py
+++ b/tests/ccgram/test_bootstrap.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -84,6 +84,42 @@ class TestWireRuntimeCallbacks:
         bootstrap.wire_runtime_callbacks()
 
         assert bootstrap._callbacks_wired is True
+
+
+class TestSettlePreexistingWindows:
+    def test_preserves_chat_identity_for_same_numbered_threads(self) -> None:
+        from ccgram.handlers.polling.polling_state import terminal_poll_state
+
+        bindings = [
+            (7, -1001, 42, "@3"),
+            (7, -1002, 42, "@4"),
+            (7, None, 43, "@5"),
+        ]
+        with (
+            patch("ccgram.thread_router.thread_router") as mock_router,
+            patch(
+                "ccgram.handlers.status.topic_emoji.mark_awaiting_first_paint"
+            ) as mark_first,
+        ):
+            mock_router.iter_thread_bindings_with_chat.return_value = bindings
+            mock_router.resolve_chat_id.return_value = -1003
+
+            bootstrap._settle_preexisting_windows()
+
+        try:
+            assert all(
+                terminal_poll_state.check_seen_status(window_id)
+                for *_, window_id in bindings
+            )
+            assert mark_first.call_args_list == [
+                call(-1001, 42),
+                call(-1002, 42),
+                call(-1003, 43),
+            ]
+            mock_router.resolve_chat_id.assert_called_once_with(7, 43)
+        finally:
+            for *_, window_id in bindings:
+                terminal_poll_state.clear_seen_status(window_id)
 
 
 class TestBootstrapApplication:

--- a/tests/ccgram/test_bootstrap.py
+++ b/tests/ccgram/test_bootstrap.py
@@ -96,10 +96,8 @@ class TestSettlePreexistingWindows:
             (7, None, 43, "@5"),
         ]
         with (
-            patch("ccgram.thread_router.thread_router") as mock_router,
-            patch(
-                "ccgram.handlers.status.topic_emoji.mark_awaiting_first_paint"
-            ) as mark_first,
+            patch("ccgram.bootstrap.thread_router") as mock_router,
+            patch("ccgram.bootstrap.mark_awaiting_first_paint") as mark_first,
         ):
             mock_router.iter_thread_bindings_with_chat.return_value = bindings
             mock_router.resolve_chat_id.return_value = -1003

--- a/tests/ccgram/test_transcript_reader.py
+++ b/tests/ccgram/test_transcript_reader.py
@@ -1,5 +1,7 @@
 """Tests for transcript reader offset handling."""
 
+from unittest.mock import AsyncMock, patch
+
 from ccgram.idle_tracker import IdleTracker
 from ccgram.monitor_state import MonitorState, TrackedSession
 from ccgram.transcript_reader import TranscriptReader
@@ -40,3 +42,136 @@ async def test_same_transcript_reuses_offset_after_session_map_refresh(
     tracked = state.get_session("sess-after-rename")
     assert tracked is not None
     assert tracked.last_byte_offset == session_file.stat().st_size
+
+
+async def test_catch_up_read_after_restart_is_not_activity(tmp_path) -> None:
+    old = '{"type":"assistant","message":{"content":[{"type":"text","text":"a"}]}}\n'
+    unread = '{"type":"assistant","message":{"content":[{"type":"text","text":"b"}]}}\n'
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(old + unread, newline="\n")
+
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess",
+            file_path=str(session_file),
+            last_byte_offset=len(old.encode()),
+        )
+    )
+    idle = IdleTracker()
+    reader = TranscriptReader(state, idle)
+
+    messages = []
+    await reader._process_session_file("sess", session_file, messages, window_id="@1")
+
+    assert [msg.text for msg in messages] == ["b"]
+    assert idle.get_last_activity("sess") is None
+
+
+async def test_first_poll_counts_only_bytes_written_after_startup(tmp_path) -> None:
+    old = '{"type":"assistant","message":{"content":[{"type":"text","text":"a"}]}}\n'
+    unread = '{"type":"assistant","message":{"content":[{"type":"text","text":"b"}]}}\n'
+    fresh = '{"type":"assistant","message":{"content":[{"type":"text","text":"c"}]}}\n'
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(old + unread, newline="\n")
+
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess",
+            file_path=str(session_file),
+            last_byte_offset=len(old.encode()),
+        )
+    )
+    idle = IdleTracker()
+    reader = TranscriptReader(state, idle)
+    with session_file.open("a") as transcript:
+        transcript.write(fresh)
+
+    messages = []
+    await reader._process_session_file("sess", session_file, messages, window_id="@1")
+
+    assert [msg.text for msg in messages] == ["b", "c"]
+    assert idle.get_last_activity("sess") is not None
+
+
+async def test_post_start_truncation_begins_a_live_file_generation(tmp_path) -> None:
+    old = '{"type":"assistant","message":{"content":[{"type":"text","text":"old"}]}}\n'
+    history = old * 10
+    fresh = (
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"new"}]}}\n'
+    )
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(history, newline="\n")
+
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess",
+            file_path=str(session_file),
+            last_byte_offset=len(old.encode()) * 5,
+        )
+    )
+    idle = IdleTracker()
+    reader = TranscriptReader(state, idle)
+    session_file.write_text(fresh, newline="\n")
+
+    messages = []
+    await reader._process_session_file("sess", session_file, messages, window_id="@1")
+
+    assert [msg.text for msg in messages] == ["new"]
+    assert idle.get_last_activity("sess") is not None
+
+
+async def test_atomic_replacement_after_start_is_read_from_zero(tmp_path) -> None:
+    old = '{"type":"assistant","message":{"content":[{"type":"text","text":"old"}]}}\n'
+    fresh = (
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"fresh"}]}}\n'
+    )
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(old, newline="\n")
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess", file_path=str(session_file), last_byte_offset=0
+        )
+    )
+    reader = TranscriptReader(state, IdleTracker())
+    await reader._process_session_file("sess", session_file, [], window_id="@1")
+
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text(fresh, newline="\n")
+    replacement.replace(session_file)
+    messages = []
+    await reader._process_session_file("sess", session_file, messages, window_id="@1")
+
+    assert [msg.text for msg in messages] == ["fresh"]
+
+
+async def test_failed_startup_read_preserves_catch_up_boundary(tmp_path) -> None:
+    old = '{"type":"assistant","message":{"content":[{"type":"text","text":"a"}]}}\n'
+    unread = '{"type":"assistant","message":{"content":[{"type":"text","text":"b"}]}}\n'
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(old + unread, newline="\n")
+
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess",
+            file_path=str(session_file),
+            last_byte_offset=len(old.encode()),
+        )
+    )
+    idle = IdleTracker()
+    reader = TranscriptReader(state, idle)
+
+    with patch.object(
+        reader, "_read_new_lines", new=AsyncMock(side_effect=OSError("busy"))
+    ):
+        await reader._process_session_file("sess", session_file, [], window_id="@1")
+
+    messages = []
+    await reader._process_session_file("sess", session_file, messages, window_id="@1")
+
+    assert [msg.text for msg in messages] == ["b"]
+    assert idle.get_last_activity("sess") is None

--- a/tests/ccgram/test_transcript_reader.py
+++ b/tests/ccgram/test_transcript_reader.py
@@ -1,5 +1,7 @@
 """Tests for transcript reader offset handling."""
 
+import os
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from ccgram.idle_tracker import IdleTracker
@@ -146,6 +148,44 @@ async def test_atomic_replacement_after_start_is_read_from_zero(tmp_path) -> Non
     await reader._process_session_file("sess", session_file, messages, window_id="@1")
 
     assert [msg.text for msg in messages] == ["fresh"]
+
+
+async def test_whole_file_replacement_bypasses_unchanged_mtime(tmp_path) -> None:
+    session_file = tmp_path / "transcript.json"
+    session_file.write_text("old")
+    old_stat = session_file.stat()
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess", file_path=str(session_file), last_byte_offset=0
+        )
+    )
+    reader = TranscriptReader(state, IdleTracker())
+    provider = SimpleNamespace(
+        capabilities=SimpleNamespace(
+            supports_incremental_read=False,
+            supports_task_tracking=False,
+        )
+    )
+
+    with (
+        patch(
+            "ccgram.transcript_reader._resolve_provider_for_file", return_value=provider
+        ),
+        patch.object(
+            reader, "_read_session_entries", new=AsyncMock(return_value=[])
+        ) as read,
+        patch.object(reader, "_append_provider_messages"),
+    ):
+        await reader._process_session_file("sess", session_file, [], window_id="@1")
+        replacement = tmp_path / "replacement.json"
+        replacement.write_text("new")
+        replacement.replace(session_file)
+        os.utime(session_file, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns))
+
+        await reader._process_session_file("sess", session_file, [], window_id="@1")
+
+    assert read.await_count == 2
 
 
 async def test_failed_startup_read_preserves_catch_up_boundary(tmp_path) -> None:


### PR DESCRIPTION
Closes #150.

Focused replacement for the closed #151 implementation. It fixes the three independent restart causes without mixing Herdr identity work:

- terminal idle/done transitions mark status as seen instead of restarting startup grace;
- inherited topics get one immediate per-chat first paint while preserving normal debounce;
- transcript activity distinguishes pre-start catch-up bytes from live writes and handles truncation, inode replacement, transient read errors, and whole-file providers.

Validation: focused polling/topic/transcript/session-monitor suites passed; full unit suite passed; architecture pre-push gate passed (817 tests, 0 blockers).