### PR TITLE
fix: harden transcript and recovery identity flows

### DIFF
--- a/src/ccgram/handlers/recovery/recovery_banner.py
+++ b/src/ccgram/handlers/recovery/recovery_banner.py
@@ -276,7 +276,12 @@ async def _create_and_bind_window(
         return False
 
     if provider.capabilities.supports_hook:
-        await session_map_sync.wait_for_session_map_entry(created_wid)
+        await session_map_sync.wait_for_session_map_entry(
+            created_wid,
+            timeout=5.0,
+            resolve_window_id=window_query.resolve_window_alias,
+        )
+    created_wid = window_query.resolve_window_alias(created_wid)
 
     session_manager.set_window_origin(created_wid, CCGRAM_CREATED_WINDOW_ORIGIN)
     session_manager.set_window_provider(created_wid, provider.capabilities.name)

--- a/src/ccgram/handlers/recovery/resume_command.py
+++ b/src/ccgram/handlers/recovery/resume_command.py
@@ -329,7 +329,12 @@ async def _create_resume_window(
     )
     if success:
         if provider.capabilities.supports_hook:
-            await session_map_sync.wait_for_session_map_entry(created_wid)
+            await session_map_sync.wait_for_session_map_entry(
+                created_wid,
+                timeout=5.0,
+                resolve_window_id=window_query.resolve_window_alias,
+            )
+        created_wid = window_query.resolve_window_alias(created_wid)
         session_manager.set_window_origin(created_wid, CCGRAM_CREATED_WINDOW_ORIGIN)
         session_manager.set_window_provider(created_wid, provider.capabilities.name)
         session_manager.set_window_approval_mode(created_wid, approval_mode)

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -14,6 +14,7 @@ Key class: TranscriptReader.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -42,6 +43,38 @@ class _StartupBoundary(NamedTuple):
     size: int
     device: int
     inode: int
+
+
+class _StableRead(NamedTuple):
+    entries: list[dict]
+    stat: Any
+    reset_generation: bool
+
+
+_MARKER_BYTES = 128
+
+
+def _prefix_digest(file_path: Path, size: int) -> bytes:
+    digest = hashlib.sha256()
+    with file_path.open("rb") as transcript:
+        remaining = size
+        while remaining:
+            chunk = transcript.read(min(64 * 1024, remaining))
+            if not chunk:
+                break
+            digest.update(chunk)
+            remaining -= len(chunk)
+    return digest.digest()
+
+
+def _tail_marker(file_path: Path, offset: int) -> bytes:
+    """Read a small marker immediately before a consumed byte offset."""
+    if offset <= 0:
+        return b""
+    start = max(0, offset - _MARKER_BYTES)
+    with file_path.open("rb") as transcript:
+        transcript.seek(start)
+        return transcript.read(offset - start)
 
 
 def _resolve_provider_for_file(window_id: str, file_path: Path) -> Any:
@@ -99,8 +132,43 @@ class TranscriptReader:
         self._idle_tracker = idle_tracker
         self._pending_tools: dict[str, dict[str, Any]] = {}
         self._file_mtimes: dict[str, float] = {}
+        self._file_ctimes: dict[str, int] = self._snapshot_file_ctimes()
+        self._file_sizes = self._snapshot_file_sizes()
+        self._file_prefixes = self._snapshot_file_prefixes()
         self._file_generations = self._snapshot_file_generations()
+        self._file_markers = self._snapshot_file_markers()
         self._startup_file_boundaries = self._snapshot_startup_boundaries()
+
+    def _snapshot_file_ctimes(self) -> dict[str, int]:
+        ctimes: dict[str, int] = {}
+        for session_id, tracked in self._state.tracked_sessions.items():
+            try:
+                ctimes[session_id] = Path(tracked.file_path).stat().st_ctime_ns
+            except OSError:
+                continue
+        return ctimes
+
+    def _snapshot_file_sizes(self) -> dict[str, int]:
+        sizes: dict[str, int] = {}
+        for session_id, tracked in self._state.tracked_sessions.items():
+            try:
+                sizes[session_id] = Path(tracked.file_path).stat().st_size
+            except OSError:
+                continue
+        return sizes
+
+    def _snapshot_file_prefixes(self) -> dict[str, tuple[int, bytes]]:
+        prefixes: dict[str, tuple[int, bytes]] = {}
+        for session_id, tracked in self._state.tracked_sessions.items():
+            try:
+                size = Path(tracked.file_path).stat().st_size
+                prefixes[session_id] = (
+                    size,
+                    _prefix_digest(Path(tracked.file_path), size),
+                )
+            except OSError:
+                continue
+        return prefixes
 
     def _snapshot_file_generations(self) -> dict[str, tuple[int, int]]:
         generations: dict[str, tuple[int, int]] = {}
@@ -111,6 +179,16 @@ class TranscriptReader:
                 continue
             generations[session_id] = (st.st_dev, st.st_ino)
         return generations
+
+    def _snapshot_file_markers(self) -> dict[str, tuple[int, bytes]]:
+        markers: dict[str, tuple[int, bytes]] = {}
+        for session_id, tracked in self._state.tracked_sessions.items():
+            try:
+                marker = _tail_marker(Path(tracked.file_path), tracked.last_byte_offset)
+            except OSError:
+                continue
+            markers[session_id] = (tracked.last_byte_offset, marker)
+        return markers
 
     def _snapshot_startup_boundaries(self) -> dict[str, _StartupBoundary]:
         """Capture each tracked transcript generation and its pre-start EOF."""
@@ -148,14 +226,133 @@ class TranscriptReader:
             self._startup_file_boundaries[session_id] = boundary
         return boundary
 
-    async def _read_session_entries(
-        self, tracked: TrackedSession, file_path: Path, window_id: str
-    ) -> list[dict] | None:
-        """Read once, preserving startup state when the file is unavailable."""
+    async def _marker_changed(
+        self, session_id: str, tracked: TrackedSession, file_path: Path
+    ) -> bool:
+        saved = self._file_markers.get(session_id)
+        if saved is None or saved[0] != tracked.last_byte_offset:
+            return False
         try:
-            return await self._read_new_lines(tracked, file_path, window_id)
+            current = await asyncio.to_thread(
+                _tail_marker, file_path, tracked.last_byte_offset
+            )
         except OSError:
-            return None
+            return False
+        return current != saved[1]
+
+    async def _prepare_observed_generation(
+        self,
+        session_id: str,
+        tracked: TrackedSession,
+        file_path: Path,
+        st: Any,
+        *,
+        check_marker: bool,
+    ) -> bool:
+        generation = (st.st_dev, st.st_ino)
+        previous = self._file_generations.get(session_id)
+        previous_ctime = self._file_ctimes.get(session_id)
+        changed = previous is not None and previous != generation
+        previous_size = self._file_sizes.get(session_id)
+        previous_prefix = self._file_prefixes.get(session_id)
+        prefix_changed = False
+        if previous_prefix is not None:
+            try:
+                prefix_changed = (
+                    await asyncio.to_thread(
+                        _prefix_digest, file_path, previous_prefix[0]
+                    )
+                    != previous_prefix[1]
+                )
+            except OSError:
+                prefix_changed = False
+        changed = (
+            changed
+            or prefix_changed
+            or (
+                previous_ctime is not None
+                and previous_ctime != st.st_ctime_ns
+                and previous_size is not None
+                and st.st_size <= previous_size
+            )
+        )
+        changed = changed or st.st_size < tracked.last_byte_offset
+        if not changed and check_marker:
+            changed = await self._marker_changed(session_id, tracked, file_path)
+        if changed:
+            tracked.last_byte_offset = 0
+            self._startup_file_boundaries.pop(session_id, None)
+        return changed
+
+    async def _read_session_entries(
+        self,
+        session_id: str,
+        tracked: TrackedSession,
+        file_path: Path,
+        window_id: str,
+        *,
+        check_marker: bool,
+    ) -> _StableRead | None:
+        """Read a stable file generation, retrying once after a write race."""
+        reset_generation = False
+        for _attempt in range(2):
+            try:
+                before = file_path.stat()
+                start_offset = tracked.last_byte_offset
+                entries = await self._read_new_lines(tracked, file_path, window_id)
+                after = file_path.stat()
+            except OSError:
+                return None
+            same_generation = (before.st_dev, before.st_ino) == (
+                after.st_dev,
+                after.st_ino,
+            )
+            rewritten_in_place = before.st_ctime_ns != after.st_ctime_ns
+            marker_changed = False
+            saved = self._file_markers.get(session_id) if check_marker else None
+            if saved is not None and saved[0] == start_offset:
+                try:
+                    marker = await asyncio.to_thread(
+                        _tail_marker, file_path, start_offset
+                    )
+                except OSError:
+                    return None
+                marker_changed = marker != saved[1]
+            if same_generation and not rewritten_in_place and not marker_changed:
+                return _StableRead(entries, after, reset_generation)
+            tracked.last_byte_offset = 0
+            self._startup_file_boundaries.pop(session_id, None)
+            reset_generation = True
+        return None
+
+    async def _commit_stable_read(
+        self,
+        session_id: str,
+        tracked: TrackedSession,
+        file_path: Path,
+        stable_read: _StableRead,
+    ) -> bool:
+        """Commit caches only after a stable read and marker capture."""
+        stable_stat = stable_read.stat
+        try:
+            marker = await asyncio.to_thread(
+                _tail_marker, file_path, tracked.last_byte_offset
+            )
+        except OSError:
+            return False
+        self._file_mtimes[session_id] = stable_stat.st_mtime
+        self._file_generations[session_id] = (
+            stable_stat.st_dev,
+            stable_stat.st_ino,
+        )
+        self._file_ctimes[session_id] = stable_stat.st_ctime_ns
+        self._file_sizes[session_id] = stable_stat.st_size
+        self._file_prefixes[session_id] = (
+            stable_stat.st_size,
+            await asyncio.to_thread(_prefix_digest, file_path, stable_stat.st_size),
+        )
+        self._file_markers[session_id] = (tracked.last_byte_offset, marker)
+        return True
 
     def clear_session(self, session_id: str) -> None:
         """Remove all per-session state for a cleaned-up session."""
@@ -163,6 +360,10 @@ class TranscriptReader:
         self._file_mtimes.pop(session_id, None)
         self._pending_tools.pop(session_id, None)
         self._file_generations.pop(session_id, None)
+        self._file_ctimes.pop(session_id, None)
+        self._file_sizes.pop(session_id, None)
+        self._file_prefixes.pop(session_id, None)
+        self._file_markers.pop(session_id, None)
         self._startup_file_boundaries.pop(session_id, None)
         log_throttle_reset(f"partial-jsonl:{session_id}")
 
@@ -198,10 +399,20 @@ class TranscriptReader:
                 self._file_generations[session_id] = self._file_generations.pop(
                     old_session_id
                 )
+            if old_session_id in self._file_ctimes:
+                self._file_ctimes[session_id] = self._file_ctimes.pop(old_session_id)
+            if old_session_id in self._file_sizes:
+                self._file_sizes[session_id] = self._file_sizes.pop(old_session_id)
+            if old_session_id in self._file_prefixes:
+                self._file_prefixes[session_id] = self._file_prefixes.pop(
+                    old_session_id
+                )
             if old_session_id in self._pending_tools:
                 self._pending_tools[session_id] = self._pending_tools.pop(
                     old_session_id
                 )
+            if old_session_id in self._file_markers:
+                self._file_markers[session_id] = self._file_markers.pop(old_session_id)
             if old_session_id in self._startup_file_boundaries:
                 self._startup_file_boundaries[session_id] = (
                     self._startup_file_boundaries.pop(old_session_id)
@@ -258,6 +469,23 @@ class TranscriptReader:
             self._file_mtimes[session_id] = current_mtime
             if generation is not None:
                 self._file_generations[session_id] = generation
+                self._file_ctimes[session_id] = st.st_ctime_ns
+                self._file_sizes[session_id] = st.st_size
+                self._file_prefixes[session_id] = (
+                    st.st_size,
+                    await asyncio.to_thread(_prefix_digest, file_path, st.st_size),
+                )
+            try:
+                marker = await asyncio.to_thread(
+                    _tail_marker, file_path, tracked.last_byte_offset
+                )
+            except OSError:
+                pass
+            else:
+                self._file_markers[session_id] = (
+                    tracked.last_byte_offset,
+                    marker,
+                )
             if provider.capabilities.supports_task_tracking and window_id:
                 await provider.seed_task_state(window_id, session_id, str(file_path))
             logger.debug("Started tracking session: %s", session_id)
@@ -269,16 +497,14 @@ class TranscriptReader:
         except OSError:
             return
 
-        generation = (st.st_dev, st.st_ino)
-        previous_generation = self._file_generations.get(session_id)
-        generation_changed = (
-            previous_generation is not None and previous_generation != generation
+        incremental = provider.capabilities.supports_incremental_read
+        generation_changed = await self._prepare_observed_generation(
+            session_id,
+            tracked,
+            file_path,
+            st,
+            check_marker=incremental,
         )
-        if generation_changed:
-            tracked.last_byte_offset = 0
-            self._startup_file_boundaries.pop(session_id, None)
-        self._file_generations[session_id] = generation
-
         last_mtime = self._file_mtimes.get(session_id, 0.0)
         if provider.capabilities.supports_incremental_read:
             if (
@@ -295,10 +521,22 @@ class TranscriptReader:
             if generation_changed or not provider.capabilities.supports_incremental_read
             else self._prepare_startup_boundary(session_id, tracked, st)
         )
-        new_entries = await self._read_session_entries(tracked, file_path, window_id)
-        if new_entries is None:
+        stable_read = await self._read_session_entries(
+            session_id,
+            tracked,
+            file_path,
+            window_id,
+            check_marker=incremental,
+        )
+        if stable_read is None:
             return
-        self._file_mtimes[session_id] = current_mtime
+        new_entries, _stable_stat, reset_during_read = stable_read
+        if not await self._commit_stable_read(
+            session_id, tracked, file_path, stable_read
+        ):
+            return
+        if reset_during_read:
+            startup_boundary = None
 
         # Deliver pre-start unread history, but count activity only when a
         # complete entry advances beyond the startup file-size boundary.

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -449,6 +449,7 @@ class TranscriptReader:
             except OSError:
                 file_size = 0
                 current_mtime = 0.0
+                st = None
                 generation = None
             else:
                 generation = (st.st_dev, st.st_ino)
@@ -467,7 +468,7 @@ class TranscriptReader:
             )
             self._state.update_session(tracked)
             self._file_mtimes[session_id] = current_mtime
-            if generation is not None:
+            if generation is not None and st is not None:
                 self._file_generations[session_id] = generation
                 self._file_ctimes[session_id] = st.st_ctime_ns
                 self._file_sizes[session_id] = st.st_size
@@ -497,13 +498,12 @@ class TranscriptReader:
         except OSError:
             return
 
-        incremental = provider.capabilities.supports_incremental_read
         generation_changed = await self._prepare_observed_generation(
             session_id,
             tracked,
             file_path,
             st,
-            check_marker=incremental,
+            check_marker=provider.capabilities.supports_incremental_read,
         )
         last_mtime = self._file_mtimes.get(session_id, 0.0)
         if provider.capabilities.supports_incremental_read:
@@ -526,11 +526,11 @@ class TranscriptReader:
             tracked,
             file_path,
             window_id,
-            check_marker=incremental,
+            check_marker=provider.capabilities.supports_incremental_read,
         )
         if stable_read is None:
             return
-        new_entries, _stable_stat, reset_during_read = stable_read
+        new_entries, _, reset_during_read = stable_read
         if not await self._commit_stable_read(
             session_id, tracked, file_path, stable_read
         ):

--- a/src/ccgram/window_resolver.py
+++ b/src/ccgram/window_resolver.py
@@ -88,9 +88,9 @@ _MIGRATED_DEFAULT_FIELDS = (
 # register it, and on a backend whose identity firms up over time the hook
 # writes under an id creation never saw.
 #
-# In-memory and bounded: a redirect only has to outlive the flows holding the
-# old id (seconds), and every durable store has already been repointed.
-_MAX_ALIAS_REDIRECTS = 256
+# In-memory. Stale redirects are bounded, but aliases in the current live
+# snapshot are never evicted: a creation flow may still hold any one of them.
+_MAX_STALE_ALIAS_REDIRECTS = 256
 _alias_redirects: dict[str, str] = {}
 
 
@@ -112,8 +112,21 @@ def resolve_window_alias(window_id: str) -> str:
 def _record_alias_redirect(alias_id: str, canonical_id: str) -> None:
     """Remember that ``alias_id`` now resolves to ``canonical_id``."""
     _alias_redirects[alias_id] = canonical_id
-    while len(_alias_redirects) > _MAX_ALIAS_REDIRECTS:
-        del _alias_redirects[next(iter(_alias_redirects))]
+
+
+def _prune_stale_alias_redirects(active_aliases: set[str]) -> None:
+    """Bound stale redirects without evicting any current alias or its chain."""
+    protected: set[str] = set()
+    for alias_id in active_aliases:
+        current = alias_id
+        seen: set[str] = set()
+        while current in _alias_redirects and current not in seen:
+            seen.add(current)
+            protected.add(current)
+            current = _alias_redirects[current]
+    stale = [key for key in _alias_redirects if key not in protected]
+    for key in stale[:-_MAX_STALE_ALIAS_REDIRECTS]:
+        _alias_redirects.pop(key, None)
 
 
 def reset_alias_redirects() -> None:
@@ -235,6 +248,11 @@ def migrate_window_aliases(
     otherwise recreate the alias state on the next sync).
     """
     migrations: list[AliasMigration] = []
+    active_aliases = {
+        alias_id
+        for alias_id, canonical_id in aliases.items()
+        if alias_id and canonical_id and alias_id != canonical_id
+    }
     for alias_id, canonical_id in aliases.items():
         if alias_id == canonical_id or not alias_id or not canonical_id:
             continue
@@ -263,6 +281,7 @@ def migrate_window_aliases(
         )
         migrations.append(AliasMigration(alias_id=alias_id, canonical_id=canonical_id))
         logger.info("Reconciled superseded window id %s -> %s", alias_id, canonical_id)
+    _prune_stale_alias_redirects(active_aliases)
     return migrations
 
 

--- a/tests/ccgram/handlers/recovery/test_recovery_ui.py
+++ b/tests/ccgram/handlers/recovery/test_recovery_ui.py
@@ -551,7 +551,12 @@ class TestRecoveryFreshCallback:
         ctx = _make_context(user_data)
         query = update.callback_query
 
-        with patch(f"{_RC}.Path") as mock_path:
+        mock_sm.resolve_window_alias.return_value = "@canonical"
+        with (
+            patch(f"{_RC}.Path") as mock_path,
+            patch(f"{_RC}.session_map_sync") as mock_sync,
+        ):
+            mock_sync.wait_for_session_map_entry = AsyncMock()
             mock_path.return_value.is_dir.return_value = True
             await handle_recovery_callback(query, 100, query.data, update, ctx)
 
@@ -559,8 +564,13 @@ class TestRecoveryFreshCallback:
         mock_tm.create_window.assert_called_once_with(
             "/tmp/project", agent_args="", launch_command="claude"
         )
+        mock_sync.wait_for_session_map_entry.assert_awaited_once_with(
+            "@5",
+            timeout=5.0,
+            resolve_window_id=mock_sm.resolve_window_alias,
+        )
         mock_tr.bind_thread.assert_called_once_with(
-            100, 42, "@5", window_name="project", chat_id=-100999
+            100, 42, "@canonical", window_name="project", chat_id=-100999
         )
         mock_tr.set_group_chat_id.assert_called_once_with(100, 42, -100999)
 
@@ -580,6 +590,7 @@ class TestRecoveryFreshCallback:
         mock_send_to_window: AsyncMock,
     ) -> None:
         mock_sm.view_window.return_value = MagicMock(cwd="/tmp/project")
+        mock_sm.resolve_window_alias.side_effect = lambda window_id: window_id
         mock_tm.create_window = AsyncMock(
             return_value=(True, "Window created", "project", "@5")
         )
@@ -680,6 +691,7 @@ class TestRecoveryContinueCallback:
         mock_sm.view_window.return_value = MagicMock(
             cwd="/tmp/project", provider_name=""
         )
+        mock_sm.resolve_window_alias.side_effect = lambda window_id: window_id
         mock_tm.create_window = AsyncMock(
             return_value=(True, "Window created", "project", "@5")
         )
@@ -721,6 +733,7 @@ class TestRecoveryContinueCallback:
         _mock_scan: MagicMock,
     ) -> None:
         mock_sm.view_window.return_value = MagicMock(cwd="/tmp/project")
+        mock_sm.resolve_window_alias.side_effect = lambda window_id: window_id
         mock_tm.create_window = AsyncMock(
             return_value=(True, "Window created", "project", "@5")
         )

--- a/tests/ccgram/handlers/recovery/test_resume_command.py
+++ b/tests/ccgram/handlers/recovery/test_resume_command.py
@@ -925,7 +925,14 @@ class TestResumePickCallback:
         ctx = _make_context(user_data)
         query = update.callback_query
 
-        with patch(f"{_RC}.Path") as mock_path:
+        with (
+            patch(f"{_RC}.Path") as mock_path,
+            patch(
+                f"{_RC}.window_query.resolve_window_alias", return_value="@canonical"
+            ) as resolve_alias,
+            patch(f"{_RC}.session_map_sync") as mock_sync,
+        ):
+            mock_sync.wait_for_session_map_entry = AsyncMock()
             mock_path.return_value.is_dir.return_value = True
             await handle_resume_command_callback(query, 100, query.data, update, ctx)
 
@@ -934,8 +941,13 @@ class TestResumePickCallback:
             agent_args="--resume a1b2c3d4-0000-0000-0000-000000000001",
             launch_command="claude",
         )
+        mock_sync.wait_for_session_map_entry.assert_awaited_once_with(
+            "@5",
+            timeout=5.0,
+            resolve_window_id=resolve_alias,
+        )
         mock_tr.bind_thread.assert_called_once_with(
-            100, 42, "@5", window_name="project"
+            100, 42, "@canonical", window_name="project"
         )
 
     @patch(f"{_RC}.tmux_manager")

--- a/tests/ccgram/test_transcript_reader.py
+++ b/tests/ccgram/test_transcript_reader.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 from ccgram.idle_tracker import IdleTracker
 from ccgram.monitor_state import MonitorState, TrackedSession
-from ccgram.transcript_reader import TranscriptReader
+from ccgram.transcript_reader import TranscriptReader, _StableRead
 
 
 async def test_same_transcript_reuses_offset_after_session_map_refresh(
@@ -150,6 +150,106 @@ async def test_atomic_replacement_after_start_is_read_from_zero(tmp_path) -> Non
     assert [msg.text for msg in messages] == ["fresh"]
 
 
+async def test_same_inode_rewrite_with_preserved_mtime_resets_offset(tmp_path) -> None:
+    old = '{"type":"assistant","message":{"content":[{"type":"text","text":"old"}]}}\n'
+    new = old.replace("old", "new")
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(old)
+    initial_stat = session_file.stat()
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess", file_path=str(session_file), last_byte_offset=0
+        )
+    )
+    reader = TranscriptReader(state, IdleTracker())
+    await reader._process_session_file("sess", session_file, [], window_id="@1")
+
+    session_file.write_text(new)
+    os.utime(
+        session_file,
+        ns=(initial_stat.st_atime_ns, initial_stat.st_mtime_ns),
+    )
+    messages = []
+    await reader._process_session_file("sess", session_file, messages, window_id="@1")
+
+    assert [message.text for message in messages] == ["new"]
+
+
+async def test_replacement_between_stat_and_open_retries_from_zero(tmp_path) -> None:
+    old = '{"type":"assistant","message":{"content":[{"type":"text","text":"old"}]}}\n'
+    new = old.replace("old", "new")
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(old)
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess", file_path=str(session_file), last_byte_offset=0
+        )
+    )
+    reader = TranscriptReader(state, IdleTracker())
+    await reader._process_session_file("sess", session_file, [], window_id="@1")
+    original_read = reader._read_new_lines
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text(new)
+    session_file.write_text(old)  # Trigger the read before replacing it in-flight.
+    replaced = False
+
+    async def replace_then_read(*args, **kwargs):
+        nonlocal replaced
+        if not replaced:
+            replacement.replace(session_file)
+            replaced = True
+        return await original_read(*args, **kwargs)
+
+    messages = []
+    with patch.object(reader, "_read_new_lines", side_effect=replace_then_read):
+        await reader._process_session_file(
+            "sess", session_file, messages, window_id="@1"
+        )
+
+    assert [message.text for message in messages] == ["new"]
+
+
+async def test_whole_file_rewrite_bypasses_unchanged_mtime(tmp_path) -> None:
+    session_file = tmp_path / "transcript.json"
+    session_file.write_text("old")
+    old_stat = session_file.stat()
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess", file_path=str(session_file), last_byte_offset=0
+        )
+    )
+    reader = TranscriptReader(state, IdleTracker())
+    provider = SimpleNamespace(
+        capabilities=SimpleNamespace(
+            supports_incremental_read=False,
+            supports_task_tracking=False,
+        )
+    )
+    with (
+        patch(
+            "ccgram.transcript_reader._resolve_provider_for_file", return_value=provider
+        ),
+        patch.object(
+            reader,
+            "_read_session_entries",
+            new=AsyncMock(
+                side_effect=lambda *_args, **_kwargs: _StableRead(
+                    [], session_file.stat(), False
+                )
+            ),
+        ) as read,
+        patch.object(reader, "_append_provider_messages"),
+    ):
+        await reader._process_session_file("sess", session_file, [], window_id="@1")
+        session_file.write_text("new-long")
+        os.utime(session_file, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns))
+        await reader._process_session_file("sess", session_file, [], window_id="@1")
+    assert read.await_count == 2
+
+
 async def test_whole_file_replacement_bypasses_unchanged_mtime(tmp_path) -> None:
     session_file = tmp_path / "transcript.json"
     session_file.write_text("old")
@@ -173,7 +273,15 @@ async def test_whole_file_replacement_bypasses_unchanged_mtime(tmp_path) -> None
             "ccgram.transcript_reader._resolve_provider_for_file", return_value=provider
         ),
         patch.object(
-            reader, "_read_session_entries", new=AsyncMock(return_value=[])
+            reader,
+            "_read_session_entries",
+            new=AsyncMock(
+                side_effect=lambda *_args, **_kwargs: _StableRead(
+                    [],
+                    session_file.stat(),
+                    False,
+                )
+            ),
         ) as read,
         patch.object(reader, "_append_provider_messages"),
     ):

--- a/tests/ccgram/test_window_resolver.py
+++ b/tests/ccgram/test_window_resolver.py
@@ -424,3 +424,22 @@ class TestResolveWindowAlias:
         # nothing to migrate, but the identity moved and callers still need it.
         assert migrate_window_aliases({"alias": "canonical"}, {}, {}, {}, {}, {}) == []
         assert resolve_window_alias("alias") == "canonical"
+
+    def test_keeps_every_alias_from_a_large_live_snapshot(self) -> None:
+        aliases = {f"alias-{index}": f"canonical-{index}" for index in range(300)}
+
+        migrate_window_aliases(aliases, {}, {}, {}, {}, {})
+
+        assert all(
+            resolve_window_alias(alias) == canonical
+            for alias, canonical in aliases.items()
+        )
+
+    def test_stale_aliases_remain_bounded(self) -> None:
+        for index in range(300):
+            migrate_window_aliases(
+                {f"alias-{index}": f"canonical-{index}"}, {}, {}, {}, {}, {}
+            )
+
+        assert resolve_window_alias("alias-0") == "alias-0"
+        assert resolve_window_alias("alias-299") == "canonical-299"


### PR DESCRIPTION
Follow-up fixes from deep review of PRs #161, #162, and #163.

Fixes:
- detect same-inode transcript rewrites with ctime/size/prefix fingerprints; retry reads when the file changes during a read;
- resolve canonical Herdr IDs in recovery/resume state writes, bindings, and pending sends;
- retain active alias redirects while bounding stale redirect memory;
- add regression coverage for races, recovery identity, and 300+ active aliases.

Validation: 6231 passed, 30 skipped; Ruff; Pyright; architecture gate 817 passed; archfit no blocking findings.