### PR TITLE
feat: stream assistant replies to Telegram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.6.0] - 2026-08-16
+
+### Added
+
+- Stream Codex assistant replies to Telegram while the agent generates them ([#155](https://github.com/alexei-led/ccgram/issues/155)).
+- Show a temporary Telegram draft before the complete reply is saved.
+
+### Fixed
+
+- Keep message queue order when a streamed reply ends.
+- Retry draft updates after Telegram rate limits.
+- Retry failed final tool-batch sends.
+- Expire stalled assistant drafts and clean up their state.
+
+### Contributors
+
+- Thanks to @osovv for the feature request in [#155](https://github.com/alexei-led/ccgram/issues/155).
+
 ## [4.5.3] - 2026-08-16
 
 ### Fixed
@@ -12,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid transcript races when files are rewritten during reads.
 - Preserve canonical Herdr IDs through recovery and resume flows.
 - Retain active Herdr aliases during resolver pruning.
+
+### Contributors
+
+- Thanks to @paskal for preserving non-Latin upload filenames.
 
 ## [4.5.2] - 2026-08-15
 
@@ -40,6 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prevent a topic-creation race when a new Herdr target starts.
 - Read a workspace path from a Herdr pane when the workspace record has no path.
+
+### Contributors
+
+- Thanks to @ChakshuGrover for the Google Antigravity provider.
 
 ## [4.3.12] - 2026-08-02
 

--- a/src/ccgram/handlers/messaging_pipeline/message_routing.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_routing.py
@@ -6,13 +6,15 @@ management.
 """
 
 import asyncio
+import contextlib
 from pathlib import Path
 
 import structlog
 
 from ... import session_query
 from ...session_monitor import NewMessage
-from ...telegram_client import TelegramClient
+from ...telegram_client import TelegramClient, unwrap_bot
+from ...telegram_draft import DRAFT_UNSET, DraftStream
 from ...user_preferences import user_preferences
 from ..interactive import (
     INTERACTIVE_TOOL_NAMES,
@@ -29,6 +31,98 @@ from .message_queue import enqueue_content_message, get_message_queue
 logger = structlog.get_logger()
 
 _MIN_THINKING_LENGTH = 20
+
+# One draft per session/topic. Provider updates are cumulative snapshots, not deltas.
+_DRAFT_TTL_SECONDS = 25.0
+_active_drafts: dict[tuple[int, str, int | None, int], DraftStream] = {}
+_draft_expiry_tasks: dict[tuple[int, str, int | None, int], asyncio.Task[None]] = {}
+
+
+async def _update_window_offset(user_id: int, window_id: str) -> None:
+    """Advance transcript offset after a complete message is handled."""
+    session = await session_query.resolve_session_for_window(window_id)
+    if not session or not session.file_path:
+        return
+    try:
+        file_size = Path(session.file_path).stat().st_size
+        user_preferences.update_user_window_offset(user_id, window_id, file_size)
+    except OSError:
+        return
+
+
+def _arm_draft_expiry(
+    key: tuple[int, str, int | None, int], draft: DraftStream
+) -> None:
+    """Drop stalled native drafts before Telegram expires their preview."""
+    previous = _draft_expiry_tasks.pop(key, None)
+    if previous is not None:
+        previous.cancel()
+    _draft_expiry_tasks[key] = asyncio.create_task(
+        _expire_draft(key, draft),
+        name=f"assistant-draft-expiry:{key[0]}:{key[3]}",
+    )
+
+
+async def _expire_draft(
+    key: tuple[int, str, int | None, int], draft: DraftStream
+) -> None:
+    try:
+        await asyncio.sleep(_DRAFT_TTL_SECONDS)
+        if _active_drafts.get(key) is draft:
+            _active_drafts.pop(key, None)
+            await draft.abort()
+    except asyncio.CancelledError:
+        raise
+    finally:
+        current = _draft_expiry_tasks.get(key)
+        if current is asyncio.current_task():
+            _draft_expiry_tasks.pop(key, None)
+
+
+async def _cancel_draft_expiry(key: tuple[int, str, int | None, int]) -> None:
+    task = _draft_expiry_tasks.pop(key, None)
+    if task is None or task is asyncio.current_task():
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+async def _handle_assistant_stream(
+    msg: NewMessage,
+    client: TelegramClient,
+    user_id: int,
+    thread_id: int | None,
+    chat_id: int | None,
+) -> bool:
+    """Deliver an assistant text snapshot to its draft, if applicable."""
+    if msg.role != "assistant" or msg.content_type != "text" or chat_id is None:
+        return False
+
+    key = (user_id, msg.session_id, thread_id, chat_id)
+    draft = _active_drafts.get(key)
+
+    if msg.is_complete:
+        if draft is not None:
+            _active_drafts.pop(key, None)
+            await _cancel_draft_expiry(key)
+            await draft.abort()
+        return False
+
+    if draft is None:
+        draft = DraftStream(
+            unwrap_bot(client),
+            chat_id,
+            message_thread_id=thread_id,
+        )
+        await draft.start(msg.text)
+        if draft.mode == DRAFT_UNSET:
+            return True
+        _active_drafts[key] = draft
+    else:
+        await draft.replace(msg.text)
+    _arm_draft_expiry(key, draft)
+    return True
 
 
 async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  # noqa: C901, PLR0912
@@ -80,21 +174,22 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
             await asyncio.sleep(0.3)
             handled = await handle_interactive_ui(client, user_id, window_id, thread_id)
             if handled:
-                session = await session_query.resolve_session_for_window(window_id)
-                if session and session.file_path:
-                    try:
-                        file_size = Path(session.file_path).stat().st_size
-                        user_preferences.update_user_window_offset(
-                            user_id, window_id, file_size
-                        )
-                    except OSError:
-                        pass
+                await _update_window_offset(user_id, window_id)
                 continue
             else:
                 clear_interactive_mode(user_id, thread_id)
 
         if get_interactive_msg_id(user_id, thread_id):
             await clear_interactive_msg(user_id, client, thread_id)
+
+        if await _handle_assistant_stream(
+            msg,
+            client,
+            user_id,
+            thread_id,
+            chat_id,
+        ):
+            continue
 
         parts = build_response_parts(
             msg.text,
@@ -117,12 +212,4 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
                 chat_id=chat_id,
             )
 
-            session = await session_query.resolve_session_for_window(window_id)
-            if session and session.file_path:
-                try:
-                    file_size = Path(session.file_path).stat().st_size
-                    user_preferences.update_user_window_offset(
-                        user_id, window_id, file_size
-                    )
-                except OSError:
-                    pass
+            await _update_window_offset(user_id, window_id)

--- a/src/ccgram/handlers/messaging_pipeline/tool_batch.py
+++ b/src/ccgram/handlers/messaging_pipeline/tool_batch.py
@@ -15,13 +15,14 @@ Key components:
 
 from __future__ import annotations
 
+import asyncio
 import re
 from dataclasses import dataclass, field
 
 import structlog
 
 from ...telegram_client import TelegramClient, unwrap_bot
-from ...telegram_draft import DraftStream
+from ...telegram_draft import DRAFT_STREAMING, DRAFT_UNSET, DraftStream
 from ...thread_router import thread_router
 from ...topic_state_registry import topic_state
 from ...window_state_ports.tool_state import get_batch_mode, is_ephemeral_tools
@@ -338,7 +339,9 @@ async def _send_or_edit_batch(
     # screen. A re-edit with the same text would trigger Telegram's "Message
     # is not modified" error, and the legacy fallback path used to strip
     # entities to "succeed", destroying the formatting.
-    if batch.telegram_msg_id is not None and batch.last_sent_text == batch_text:
+    if batch.last_sent_text == batch_text and (
+        batch.telegram_msg_id is not None or batch.draft is not None
+    ):
         return
 
     if is_ephemeral_tools(batch.window_id):
@@ -371,7 +374,7 @@ async def _send_or_edit_batch(
             message_thread_id=raw_thread_id,
         )
         msg_id = await batch.draft.start(batch_text)
-        if msg_id is not None:
+        if msg_id is not None or batch.draft.mode == DRAFT_STREAMING:
             batch.telegram_msg_id = msg_id
             batch.last_sent_text = batch_text
         else:
@@ -547,7 +550,7 @@ async def flush_if_active(
         await flush_batch(client, user_id, thread_id_or_0)
 
 
-async def flush_batch(
+async def flush_batch(  # noqa: C901, PLR0911
     client: TelegramClient, user_id: int, thread_id_or_0: int
 ) -> None:
     """Finalize the active batch: do a final edit and clear state.
@@ -558,8 +561,11 @@ async def flush_batch(
     from telegram.error import TelegramError
 
     bkey = (user_id, thread_id_or_0)
-    batch = _active_batches.pop(bkey, None)
-    if not batch or not batch.entries:
+    batch = _active_batches.get(bkey)
+    if not batch:
+        return
+    if not batch.entries:
+        _active_batches.pop(bkey, None)
         return
 
     thread_id: int | None = thread_id_or_0 if thread_id_or_0 != 0 else None
@@ -573,6 +579,7 @@ async def flush_batch(
                 )
             except TelegramError as exc:
                 logger.warning("flush_batch ephemeral delete failed: %s", exc)
+        _active_batches.pop(bkey, None)
         return
 
     # Lazy: claude_task_state imports session readers; deferring keeps
@@ -585,9 +592,17 @@ async def flush_batch(
 
     if batch.draft is not None and not batch.draft.closed:
         try:
+            if batch.draft.mode == DRAFT_UNSET:
+                await _rate_limit_chat(chat_id)
+                await batch.draft.start(batch_text)
+                if batch.draft.mode == DRAFT_UNSET:
+                    logger.warning("flush_batch could not open a Telegram draft")
+                    return
             await batch.draft.finalize(batch_text)
         except TelegramError as exc:
             logger.warning("flush_batch finalize failed: %s", exc)
+            return
+        _active_batches.pop(bkey, None)
         return
 
     if batch.telegram_msg_id is not None:
@@ -601,16 +616,23 @@ async def flush_batch(
             )
         except TelegramError as exc:
             logger.warning("flush_batch edit failed: %s", exc)
+        _active_batches.pop(bkey, None)
         return
 
     # No prior message at all — open a fresh draft and finalize immediately.
     await _rate_limit_chat(chat_id)
     draft = DraftStream(unwrap_bot(client), chat_id, message_thread_id=thread_id)
+    batch.draft = draft
     try:
         await draft.start(batch_text)
+        if draft.mode == DRAFT_UNSET:
+            logger.warning("flush_batch could not open a Telegram draft")
+            return
         await draft.finalize()
-    except TelegramError as exc:
+    except (RuntimeError, TelegramError) as exc:
         logger.warning("flush_batch start+finalize failed: %s", exc)
+        return
+    _active_batches.pop(bkey, None)
 
 
 def has_active_batch(user_id: int, thread_id_or_0: int) -> bool:
@@ -632,12 +654,27 @@ def has_ephemeral_active_batch(user_id: int, thread_id_or_0: int) -> bool:
     return batch is not None and is_ephemeral_tools(batch.window_id)
 
 
+def _schedule_batch_abort(batch: ToolBatch) -> None:
+    if batch.draft is None or batch.draft.closed:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    loop.create_task(batch.draft.abort())
+
+
 @topic_state.register("topic")
 def clear_batch_for_topic(user_id: int, thread_id: int | None = None) -> None:
     """Clear active batch for a specific topic (called on topic cleanup)."""
-    _active_batches.pop((user_id, thread_key(thread_id)), None)
+    batch = _active_batches.pop((user_id, thread_key(thread_id)), None)
+    if batch:
+        _schedule_batch_abort(batch)
 
 
 def clear_all_batches() -> None:
     """Clear all active batches (called on shutdown)."""
+    batches = list(_active_batches.values())
     _active_batches.clear()
+    for batch in batches:
+        _schedule_batch_abort(batch)

--- a/src/ccgram/providers/codex.py
+++ b/src/ccgram/providers/codex.py
@@ -450,7 +450,14 @@ def _parse_event_message(
         if not isinstance(text, str) or not text:
             return [], pending
         return (
-            [AgentMessage(text=text, role="assistant", content_type="text")],
+            [
+                AgentMessage(
+                    text=text,
+                    role="assistant",
+                    content_type="text",
+                    is_complete=False,
+                )
+            ],
             pending,
         )
     if payload_type == "task_complete":

--- a/src/ccgram/telegram_draft.py
+++ b/src/ccgram/telegram_draft.py
@@ -1,65 +1,41 @@
-"""Streaming-message helper backed by Bot API 9.5+ ``sendMessageDraft``.
+"""Best-effort streaming delivery through Telegram Bot API 9.5 drafts.
 
-`DraftStream` provides one abstraction over two backends:
-
-- **streaming** — uses the Bot API draft-message methods (``sendMessageDraft``,
-  ``editMessageDraft``) so the message updates server-side without multiple
-  edit round-trips. Available on Bot API 9.5+.
-- **legacy** — falls back to ``send_message`` + ``edit_message_text`` polling,
-  which is the pre-9.5 baseline already used throughout ccgram.
-
-A process-wide flag (`_DRAFT_UNAVAILABLE`) flips to True the first time the
-draft API returns ``400 method not found`` (or the equivalent), after which
-all subsequent streams open in legacy mode without a probe round-trip.
-
-Public surface:
-  - DraftStream(bot, chat_id, *, message_thread_id=None, reply_to_message_id=None, reply_markup=None)
-  - DraftStream.start(text) -> message_id | None
-  - DraftStream.append(delta) -> None
-  - DraftStream.replace(text, *, reply_markup=...) -> None
-  - DraftStream.finalize(text=None, *, reply_markup=...) -> None
-  - DraftStream.abort() -> None
-  - is_draft_unavailable() -> bool
-  - mark_draft_unavailable(reason: str) -> None
-  - reset_draft_state() -> None  (test helper)
+``sendMessageDraft`` creates a temporary preview. It returns ``True`` and has
+no message id. A normal ``sendMessage`` is required to persist the final text.
+For unsupported peers or older Bot API servers, ``DraftStream`` falls back to
+``send_message`` plus ``edit_message_text``.
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
-import warnings
+import secrets
+from datetime import timedelta
+import time
 from typing import Any, Final, Literal
 
 import structlog
 from telegram import Bot, InlineKeyboardMarkup
 from telegram.error import BadRequest, NetworkError, RetryAfter, TelegramError, TimedOut
-from telegram.warnings import PTBUserWarning
 
 from .utils import log_throttled
 
-# PTB v22.6+ exposes a typed `send_message_draft` whose signature requires a
-# `draft_id` and returns `bool` rather than a Message dict — incompatible with
-# our message_id-keyed edit flow. Keep using `do_api_request` and silence the
-# nag warning at the source.
-warnings.filterwarnings(
-    "ignore",
-    message=r".*sendMessageDraft.*",
-    category=PTBUserWarning,
-)
-warnings.filterwarnings(
-    "ignore",
-    message=r".*editMessageDraft.*",
-    category=PTBUserWarning,
-)
-warnings.filterwarnings(
-    "ignore",
-    message=r".*finalizeMessageDraft.*",
-    category=PTBUserWarning,
-)
-
-# Sentinel for "leave reply_markup as-is" vs "explicitly clear it".
 _KEEP_MARKUP: Final[Any] = object()
+_MAX_LEN: Final[int] = 4096
+_DEGRADE_AFTER_FAILURES: Final[int] = 2
+_MIN_DRAFT_INTERVAL: Final[float] = 0.35
+_UNSUPPORTED_MARKERS: Final[tuple[str, ...]] = (
+    "method not found",
+    "method is not implemented",
+    "unknown method",
+    "endpoint not found",
+)
+_PEER_INVALID_MARKERS: Final[tuple[str, ...]] = (
+    "draft_peer_invalid",
+    "peer_invalid",
+    "chat not found",
+)
 
 logger = structlog.get_logger()
 
@@ -75,56 +51,22 @@ __all__ = [
     "reset_draft_state",
 ]
 
-
 DRAFT_STREAMING: Final[str] = "streaming"
 DRAFT_LEGACY: Final[str] = "legacy"
 DRAFT_UNSET: Final[str] = "unset"
 
-# Maximum content length for a single Telegram message
-_MAX_LEN: Final[int] = 4096
-
-# Backoff base for repeated transient failures within a single stream.
-_DEGRADE_AFTER_FAILURES: Final[int] = 2
-
-# Strings in BadRequest.message that indicate the draft API is unsupported
-# by the server (Bot API < 9.5 or method renamed).
-_UNSUPPORTED_MARKERS: Final[tuple[str, ...]] = (
-    "method not found",
-    "method is not implemented",
-    "unknown method",
-    "endpoint not found",
-)
-
-# Strings in BadRequest.message that indicate the draft API rejects this
-# specific peer (chat type or topic config), even though the API is
-# generally available. Cached per-peer, not process-wide.
-_PEER_INVALID_MARKERS: Final[tuple[str, ...]] = (
-    "draft_peer_invalid",
-    "peer_invalid",
-    "chat not found",
-)
-
-
-# Process-wide flag — once any caller observes the draft API as unavailable,
-# all subsequent DraftStream instances open in legacy mode without re-probing.
-_DRAFT_UNAVAILABLE: bool = False
-_DRAFT_REASON: str = ""
-
-# Per-peer cache of peers that have rejected drafts. Avoids retrying the
-# draft probe on every stream once a peer is known unsupported.
+_DRAFT_UNAVAILABLE = False
+_DRAFT_REASON = ""
 _UNSUPPORTED_PEERS: set[tuple[int, int | None]] = set()
 
 
 def is_draft_unavailable() -> bool:
-    """Return True if the draft API has been observed unavailable."""
+    """Return whether the Bot API draft method is globally unavailable."""
     return _DRAFT_UNAVAILABLE
 
 
 def mark_draft_unavailable(reason: str = "") -> None:
-    """Mark the draft API as unavailable process-wide.
-
-    Idempotent — only the first call records a reason.
-    """
+    """Disable draft probing after a server reports an unknown method."""
     global _DRAFT_UNAVAILABLE, _DRAFT_REASON
     if not _DRAFT_UNAVAILABLE:
         _DRAFT_UNAVAILABLE = True
@@ -133,12 +75,12 @@ def mark_draft_unavailable(reason: str = "") -> None:
 
 
 def draft_unavailable_reason() -> str:
-    """Return the recorded reason the draft API was disabled, or empty."""
+    """Return the first reason recorded for global draft disablement."""
     return _DRAFT_REASON
 
 
 def reset_draft_state() -> None:
-    """Clear the process-wide draft-availability flag and per-peer cache (test helper)."""
+    """Reset availability caches. Intended for tests and process restart."""
     global _DRAFT_UNAVAILABLE, _DRAFT_REASON
     _DRAFT_UNAVAILABLE = False
     _DRAFT_REASON = ""
@@ -146,32 +88,30 @@ def reset_draft_state() -> None:
 
 
 def is_peer_draft_unsupported(chat_id: int, thread_id: int | None) -> bool:
-    """Return True if `(chat_id, thread_id)` previously rejected drafts."""
+    """Return whether this chat/topic previously rejected drafts."""
     return (chat_id, thread_id) in _UNSUPPORTED_PEERS
 
 
 def mark_peer_draft_unsupported(chat_id: int, thread_id: int | None) -> None:
-    """Mark `(chat_id, thread_id)` as draft-unsupported.
-
-    Subsequent DraftStream instances for this peer skip the draft probe
-    and open in legacy mode immediately.
-    """
+    """Cache a peer-specific draft rejection."""
     _UNSUPPORTED_PEERS.add((chat_id, thread_id))
 
 
 def _is_unsupported_error(exc: BadRequest) -> bool:
-    msg = exc.message.lower() if exc.message else ""
-    return any(m in msg for m in _UNSUPPORTED_MARKERS)
+    message = (exc.message or "").lower()
+    return any(marker in message for marker in _UNSUPPORTED_MARKERS)
 
 
 def _is_peer_invalid_error(exc: BadRequest) -> bool:
-    msg = exc.message.lower() if exc.message else ""
-    return any(m in msg for m in _PEER_INVALID_MARKERS)
+    message = (exc.message or "").lower()
+    return any(marker in message for marker in _PEER_INVALID_MARKERS)
 
 
 def _retry_after_seconds(exc: RetryAfter) -> float:
-    ra = exc.retry_after
-    return float(ra) if isinstance(ra, int | float) else ra.total_seconds()
+    retry_after = exc.retry_after
+    if isinstance(retry_after, timedelta):
+        return retry_after.total_seconds()
+    return float(retry_after)
 
 
 def _truncate(text: str) -> str:
@@ -179,18 +119,12 @@ def _truncate(text: str) -> str:
 
 
 class DraftStream:
-    """Streaming message that grows incrementally.
+    """Accumulate text and deliver it as a Telegram draft or editable message.
 
-    Lifecycle: ``start`` → ``append``\\* → ``finalize`` (or ``abort``).
-    Reusable streams are not supported — create a new instance per message.
-
-    Mode selection happens on ``start``:
-      - if `_DRAFT_UNAVAILABLE` is set, opens in legacy mode immediately;
-      - otherwise tries `sendMessageDraft`; on ``400 method not found``
-        flips the flag and falls back to legacy for this stream.
-
-    A stream may also self-degrade to legacy mid-flight after repeated
-    transient failures on append; the underlying message is preserved.
+    The streaming lifecycle is ``start`` → ``append``/``replace``* →
+    ``finalize``. In streaming mode ``start`` returns ``None`` because a draft
+    has no message id. ``finalize`` sends the persisted message and stores its
+    id. In legacy mode ``start`` returns the initial message id.
     """
 
     def __init__(
@@ -206,44 +140,42 @@ class DraftStream:
         self._chat_id = chat_id
         self._thread_id = message_thread_id
         self._reply_to = reply_to_message_id
-        self._reply_markup: InlineKeyboardMarkup | None = reply_markup
+        self._reply_markup = reply_markup
+        self._draft_id = secrets.randbelow(2_147_483_646) + 1
         self._message_id: int | None = None
-        self._buffer: str = ""
+        self._buffer = ""
         self._mode: Literal["streaming", "legacy", "unset"] = DRAFT_UNSET  # type: ignore[assignment]
-        self._closed: bool = False
-        self._stream_failures: int = 0
+        self._closed = False
+        self._stream_failures = 0
+        self._last_draft_at = 0.0
+        self._retry_not_before = 0.0
+        self._pending_flush: asyncio.Task[None] | None = None
+        self._update_lock = asyncio.Lock()
 
     @property
     def message_id(self) -> int | None:
-        """ID of the underlying Telegram message, or None before ``start``."""
+        """Return the persisted message id, if one exists."""
         return self._message_id
 
     @property
     def mode(self) -> str:
-        """Current mode: ``streaming``, ``legacy``, or ``unset`` before start."""
+        """Return ``streaming``, ``legacy``, or ``unset``."""
         return self._mode
 
     @property
     def closed(self) -> bool:
-        """True after ``finalize`` or ``abort``."""
+        """Return whether the stream has been finalized or aborted."""
         return self._closed
 
     @property
     def text(self) -> str:
-        """Current accumulated text (post-truncation if longer than 4096)."""
+        """Return the text that fits in one Telegram message."""
         return _truncate(self._buffer)
 
     async def start(self, initial_text: str) -> int | None:
-        """Open the stream with `initial_text`. Returns the message_id.
-
-        Returns None if the underlying transport fails transiently
-        (TimedOut/NetworkError) — neither streaming nor legacy could deliver.
-        Caller treats None as "stream not opened" and skips edits.
-        """
+        """Open a stream and send its first snapshot."""
         if self._mode != DRAFT_UNSET:
             raise RuntimeError("DraftStream.start called twice")
-        # Telegram rejects empty text with BadRequest. Treat empty as
-        # "nothing to send" rather than letting the request fail server-side.
         if not initial_text:
             return None
         self._buffer = initial_text
@@ -255,19 +187,13 @@ class DraftStream:
                 await self._start_legacy()
             else:
                 await self._start_streaming()
-        except (TimedOut, NetworkError) as exc:
-            logger.warning("DraftStream.start transient failure: %s", exc)
-            return None
-        except RetryAfter as exc:
-            logger.warning("DraftStream.start rate-limited: %s", exc)
-            return None
-        except TelegramError as exc:
-            logger.warning("DraftStream.start telegram error: %s", exc)
+        except (TimedOut, NetworkError, RetryAfter, TelegramError) as exc:
+            logger.warning("DraftStream.start failed: %s", exc)
             return None
         return self._message_id
 
     async def append(self, delta: str) -> None:
-        """Append `delta` to the message and push the update."""
+        """Append a delta and publish the cumulative text."""
         self._ensure_open()
         self._buffer += delta
         await self._push_update()
@@ -278,12 +204,7 @@ class DraftStream:
         *,
         reply_markup: InlineKeyboardMarkup | None | Any = _KEEP_MARKUP,
     ) -> None:
-        """Replace the buffer with `text` and push the update.
-
-        When passed, `reply_markup` updates the persisted markup for this
-        and subsequent pushes; ``None`` clears the markup, ``_KEEP_MARKUP``
-        (default) leaves it untouched.
-        """
+        """Replace the cumulative text and publish the new snapshot."""
         self._ensure_open()
         self._buffer = text
         if reply_markup is not _KEEP_MARKUP:
@@ -296,29 +217,33 @@ class DraftStream:
         *,
         reply_markup: InlineKeyboardMarkup | None | Any = _KEEP_MARKUP,
     ) -> None:
-        """Push a terminal update (optionally replacing the text) and close."""
+        """Persist the final text and close the stream."""
         self._ensure_open()
         if final_text is not None:
             self._buffer = final_text
         if reply_markup is not _KEEP_MARKUP:
             self._reply_markup = reply_markup
-        await self._push_update(final=True)
+
+        await self._cancel_pending_flush()
+        if self._mode == DRAFT_STREAMING:
+            await self._send_final_message()
+        else:
+            await self._push_legacy(raise_on_error=True)
         self._closed = True
 
     async def abort(self) -> None:
-        """Delete the underlying message (best-effort) and close."""
-        if self._closed or self._message_id is None:
-            self._closed = True
+        """Close a draft, or delete the fallback message."""
+        if self._closed:
             return
-        try:
-            await self._bot.delete_message(
-                chat_id=self._chat_id, message_id=self._message_id
-            )
-        except TelegramError as exc:
-            logger.warning("DraftStream.abort delete failed: %s", exc)
+        await self._cancel_pending_flush()
+        if self._mode == DRAFT_LEGACY and self._message_id is not None:
+            try:
+                await self._bot.delete_message(
+                    chat_id=self._chat_id, message_id=self._message_id
+                )
+            except TelegramError as exc:
+                logger.warning("DraftStream.abort delete failed: %s", exc)
         self._closed = True
-
-    # ---- internals ----------------------------------------------------
 
     def _ensure_open(self) -> None:
         if self._mode == DRAFT_UNSET:
@@ -327,52 +252,40 @@ class DraftStream:
             raise RuntimeError("DraftStream already closed")
 
     def _send_kwargs(self) -> dict[str, Any]:
-        kw: dict[str, Any] = {}
+        kwargs: dict[str, Any] = {}
         if self._thread_id is not None:
-            kw["message_thread_id"] = self._thread_id
+            kwargs["message_thread_id"] = self._thread_id
         if self._reply_to is not None:
-            kw["reply_to_message_id"] = self._reply_to
+            kwargs["reply_to_message_id"] = self._reply_to
         if self._reply_markup is not None:
-            kw["reply_markup"] = self._reply_markup
-        return kw
+            kwargs["reply_markup"] = self._reply_markup
+        return kwargs
 
-    def _markup_dict(self) -> Any | None:
-        if self._reply_markup is None:
-            return None
-        to_dict = getattr(self._reply_markup, "to_dict", None)
-        if callable(to_dict):
-            return to_dict()
-        return self._reply_markup
-
-    async def _start_streaming(self) -> None:
-        data: dict[str, Any] = {
+    def _draft_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
             "chat_id": self._chat_id,
+            "draft_id": self._draft_id,
             "text": self.text,
         }
         if self._thread_id is not None:
-            data["message_thread_id"] = self._thread_id
-        if self._reply_to is not None:
-            data["reply_to_message_id"] = self._reply_to
-        markup = self._markup_dict()
-        if markup is not None:
-            data["reply_markup"] = markup
+            kwargs["message_thread_id"] = self._thread_id
+        return kwargs
+
+    async def _start_streaming(self) -> None:
         try:
-            result = await self._bot.do_api_request("sendMessageDraft", api_kwargs=data)
+            await self._send_draft()
         except BadRequest as exc:
             if _is_unsupported_error(exc):
                 mark_draft_unavailable(f"sendMessageDraft: {exc.message}")
-                await self._start_legacy()
-                return
-            if _is_peer_invalid_error(exc):
+            elif _is_peer_invalid_error(exc):
                 mark_peer_draft_unsupported(self._chat_id, self._thread_id)
                 logger.info(
-                    "sendMessageDraft peer-invalid for chat=%s thread=%s — caching legacy",
+                    "sendMessageDraft peer-invalid for chat=%s thread=%s",
                     self._chat_id,
                     self._thread_id,
                 )
-                await self._start_legacy()
-                return
-            logger.warning("sendMessageDraft BadRequest: %s — degrading", exc)
+            else:
+                logger.warning("sendMessageDraft rejected: %s", exc)
             await self._start_legacy()
             return
         except RetryAfter as exc:
@@ -380,101 +293,163 @@ class DraftStream:
             await self._start_legacy()
             return
         except TelegramError as exc:
-            logger.warning("sendMessageDraft TelegramError: %s — degrading", exc)
+            logger.warning("sendMessageDraft failed: %s", exc)
             await self._start_legacy()
             return
-
-        self._message_id = _extract_message_id(result)
-        if self._message_id is None:
-            logger.warning("sendMessageDraft returned no message id — degrading")
-            await self._start_legacy()
-            return
+        self._last_draft_at = time.monotonic()
         self._mode = DRAFT_STREAMING
 
     async def _start_legacy(self) -> None:
-        msg = await self._bot.send_message(
+        message = await self._bot.send_message(
             chat_id=self._chat_id,
             text=self.text,
             **self._send_kwargs(),
         )
-        self._message_id = msg.message_id
+        self._message_id = message.message_id
         self._mode = DRAFT_LEGACY
 
-    async def _push_update(self, *, final: bool = False) -> None:
+    async def _push_update(self) -> None:
         if self._mode == DRAFT_STREAMING:
-            await self._push_streaming(final=final)
+            await self._push_streaming()
         else:
             await self._push_legacy()
 
-    async def _push_streaming(self, *, final: bool) -> None:
-        method = "finalizeMessageDraft" if final else "editMessageDraft"
-        data: dict[str, Any] = {
-            "chat_id": self._chat_id,
-            "message_id": self._message_id,
-            "text": self.text,
-        }
-        # Always include reply_markup so an explicit None clears any prior
-        # keyboard. Telegram leaves the existing keyboard untouched when the
-        # field is omitted, so omitting on None would silently fail to clear.
-        markup = self._markup_dict()
-        data["reply_markup"] = markup if markup is not None else {"inline_keyboard": []}
+    async def _push_streaming(self) -> None:
+        if _DRAFT_UNAVAILABLE or is_peer_draft_unsupported(
+            self._chat_id, self._thread_id
+        ):
+            return
+        async with self._update_lock:
+            now = time.monotonic()
+            remaining = max(
+                _MIN_DRAFT_INTERVAL - (now - self._last_draft_at),
+                self._retry_not_before - now,
+            )
+            if remaining > 0:
+                self._schedule_pending_flush(remaining)
+                return
+            retry_delay = await self._send_stream_snapshot()
+        if retry_delay is not None:
+            self._schedule_pending_flush(retry_delay)
+
+    def _schedule_pending_flush(self, delay: float) -> None:
+        if self._pending_flush is not None and not self._pending_flush.done():
+            return
+        self._pending_flush = asyncio.create_task(
+            self._flush_pending_after(delay),
+            name=f"telegram-draft-flush:{self._chat_id}:{self._draft_id}",
+        )
+
+    async def _flush_pending_after(self, delay: float) -> None:
+        retry_delay: float | None = None
         try:
-            await self._bot.do_api_request(method, api_kwargs=data)
+            await asyncio.sleep(delay)
+            async with self._update_lock:
+                if self._closed or self._mode != DRAFT_STREAMING:
+                    return
+                retry_delay = await self._send_stream_snapshot()
+        except asyncio.CancelledError:
+            raise
+        except TelegramError as exc:
+            logger.warning("DraftStream trailing update failed: %s", exc)
+        finally:
+            self._pending_flush = None
+        if retry_delay is not None and not self._closed:
+            self._schedule_pending_flush(retry_delay)
+
+    async def _cancel_pending_flush(self) -> None:
+        task = self._pending_flush
+        self._pending_flush = None
+        if task is None or task.done() or task is asyncio.current_task():
+            return
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def _send_stream_snapshot(self) -> float | None:
+        if _DRAFT_UNAVAILABLE or is_peer_draft_unsupported(
+            self._chat_id, self._thread_id
+        ):
+            return None
+        try:
+            await self._send_draft()
+            self._last_draft_at = time.monotonic()
+            self._retry_not_before = 0.0
+            self._stream_failures = 0
         except BadRequest as exc:
             if _is_unsupported_error(exc):
-                mark_draft_unavailable(f"{method}: {exc.message}")
-                await self._degrade_in_flight()
-                return
+                mark_draft_unavailable(f"sendMessageDraft: {exc.message}")
+            elif _is_peer_invalid_error(exc):
+                mark_peer_draft_unsupported(self._chat_id, self._thread_id)
             await self._handle_stream_failure(exc)
         except RetryAfter as exc:
-            await asyncio.sleep(_retry_after_seconds(exc) + 1)
+            retry_delay = _retry_after_seconds(exc)
+            self._retry_not_before = time.monotonic() + retry_delay
             await self._handle_stream_failure(exc)
+            return retry_delay
         except TelegramError as exc:
             await self._handle_stream_failure(exc)
+        return None
 
-    async def _push_legacy(self) -> None:
-        # Always pass reply_markup: Telegram keeps the existing keyboard when
-        # the field is omitted, so reply_markup=None must serialize to an
-        # empty inline keyboard for the clear to take effect.
+    async def _send_draft(self) -> None:
+        """Call PTB's typed method, with an escape hatch for older PTB."""
+        payload = self._draft_kwargs()
+        send_draft = getattr(self._bot, "send_message_draft", None)
+        if send_draft is not None:
+            await send_draft(**payload)
+            return
+        await self._bot.do_api_request("sendMessageDraft", api_kwargs=payload)
+
+    async def _send_final_message(self) -> None:
+        try:
+            message = await self._bot.send_message(
+                chat_id=self._chat_id,
+                text=self.text,
+                **self._send_kwargs(),
+            )
+        except TelegramError as exc:
+            logger.warning("DraftStream final send failed: %s", exc)
+            raise
+        self._message_id = message.message_id
+
+    async def _push_legacy(  # noqa: C901
+        self, *, raise_on_error: bool = False
+    ) -> None:
+        if self._message_id is None:
+            return
         markup = self._reply_markup
         if markup is None:
             markup = InlineKeyboardMarkup([])
-        edit_kwargs: dict[str, Any] = {"reply_markup": markup}
         try:
             await self._bot.edit_message_text(
                 chat_id=self._chat_id,
                 message_id=self._message_id,
                 text=self.text,
-                **edit_kwargs,
+                reply_markup=markup,
             )
         except BadRequest as exc:
-            # message not modified — treat as success (no-op edit)
             if "not modified" in (exc.message or "").lower():
                 return
             self._warn_legacy_edit_failed(exc)
+            if raise_on_error:
+                raise
         except RetryAfter as exc:
             await asyncio.sleep(_retry_after_seconds(exc) + 1)
-            with contextlib.suppress(TelegramError):
+            try:
                 await self._bot.edit_message_text(
                     chat_id=self._chat_id,
                     message_id=self._message_id,
                     text=self.text,
-                    **edit_kwargs,
+                    reply_markup=markup,
                 )
+            except TelegramError as retry_exc:
+                self._warn_legacy_edit_failed(retry_exc)
+                if raise_on_error:
+                    raise
         except TelegramError as exc:
             self._warn_legacy_edit_failed(exc)
-
-    def _warn_legacy_edit_failed(self, exc: TelegramError) -> None:
-        # Throttled: _push_legacy runs on every append()/finalize(). When the
-        # target message is gone or persistently rejecting edits this would
-        # warn per delta. The degrade into legacy mode was already announced at
-        # WARNING by _handle_stream_failure, so repeats here are low value.
-        log_throttled(
-            logger,
-            f"draft-legacy-edit:{self._chat_id}:{self._message_id}",
-            "DraftStream legacy edit failed: %s",
-            exc,
-        )
+            if raise_on_error:
+                raise
 
     async def _handle_stream_failure(self, exc: TelegramError) -> None:
         self._stream_failures += 1
@@ -485,26 +460,14 @@ class DraftStream:
             exc,
         )
         if self._stream_failures >= _DEGRADE_AFTER_FAILURES:
-            await self._degrade_in_flight()
+            logger.warning(
+                "DraftStream keeping stale preview after repeated update failures"
+            )
 
-    async def _degrade_in_flight(self) -> None:
-        if self._mode == DRAFT_LEGACY:
-            return
-        self._mode = DRAFT_LEGACY
-        await self._push_legacy()
-
-
-def _extract_message_id(result: Any) -> int | None:
-    """Pull message_id out of whatever sendMessageDraft returns.
-
-    Telegram returns either a Message-like object with ``.message_id`` or
-    a dict ``{"message_id": ...}``. PTB's do_api_request strips the
-    envelope and returns the inner result.
-    """
-    if result is None:
-        return None
-    if isinstance(result, dict):
-        mid = result.get("message_id")
-        return int(mid) if mid is not None else None
-    mid = getattr(result, "message_id", None)
-    return int(mid) if mid is not None else None
+    def _warn_legacy_edit_failed(self, exc: TelegramError) -> None:
+        log_throttled(
+            logger,
+            f"draft-legacy-edit:{self._chat_id}:{self._message_id}",
+            "DraftStream legacy edit failed: %s",
+            exc,
+        )

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_routing.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_routing.py
@@ -1,8 +1,10 @@
+import asyncio
 from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ccgram.handlers.messaging_pipeline import message_routing
 from ccgram.handlers.messaging_pipeline.message_routing import handle_new_message
 from ccgram.handlers.telegram_origin import (
     clear_pending_telegram_injections,
@@ -37,8 +39,16 @@ def _make_msg(
 @pytest.fixture(autouse=True)
 def _clear_pending_telegram_injections() -> Iterator[None]:
     clear_pending_telegram_injections()
+    for task in message_routing._draft_expiry_tasks.values():
+        task.cancel()
+    message_routing._draft_expiry_tasks.clear()
+    message_routing._active_drafts.clear()
     yield
     clear_pending_telegram_injections()
+    for task in message_routing._draft_expiry_tasks.values():
+        task.cancel()
+    message_routing._draft_expiry_tasks.clear()
+    message_routing._active_drafts.clear()
 
 
 @pytest.fixture
@@ -162,6 +172,70 @@ async def test_complete_message_enqueues_content(bot, mock_deps):
     assert kwargs["window_id"] == "@5"
     assert kwargs["thread_id"] == 42
     assert kwargs["chat_id"] == -100
+
+
+async def test_incomplete_assistant_text_updates_and_finalizes_draft(bot, mock_deps):
+    draft = MagicMock(mode="streaming")
+    draft.start = AsyncMock(return_value=None)
+    draft.replace = AsyncMock()
+    draft.abort = AsyncMock()
+    with patch(
+        "ccgram.handlers.messaging_pipeline.message_routing.DraftStream",
+        return_value=draft,
+    ) as draft_class:
+        await handle_new_message(_make_msg(text="first", is_complete=False), bot)
+        await handle_new_message(_make_msg(text="second", is_complete=False), bot)
+        await handle_new_message(_make_msg(text="final", is_complete=True), bot)
+
+    draft_class.assert_called_once_with(
+        bot,
+        -100,
+        message_thread_id=42,
+    )
+    draft.start.assert_awaited_once_with("first")
+    draft.replace.assert_awaited_once_with("second")
+    draft.abort.assert_awaited_once()
+    mock_deps["eq"].assert_called_once()
+
+
+@pytest.mark.parametrize("mode", ["streaming", "legacy"])
+async def test_stalled_draft_is_expired(bot, mock_deps, monkeypatch, mode):
+    monkeypatch.setattr(message_routing, "_DRAFT_TTL_SECONDS", 0.01)
+    draft = MagicMock(mode=mode)
+    draft.start = AsyncMock(return_value=None)
+    draft.abort = AsyncMock()
+    with patch(
+        "ccgram.handlers.messaging_pipeline.message_routing.DraftStream",
+        return_value=draft,
+    ):
+        await handle_new_message(_make_msg(text="partial", is_complete=False), bot)
+        await asyncio.sleep(0.02)
+
+    assert message_routing._active_drafts == {}
+    draft.abort.assert_awaited_once()
+
+
+async def test_long_final_message_falls_back_to_paginated_delivery(bot, mock_deps):
+    draft = MagicMock(mode="streaming")
+    draft.start = AsyncMock(return_value=None)
+    draft.abort = AsyncMock()
+    with patch(
+        "ccgram.handlers.messaging_pipeline.message_routing.DraftStream",
+        return_value=draft,
+    ):
+        await handle_new_message(_make_msg(text="partial", is_complete=False), bot)
+        await handle_new_message(_make_msg(text="x" * 4097, is_complete=True), bot)
+
+    draft.abort.assert_awaited_once()
+    mock_deps["eq"].assert_awaited_once()
+    mock_deps["brp"].assert_called_with("x" * 4097, True, "text", "assistant")
+
+
+async def test_incomplete_user_message_is_not_streamed(bot, mock_deps):
+    await handle_new_message(
+        _make_msg(text="partial", role="user", is_complete=False), bot
+    )
+    mock_deps["eq"].assert_not_called()
 
 
 async def test_matching_telegram_user_message_is_suppressed(bot, mock_deps):

--- a/tests/ccgram/handlers/messaging_pipeline/test_tool_batch.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_tool_batch.py
@@ -3,6 +3,7 @@ import inspect
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from telegram.error import TelegramError
 
 from ccgram.handlers.messaging_pipeline.message_task import ContentTask
 from ccgram.handlers.messaging_pipeline.tool_batch import (
@@ -240,6 +241,95 @@ class TestDraftStreamIntegration:
         await flush_batch(bot, user_id=1, thread_id_or_0=10)
         bot.send_message.assert_not_called()
         bot.edit_message_text.assert_not_called()
+
+
+class TestNativeDraftIntegration:
+    async def test_streaming_draft_is_kept_without_message_id(
+        self, monkeypatch
+    ) -> None:
+        from ccgram.telegram_draft import reset_draft_state
+
+        reset_draft_state()
+        monkeypatch.setattr(
+            "ccgram.handlers.status.status_bubble.clear_status_message",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(
+            "ccgram.handlers.messaging_pipeline.tool_batch._rate_limit_chat",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(
+            "ccgram.handlers.messaging_pipeline.tool_batch.get_batch_mode",
+            lambda _wid: "batched",
+        )
+        monkeypatch.setattr(
+            "ccgram.handlers.messaging_pipeline.tool_batch.is_ephemeral_tools",
+            lambda _wid: False,
+        )
+        monkeypatch.setattr(
+            "ccgram.handlers.messaging_pipeline.tool_batch.thread_router",
+            MagicMock(resolve_chat_id=MagicMock(return_value=42)),
+        )
+
+        bot = AsyncMock()
+        bot.send_message_draft = AsyncMock(return_value=True)
+        sent = MagicMock(message_id=77)
+        bot.send_message.return_value = sent
+        batch = ToolBatch(window_id="@0", thread_id=10)
+        batch.entries.append(
+            ToolBatchEntry(tool_use_id="t1", tool_use_text="Read foo.py")
+        )
+        _active_batches[(1, 10)] = batch
+
+        await _send_or_edit_batch(bot, 1, batch, 42, 10, 10)
+        assert batch.draft is not None
+        assert batch.draft.mode == "streaming"
+        assert batch.telegram_msg_id is None
+        assert batch.last_sent_text == "Read foo.py"
+
+        await _send_or_edit_batch(bot, 1, batch, 42, 10, 10)
+        bot.send_message_draft.assert_awaited_once()
+
+        await flush_batch(bot, 1, 10)
+        bot.send_message.assert_awaited_once_with(
+            chat_id=42, text="Read foo.py", message_thread_id=10
+        )
+
+    async def test_failed_final_send_keeps_batch_for_retry(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "ccgram.handlers.messaging_pipeline.tool_batch._rate_limit_chat",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(
+            "ccgram.handlers.messaging_pipeline.tool_batch.thread_router",
+            MagicMock(resolve_chat_id=MagicMock(return_value=42)),
+        )
+        monkeypatch.setattr(
+            "ccgram.handlers.messaging_pipeline.tool_batch.get_batch_mode",
+            lambda _wid: "batched",
+        )
+        monkeypatch.setattr(
+            "ccgram.handlers.messaging_pipeline.tool_batch.is_ephemeral_tools",
+            lambda _wid: False,
+        )
+        bot = AsyncMock()
+        bot.send_message_draft = AsyncMock(return_value=True)
+        bot.send_message.side_effect = [
+            TelegramError("temporary"),
+            MagicMock(message_id=9),
+        ]
+        batch = ToolBatch(window_id="@0", thread_id=10)
+        batch.entries.append(
+            ToolBatchEntry(tool_use_id="t1", tool_use_text="Read foo.py")
+        )
+        _active_batches[(1, 10)] = batch
+
+        await _send_or_edit_batch(bot, 1, batch, 42, 10, 10)
+        await flush_batch(bot, 1, 10)
+        assert _active_batches[(1, 10)] is batch
+
+        await flush_batch(bot, 1, 10)
+        assert (1, 10) not in _active_batches
 
 
 class TestDedupConsecutiveEntries:

--- a/tests/ccgram/providers/test_jsonl_providers.py
+++ b/tests/ccgram/providers/test_jsonl_providers.py
@@ -175,6 +175,28 @@ class TestCodexTranscriptParsing:
         assert messages[0].text == "working on it"
         assert messages[0].role == "assistant"
         assert messages[0].content_type == "text"
+        assert messages[0].is_complete is False
+
+    def test_agent_message_stream_is_completed_by_task_complete(self) -> None:
+        codex = CodexProvider()
+        entries = [
+            {
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "working"},
+            },
+            {
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "last_agent_message": "working and done",
+                },
+            },
+        ]
+
+        messages, _ = codex.parse_transcript_entries(entries, {})
+
+        assert [message.text for message in messages] == ["working", "working and done"]
+        assert [message.is_complete for message in messages] == [False, True]
 
     def test_dedupes_identical_event_and_response_messages(self) -> None:
         codex = CodexProvider()

--- a/tests/ccgram/test_telegram_draft.py
+++ b/tests/ccgram/test_telegram_draft.py
@@ -1,5 +1,8 @@
 from unittest.mock import AsyncMock, MagicMock
 
+import asyncio
+from datetime import timedelta
+
 import pytest
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.error import BadRequest, RetryAfter, TelegramError
@@ -12,21 +15,22 @@ from ccgram.telegram_draft import (
     is_draft_unavailable,
     is_peer_draft_unsupported,
     mark_draft_unavailable,
-    mark_peer_draft_unsupported,
     reset_draft_state,
 )
 
 
 @pytest.fixture(autouse=True)
-def _reset_draft_state():
+def _reset_draft_state(monkeypatch):
+    monkeypatch.setattr(telegram_draft, "_MIN_DRAFT_INTERVAL", 0.0)
     reset_draft_state()
     yield
     reset_draft_state()
 
 
-def _make_bot(*, draft_result=None, send_id=42):
+def _make_bot(*, send_id=42):
     bot = MagicMock()
-    bot.do_api_request = AsyncMock(return_value=draft_result or {"message_id": 11})
+    bot.send_message_draft = AsyncMock(return_value=True)
+    bot.do_api_request = AsyncMock(return_value=True)
     sent_msg = MagicMock(message_id=send_id)
     bot.send_message = AsyncMock(return_value=sent_msg)
     bot.edit_message_text = AsyncMock(return_value=None)
@@ -34,452 +38,262 @@ def _make_bot(*, draft_result=None, send_id=42):
     return bot
 
 
+def _draft_calls(bot):
+    return bot.send_message_draft.call_args_list
+
+
 class TestDraftStreamHappyPath:
-    async def test_streaming_start_uses_draft_api(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
-        stream = DraftStream(bot, chat_id=100, message_thread_id=5)
+    async def test_start_uses_nonzero_draft_id_and_returns_no_message_id(self) -> None:
+        bot = _make_bot()
+        stream = DraftStream(bot, chat_id=100)
 
-        mid = await stream.start("hello")
+        message_id = await stream.start("hello")
 
-        assert mid == 7
+        assert message_id is None
+        assert stream.message_id is None
         assert stream.mode == DRAFT_STREAMING
-        bot.do_api_request.assert_awaited_once()
-        method, kwargs = (
-            bot.do_api_request.call_args.args[0],
-            bot.do_api_request.call_args.kwargs,
-        )
-        assert method == "sendMessageDraft"
-        assert kwargs["api_kwargs"]["chat_id"] == 100
-        assert kwargs["api_kwargs"]["text"] == "hello"
-        assert kwargs["api_kwargs"]["message_thread_id"] == 5
+        call = _draft_calls(bot)[0]
+        payload = call.kwargs
+        assert payload["chat_id"] == 100
+        assert payload["text"] == "hello"
+        assert payload["draft_id"] > 0
+        assert "reply_to_message_id" not in payload
+        assert "reply_markup" not in payload
         bot.send_message.assert_not_awaited()
 
-    async def test_append_then_finalize_streaming(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
-        stream = DraftStream(bot, chat_id=100)
+    async def test_updates_reuse_draft_id_and_finalize_with_send_message(self) -> None:
+        bot = _make_bot()
+        stream = DraftStream(bot, chat_id=100, message_thread_id=5)
 
         await stream.start("a")
         await stream.append("b")
-        await stream.append("c")
-        await stream.finalize()
+        await stream.replace("abc")
+        await stream.finalize("final")
 
-        # 1 sendMessageDraft + 2 editMessageDraft + 1 finalizeMessageDraft
-        assert bot.do_api_request.await_count == 4
-        called_methods = [c.args[0] for c in bot.do_api_request.call_args_list]
-        assert called_methods == [
-            "sendMessageDraft",
-            "editMessageDraft",
-            "editMessageDraft",
-            "finalizeMessageDraft",
+        calls = _draft_calls(bot)
+        assert [call.kwargs["text"] for call in calls] == [
+            "a",
+            "ab",
+            "abc",
         ]
-        # Buffer accumulates
-        last_call = bot.do_api_request.call_args_list[-1]
-        assert last_call.kwargs["api_kwargs"]["text"] == "abc"
+        draft_ids = {call.kwargs["draft_id"] for call in calls}
+        assert len(draft_ids) == 1
+        bot.send_message.assert_awaited_once_with(
+            chat_id=100,
+            text="final",
+            message_thread_id=5,
+        )
+        assert stream.message_id == 42
         assert stream.closed is True
 
-    async def test_finalize_with_replacement_text(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
+    async def test_finalize_uses_final_text_without_extra_draft_call(self) -> None:
+        bot = _make_bot()
         stream = DraftStream(bot, chat_id=100)
 
         await stream.start("draft")
         await stream.finalize("final")
 
-        last_call = bot.do_api_request.call_args_list[-1]
-        assert last_call.args[0] == "finalizeMessageDraft"
-        assert last_call.kwargs["api_kwargs"]["text"] == "final"
+        assert len(_draft_calls(bot)) == 1
+        bot.send_message.assert_awaited_once_with(chat_id=100, text="final")
+
+    async def test_throttled_updates_flush_latest_snapshot(self, monkeypatch) -> None:
+        monkeypatch.setattr(telegram_draft, "_MIN_DRAFT_INTERVAL", 0.01)
+        bot = _make_bot()
+        stream = DraftStream(bot, chat_id=100)
+
+        await stream.start("a")
+        await stream.append("b")
+        await stream.append("c")
+        await asyncio.sleep(0.02)
+
+        assert [call.kwargs["text"] for call in _draft_calls(bot)] == ["a", "abc"]
+
+    async def test_retry_after_defers_and_retries_latest_snapshot(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(telegram_draft, "_MIN_DRAFT_INTERVAL", 0.0)
+        bot = _make_bot()
+        bot.send_message_draft.side_effect = [
+            True,
+            RetryAfter(timedelta(milliseconds=1)),
+            True,
+        ]
+        stream = DraftStream(bot, chat_id=100)
+
+        await stream.start("a")
+        await stream.append("b")
+        assert bot.send_message_draft.await_count == 2
+
+        await asyncio.sleep(0.02)
+        assert bot.send_message_draft.await_count == 3
+        assert bot.send_message_draft.call_args.kwargs["text"] == "ab"
+
+    async def test_final_send_failure_keeps_stream_open_for_retry(self) -> None:
+        bot = _make_bot()
+        bot.send_message.side_effect = TelegramError("temporary")
+        stream = DraftStream(bot, chat_id=100)
+
+        await stream.start("draft")
+        with pytest.raises(TelegramError, match="temporary"):
+            await stream.finalize("final")
+
+        assert stream.closed is False
 
 
 class TestDraftStreamFallback:
-    async def test_400_method_not_found_flips_global_flag(self) -> None:
+    async def test_method_not_found_falls_back_to_legacy(self) -> None:
         bot = _make_bot()
-        bot.do_api_request.side_effect = BadRequest("method not found")
+        bot.send_message_draft.side_effect = BadRequest("method not found")
 
         stream = DraftStream(bot, chat_id=100)
-        mid = await stream.start("hi")
+        message_id = await stream.start("hi")
 
-        assert mid == 42
+        assert message_id == 42
         assert stream.mode == DRAFT_LEGACY
         assert is_draft_unavailable() is True
-        bot.send_message.assert_awaited_once()
+        bot.send_message.assert_awaited_once_with(chat_id=100, text="hi")
 
-    async def test_subsequent_streams_skip_probe_after_flag_set(self) -> None:
-        mark_draft_unavailable("test")
+    async def test_peer_invalid_is_cached_without_disabling_other_peers(self) -> None:
         bot = _make_bot()
+        bot.send_message_draft.side_effect = BadRequest("draft_peer_invalid")
 
-        stream = DraftStream(bot, chat_id=100)
+        stream = DraftStream(bot, chat_id=100, message_thread_id=5)
         await stream.start("hi")
 
         assert stream.mode == DRAFT_LEGACY
-        bot.do_api_request.assert_not_awaited()
-        bot.send_message.assert_awaited_once()
-
-    async def test_other_badrequest_degrades_without_flag(self) -> None:
-        bot = _make_bot()
-        bot.do_api_request.side_effect = BadRequest("internal server error")
-
-        stream = DraftStream(bot, chat_id=100)
-        await stream.start("hi")
-
-        assert stream.mode == DRAFT_LEGACY
-        # Generic BadRequest does not set process-wide unavailable
         assert is_draft_unavailable() is False
+        assert is_peer_draft_unsupported(100, 5) is True
 
-    async def test_legacy_mode_uses_edit_message_text(self) -> None:
+        other_bot = _make_bot()
+        other = DraftStream(other_bot, chat_id=200, message_thread_id=5)
+        await other.start("hi")
+        assert other.mode == DRAFT_STREAMING
+        assert _draft_calls(other_bot)
+
+    async def test_legacy_updates_use_edit_message_text(self) -> None:
         mark_draft_unavailable("test")
         bot = _make_bot()
-
         stream = DraftStream(bot, chat_id=100)
+
         await stream.start("a")
         await stream.append("b")
         await stream.finalize()
 
-        bot.do_api_request.assert_not_awaited()
-        # 2 edit calls (append + finalize), 1 send_message at start
-        assert bot.send_message.await_count == 1
+        assert bot.send_message_draft.await_count == 0
         assert bot.edit_message_text.await_count == 2
-        last_call = bot.edit_message_text.call_args_list[-1]
-        assert last_call.kwargs["text"] == "ab"
+        assert bot.edit_message_text.call_args_list[-1].kwargs["text"] == "ab"
 
-    async def test_self_degrade_after_repeated_failures(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
-        # Start succeeds; subsequent calls raise transient errors twice.
-        bot.do_api_request.side_effect = [
-            {"message_id": 7},
-            TelegramError("transient1"),
-            TelegramError("transient2"),
-        ]
-
+    async def test_legacy_final_edit_failure_keeps_stream_open(self) -> None:
+        mark_draft_unavailable("test")
+        bot = _make_bot()
+        bot.edit_message_text.side_effect = TelegramError("temporary")
         stream = DraftStream(bot, chat_id=100)
+
+        await stream.start("draft")
+        with pytest.raises(TelegramError, match="temporary"):
+            await stream.finalize("final")
+
+        assert stream.closed is False
+
+    async def test_streaming_failures_keep_native_draft_without_duplicate_message(
+        self,
+    ) -> None:
+        bot = _make_bot()
+        bot.send_message_draft.side_effect = [True, TelegramError("transient")]
+        stream = DraftStream(bot, chat_id=100)
+
         await stream.start("a")
-        assert stream.mode == DRAFT_STREAMING
-
         await stream.append("b")
-        # First failure does not degrade
         assert stream.mode == DRAFT_STREAMING
 
+        bot.send_message_draft.side_effect = TelegramError("transient")
         await stream.append("c")
-        # Second failure degrades to legacy and re-pushes via edit_message_text
-        assert stream.mode == DRAFT_LEGACY
-        bot.edit_message_text.assert_awaited()
-
-
-class TestDraftStreamWarningSuppressed:
-    async def test_send_warning_filtered(self) -> None:
-        import warnings
-
-        from telegram.warnings import PTBUserWarning
-
-        bot = _make_bot(draft_result={"message_id": 7})
-        stream = DraftStream(bot, chat_id=100)
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            await stream.start("hi")
-
-        nag = [
-            w
-            for w in caught
-            if issubclass(w.category, PTBUserWarning)
-            and "sendMessageDraft" in str(w.message)
-        ]
-        assert nag == []
-
-
-class TestDraftStreamTransientLegacyFailure:
-    async def test_streaming_badrequest_then_legacy_timeout_returns_none(self) -> None:
-        from telegram.error import TimedOut
-
-        bot = _make_bot()
-        bot.do_api_request.side_effect = BadRequest("Textdraft_peer_invalid")
-        bot.send_message.side_effect = TimedOut("Timed out")
-
-        stream = DraftStream(bot, chat_id=100, message_thread_id=5)
-        mid = await stream.start("hi")
-
-        assert mid is None
-        assert stream.message_id is None
-
-    async def test_legacy_only_path_timeout_returns_none(self) -> None:
-        from telegram.error import TimedOut
-
-        mark_draft_unavailable("test")
-        bot = _make_bot()
-        bot.send_message.side_effect = TimedOut("Timed out")
-
-        stream = DraftStream(bot, chat_id=100)
-        mid = await stream.start("hi")
-
-        assert mid is None
-
-    async def test_legacy_only_path_telegram_error_returns_none(self) -> None:
-        from telegram.error import TelegramError as TgError
-
-        mark_draft_unavailable("test")
-        bot = _make_bot()
-        # Non-transient TelegramError (e.g. BadRequest, RetryAfter, generic)
-        # must not propagate — the stream is best-effort and silent.
-        bot.send_message.side_effect = TgError("flood")
-
-        stream = DraftStream(bot, chat_id=100)
-        mid = await stream.start("hi")
-
-        assert mid is None
-
-    async def test_empty_initial_text_returns_none_without_api_call(self) -> None:
-        bot = _make_bot()
-
-        stream = DraftStream(bot, chat_id=100)
-        mid = await stream.start("")
-
-        assert mid is None
-        bot.do_api_request.assert_not_awaited()
-        bot.send_message.assert_not_awaited()
-
-
-class TestDraftStreamPeerCache:
-    async def test_peer_invalid_caches_per_peer(self) -> None:
-        bot = _make_bot()
-        bot.do_api_request.side_effect = BadRequest("Textdraft_peer_invalid")
-
-        stream = DraftStream(bot, chat_id=100, message_thread_id=5)
-        await stream.start("hi")
-
-        assert stream.mode == DRAFT_LEGACY
-        assert is_draft_unavailable() is False  # only this peer
-        assert is_peer_draft_unsupported(100, 5) is True
-
-    async def test_subsequent_stream_to_same_peer_skips_probe(self) -> None:
-        mark_peer_draft_unsupported(100, 5)
-        bot = _make_bot()
-
-        stream = DraftStream(bot, chat_id=100, message_thread_id=5)
-        await stream.start("hi")
-
-        assert stream.mode == DRAFT_LEGACY
-        bot.do_api_request.assert_not_awaited()
-        bot.send_message.assert_awaited_once()
-
-    async def test_different_peer_still_probes(self) -> None:
-        mark_peer_draft_unsupported(100, 5)
-        bot = _make_bot(draft_result={"message_id": 7})
-
-        stream = DraftStream(bot, chat_id=200, message_thread_id=5)
-        await stream.start("hi")
-
+        await stream.append("d")
         assert stream.mode == DRAFT_STREAMING
-        bot.do_api_request.assert_awaited_once()
-
-    async def test_peer_invalid_marker_variants(self) -> None:
-        for marker in ("draft_peer_invalid", "PEER_INVALID", "Bad: Chat not found"):
-            reset_draft_state()
-            bot = _make_bot()
-            bot.do_api_request.side_effect = BadRequest(marker)
-
-            stream = DraftStream(bot, chat_id=100)
-            await stream.start("hi")
-
-            assert is_peer_draft_unsupported(100, None) is True, marker
+        assert bot.send_message.await_count == 0
 
 
-class TestDraftStreamRetryAfter:
-    async def test_retry_after_on_start_falls_back(self, monkeypatch) -> None:
-        async def _no_sleep(_):
-            return None
-
-        monkeypatch.setattr("asyncio.sleep", _no_sleep)
-
-        bot = _make_bot()
-        bot.do_api_request.side_effect = RetryAfter(0)
-
-        stream = DraftStream(bot, chat_id=100)
-        await stream.start("hi")
-
-        assert stream.mode == DRAFT_LEGACY
-        bot.send_message.assert_awaited_once()
-
-
-class TestDraftStreamAbort:
-    async def test_abort_deletes_message(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
-        stream = DraftStream(bot, chat_id=100)
-
-        await stream.start("hi")
-        await stream.abort()
-
-        assert stream.closed is True
-        bot.delete_message.assert_awaited_once_with(chat_id=100, message_id=7)
-
-    async def test_abort_swallows_telegram_error(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
-        bot.delete_message.side_effect = TelegramError("gone")
-
-        stream = DraftStream(bot, chat_id=100)
-        await stream.start("hi")
-        await stream.abort()
-
-        assert stream.closed is True
-
-    async def test_abort_before_start_is_safe(self) -> None:
+class TestDraftStreamLifecycle:
+    async def test_abort_does_not_delete_ephemeral_draft(self) -> None:
         bot = _make_bot()
         stream = DraftStream(bot, chat_id=100)
+
+        await stream.start("hi")
         await stream.abort()
+
         assert stream.closed is True
         bot.delete_message.assert_not_awaited()
 
-
-class TestDraftStreamGuards:
-    async def test_double_start_raises(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
-        stream = DraftStream(bot, chat_id=100)
-        await stream.start("hi")
-        with pytest.raises(RuntimeError, match="start called twice"):
-            await stream.start("again")
-
-    async def test_append_before_start_raises(self) -> None:
+    async def test_abort_deletes_legacy_message(self) -> None:
+        mark_draft_unavailable("test")
         bot = _make_bot()
         stream = DraftStream(bot, chat_id=100)
-        with pytest.raises(RuntimeError, match="not started"):
-            await stream.append("x")
 
-    async def test_append_after_finalize_raises(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
-        stream = DraftStream(bot, chat_id=100)
         await stream.start("hi")
-        await stream.finalize()
-        with pytest.raises(RuntimeError, match="already closed"):
-            await stream.append("x")
+        await stream.abort()
 
+        bot.delete_message.assert_awaited_once_with(chat_id=100, message_id=42)
 
-class TestDraftStreamTextSafety:
-    async def test_text_truncated_to_4096(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
+    async def test_empty_start_does_not_call_api(self) -> None:
+        bot = _make_bot()
+        stream = DraftStream(bot, chat_id=100)
+
+        assert await stream.start("") is None
+        bot.do_api_request.assert_not_awaited()
+        bot.send_message.assert_not_awaited()
+
+    async def test_text_is_truncated_to_4096_for_draft_and_final(self) -> None:
+        bot = _make_bot()
         stream = DraftStream(bot, chat_id=100)
 
         await stream.start("a" * 5000)
-
-        sent_text = bot.do_api_request.call_args.kwargs["api_kwargs"]["text"]
-        assert len(sent_text) == 4096
-        # Buffer is full; truncation only at send/edit boundary
-        assert stream.text == "a" * 4096
-
-    async def test_legacy_not_modified_is_silent(self) -> None:
-        mark_draft_unavailable("test")
-        bot = _make_bot()
-        bot.edit_message_text.side_effect = BadRequest(
-            "Bad Request: message is not modified"
-        )
-
-        stream = DraftStream(bot, chat_id=100)
-        await stream.start("a")
-        # Should not raise
-        await stream.append("a")
-        assert stream.mode == DRAFT_LEGACY
-
-
-class TestModuleStateHelpers:
-    def test_mark_unavailable_idempotent(self) -> None:
-        mark_draft_unavailable("first")
-        mark_draft_unavailable("second")
-        assert telegram_draft.draft_unavailable_reason() == "first"
-
-    def test_reset_clears_state(self) -> None:
-        mark_draft_unavailable("x")
-        assert is_draft_unavailable() is True
-        reset_draft_state()
-        assert is_draft_unavailable() is False
-        assert telegram_draft.draft_unavailable_reason() == ""
-
-
-class TestDraftStreamReplace:
-    async def test_replace_streaming_pushes_full_text(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
-        stream = DraftStream(bot, chat_id=100)
-
-        await stream.start("first")
-        await stream.replace("second")
-
-        called_methods = [c.args[0] for c in bot.do_api_request.call_args_list]
-        assert called_methods == ["sendMessageDraft", "editMessageDraft"]
-        last = bot.do_api_request.call_args_list[-1]
-        assert last.kwargs["api_kwargs"]["text"] == "second"
-        assert stream.text == "second"
-
-    async def test_replace_legacy_pushes_via_edit_message_text(self) -> None:
-        mark_draft_unavailable("test")
-        bot = _make_bot()
-
-        stream = DraftStream(bot, chat_id=100)
-        await stream.start("first")
-        await stream.replace("second")
-
-        bot.send_message.assert_awaited_once()
-        bot.edit_message_text.assert_awaited_once()
-        last = bot.edit_message_text.call_args_list[-1]
-        assert last.kwargs["text"] == "second"
-        assert stream.text == "second"
-
-    async def test_replace_after_finalize_raises(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
-        stream = DraftStream(bot, chat_id=100)
-        await stream.start("first")
         await stream.finalize()
 
+        assert len(_draft_calls(bot)[0].kwargs["text"]) == 4096
+        assert len(bot.send_message.call_args.kwargs["text"]) == 4096
+
+    async def test_guards(self) -> None:
+        bot = _make_bot()
+        stream = DraftStream(bot, chat_id=100)
+
+        with pytest.raises(RuntimeError, match="not started"):
+            await stream.append("x")
+        await stream.start("hi")
+        with pytest.raises(RuntimeError, match="start called twice"):
+            await stream.start("again")
+        await stream.finalize()
         with pytest.raises(RuntimeError, match="already closed"):
-            await stream.replace("second")
+            await stream.append("x")
 
 
-class TestDraftStreamReplyMarkup:
+class TestDraftStreamMarkup:
     @staticmethod
     def _markup() -> InlineKeyboardMarkup:
         return InlineKeyboardMarkup(
             [[InlineKeyboardButton("Esc", callback_data="esc")]]
         )
 
-    async def test_streaming_includes_serialized_markup(self) -> None:
-        bot = _make_bot(draft_result={"message_id": 7})
-        stream = DraftStream(bot, chat_id=100, reply_markup=self._markup())
-        await stream.start("hi")
-
-        kw = bot.do_api_request.call_args.kwargs["api_kwargs"]
-        assert "reply_markup" in kw
-        assert isinstance(kw["reply_markup"], dict)
-        assert kw["reply_markup"]["inline_keyboard"][0][0]["text"] == "Esc"
-
-    async def test_legacy_passes_inline_keyboard_through(self) -> None:
+    async def test_markup_is_only_sent_with_persisted_message(self) -> None:
         mark_draft_unavailable("test")
         bot = _make_bot()
         markup = self._markup()
         stream = DraftStream(bot, chat_id=100, reply_markup=markup)
 
         await stream.start("hi")
+        await stream.finalize("done")
+
         assert bot.send_message.call_args.kwargs["reply_markup"] is markup
+        assert not _draft_calls(bot)
 
-        await stream.replace("more")
-        assert bot.edit_message_text.call_args.kwargs["reply_markup"] is markup
 
-    async def test_replace_can_clear_markup(self) -> None:
-        mark_draft_unavailable("test")
-        bot = _make_bot()
-        stream = DraftStream(bot, chat_id=100, reply_markup=self._markup())
+class TestModuleStateHelpers:
+    def test_mark_unavailable_is_idempotent(self) -> None:
+        mark_draft_unavailable("first")
+        mark_draft_unavailable("second")
+        assert telegram_draft.draft_unavailable_reason() == "first"
 
-        await stream.start("hi")
-        await stream.replace("bye", reply_markup=None)
-
-        # Telegram leaves the existing keyboard untouched when reply_markup
-        # is omitted, so an explicit clear must serialize to an empty
-        # InlineKeyboardMarkup for the keyboard to actually disappear.
-        last_edit = bot.edit_message_text.call_args_list[-1]
-        markup = last_edit.kwargs["reply_markup"]
-        assert isinstance(markup, InlineKeyboardMarkup)
-        assert markup.inline_keyboard == ()
-
-    async def test_finalize_can_update_markup(self) -> None:
-        mark_draft_unavailable("test")
-        bot = _make_bot()
-        stream = DraftStream(bot, chat_id=100)
-
-        await stream.start("hi")
-        await stream.finalize("done", reply_markup=self._markup())
-
-        last_edit = bot.edit_message_text.call_args_list[-1]
-        assert isinstance(last_edit.kwargs["reply_markup"], InlineKeyboardMarkup)
+    def test_reset_clears_state(self) -> None:
+        mark_draft_unavailable("x")
+        reset_draft_state()
+        assert is_draft_unavailable() is False
+        assert telegram_draft.draft_unavailable_reason() == ""


### PR DESCRIPTION
Closes #155

## What This Changes

Stream Codex assistant replies to Telegram while the agent generates them. The bot uses `sendMessageDraft` for temporary previews and sends the complete reply through the normal message queue. Legacy chats use editable messages.

This change also adds retry handling, stalled-draft cleanup, queue-order protection, Codex completion events, and regression tests.

## Validation

- `uv run ruff format --check src/ tests/`
- `make lint`
- `make typecheck`
- `make deptry`
- `make test`
- Architecture pre-push gate: 817 passed, 0 blocking findings

## Checklist

- [x] There is a linked issue above
- [x] `make test` passes
- [x] `make lint` passes
- [x] This PR changes one thing only
- [x] Tests cover the new behavior and failure paths
