### PR TITLE
fix: stop topic probe from tripping Telegram flood control

### DIFF
--- a/src/ccgram/handlers/messaging_pipeline/message_sender.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_sender.py
@@ -53,6 +53,7 @@ __all__ = [
     "rate_limit_send",
     "rate_limit_send_message",
     "react",
+    "retry_after_seconds",
     "safe_edit",
     "safe_reply",
     "safe_send",
@@ -78,10 +79,10 @@ class _MessageGoneError(Exception):
     """Raised when the target message no longer exists (deleted topic)."""
 
 
-def _retry_after_seconds(exc: RetryAfter) -> int:
+def retry_after_seconds(exc: RetryAfter) -> float:
     """Extract retry delay from RetryAfter, handling both int and timedelta."""
     ra = exc.retry_after
-    return ra if isinstance(ra, int) else int(ra.total_seconds())
+    return float(ra) if isinstance(ra, int) else ra.total_seconds()
 
 
 # Rate limiting: last send time per chat to avoid Telegram flood control
@@ -158,7 +159,7 @@ async def _with_entity_fallback(
         try:
             return await send_fn(plain_text, **send_kwargs)
         except RetryAfter as e:
-            await asyncio.sleep(_retry_after_seconds(e) + 1)
+            await asyncio.sleep(retry_after_seconds(e) + 1)
             try:
                 return await send_fn(plain_text, **send_kwargs)
             except TelegramError as e2:

--- a/src/ccgram/handlers/topics/topic_lifecycle.py
+++ b/src/ccgram/handlers/topics/topic_lifecycle.py
@@ -240,6 +240,9 @@ PROBE_INTERVAL = 300.0
 PROBE_MAX_PER_CYCLE = 2
 
 # Last probe time per (user_id, thread_id); pruned to live bindings each pass.
+# Never probed sorts first and is always due — a plain 0.0 would not be, since
+# time.monotonic() is seconds since boot and starts below PROBE_INTERVAL.
+_NEVER_PROBED = float("-inf")
 _probe_last_ts: dict[tuple[int, int], float] = {}
 # Set on RetryAfter: flood control is chat-wide, so pause the whole probe pass.
 _probe_backoff_until: float = 0.0
@@ -266,7 +269,7 @@ def _due_probe_targets(
 
     def last_probe(binding: tuple[int, int | None, int, str]) -> float:
         user_id, _, thread_id, _wid = binding
-        return _probe_last_ts.get((user_id, thread_id), 0.0)
+        return _probe_last_ts.get((user_id, thread_id), _NEVER_PROBED)
 
     due = [
         b

--- a/src/ccgram/handlers/topics/topic_lifecycle.py
+++ b/src/ccgram/handlers/topics/topic_lifecycle.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 from telegram import Update
-from telegram.error import BadRequest, TelegramError
+from telegram.error import BadRequest, RetryAfter, TelegramError
 from ... import window_query
 from ...config import config
 from ...session import session_manager
@@ -26,7 +26,7 @@ from ...window_state_ports import legacy_state
 from ...window_state_store import CCGRAM_CREATED_WINDOW_ORIGIN
 from ..callback_tokens import revoke_window_tokens
 from ..cleanup import clear_topic_state
-from ..messaging_pipeline.message_sender import is_thread_gone
+from ..messaging_pipeline.message_sender import is_thread_gone, retry_after_seconds
 from ..polling.polling_state import (
     lifecycle_strategy,
     terminal_poll_state,
@@ -228,20 +228,103 @@ async def prune_stale_state(live_windows: "list[TmuxWindow]") -> None:
 # handlers/status/topic_emoji.py.
 _probe_pin_disabled: set[str] = set()
 
+# unpin_all_forum_topic_messages is a chat-admin call: Telegram flood-limits it
+# per chat, and every bound topic lives in the same chat. Probing all of them
+# once per poll cycle spent that budget on liveness checks, so the ones that
+# lost the race got RetryAfter — and each retry inside AIORateLimiter pauses
+# *every* Bot API request for the retry window. Probe at most
+# PROBE_MAX_PER_CYCLE topics per cycle, least-recently-probed first, and no
+# topic more than once per PROBE_INTERVAL. Deleted topics are still caught
+# reactively by is_thread_gone on the next real send.
+PROBE_INTERVAL = 300.0
+PROBE_MAX_PER_CYCLE = 2
+
+# Last probe time per (user_id, thread_id); pruned to live bindings each pass.
+_probe_last_ts: dict[tuple[int, int], float] = {}
+# Set on RetryAfter: flood control is chat-wide, so pause the whole probe pass.
+_probe_backoff_until: float = 0.0
+
+
+def reset_probe_schedule() -> None:
+    """Clear probe scheduling state (restart/testing)."""
+    global _probe_backoff_until
+    _probe_last_ts.clear()
+    _probe_backoff_until = 0.0
+
+
+def _due_probe_targets(
+    bindings: list[tuple[int, int | None, int, str]], now: float
+) -> list[tuple[int, int | None, int, str]]:
+    """Pick the least-recently-probed topics that are due this cycle.
+
+    Windows that can never be probed (no pin rights, suspended after repeated
+    failures) are dropped first: leaving them in would let them hold the
+    per-cycle slots and starve the topics that can be probed.
+    """
+    for key in _probe_last_ts.keys() - {(u, t) for u, _, t, _ in bindings}:
+        del _probe_last_ts[key]
+
+    def last_probe(binding: tuple[int, int | None, int, str]) -> float:
+        user_id, _, thread_id, _wid = binding
+        return _probe_last_ts.get((user_id, thread_id), 0.0)
+
+    due = [
+        b
+        for b in bindings
+        if b[3] not in _probe_pin_disabled
+        and not lifecycle_strategy.should_skip_probe(b[3])
+        and now - last_probe(b) >= PROBE_INTERVAL
+    ]
+    due.sort(key=last_probe)
+    return due[:PROBE_MAX_PER_CYCLE]
+
+
+async def _unbind_deleted_topic(
+    client: TelegramClient,
+    user_id: int,
+    chat_id: int | None,
+    thread_id: int,
+    wid: str,
+) -> None:
+    """Tear down a window whose Telegram topic no longer exists."""
+    w = await tmux_manager.find_window_by_id(wid)
+    view = window_query.view_window(wid)
+    killed = False
+    if w and view and view.origin == CCGRAM_CREATED_WINDOW_ORIGIN:
+        await tmux_manager.kill_window(w.window_id)
+        killed = True
+    terminal_poll_state.reset_probe_failures(wid)
+    await clear_topic_state(user_id, thread_id, client, window_id=wid, chat_id=chat_id)
+    thread_router.unbind_thread(user_id, thread_id, chat_id=chat_id)
+    logger.info(
+        "Topic deleted: %s window_id '%s' and unbound thread %d for user %d",
+        "killed" if killed else "unbound",
+        wid,
+        thread_id,
+        user_id,
+    )
+
 
 async def probe_topic_existence(client: TelegramClient) -> None:
-    """Probe all bound topics via Telegram API; detect deleted topics."""
-    bindings = list(thread_router.iter_thread_bindings_with_chat())
+    """Probe a slice of bound topics via Telegram API; detect deleted topics."""
+    global _probe_backoff_until
+
+    now = time.monotonic()
+    if now < _probe_backoff_until:
+        return
+
+    bindings: list[tuple[int, int | None, int, str]] = list(
+        thread_router.iter_thread_bindings_with_chat()
+    )
     if not bindings:
         bindings = [
             (user_id, None, thread_id, wid)
             for user_id, thread_id, wid in thread_router.iter_thread_bindings()
         ]
-    for user_id, chat_id, thread_id, wid in bindings:
+    for user_id, chat_id, thread_id, wid in _due_probe_targets(bindings, now):
         if chat_id is None:
             chat_id = thread_router.resolve_chat_id(user_id, thread_id)
-        if wid in _probe_pin_disabled or lifecycle_strategy.should_skip_probe(wid):
-            continue
+        _probe_last_ts[(user_id, thread_id)] = time.monotonic()
         try:
             await client.unpin_all_forum_topic_messages(
                 chat_id=chat_id,
@@ -253,31 +336,25 @@ async def probe_topic_existence(client: TelegramClient) -> None:
                 "Topic_id_invalid" in e.message
                 or "thread not found" in e.message.lower()
             ):
-                w = await tmux_manager.find_window_by_id(wid)
-                view = window_query.view_window(wid)
-                killed = False
-                if w and view and view.origin == CCGRAM_CREATED_WINDOW_ORIGIN:
-                    await tmux_manager.kill_window(w.window_id)
-                    killed = True
-                terminal_poll_state.reset_probe_failures(wid)
-                await clear_topic_state(
-                    user_id, thread_id, client, window_id=wid, chat_id=chat_id
-                )
-                thread_router.unbind_thread(user_id, thread_id, chat_id=chat_id)
-                action = "killed" if killed else "unbound"
-                logger.info(
-                    "Topic deleted: %s window_id '%s' and unbound thread %d for user %d",
-                    action,
-                    wid,
-                    thread_id,
-                    user_id,
-                )
+                await _unbind_deleted_topic(client, user_id, chat_id, thread_id, wid)
             elif isinstance(e, BadRequest) and "not enough rights" in e.message.lower():
                 _probe_pin_disabled.add(wid)
                 logger.info(
                     "Topic probe disabled for window_id '%s': bot lacks pin rights",
                     wid,
                 )
+            elif isinstance(e, RetryAfter):
+                # Flood control is chat-wide and says nothing about topic
+                # existence: counting it would suspend deleted-topic detection
+                # for a live topic. Give the chat its budget back instead.
+                _probe_backoff_until = time.monotonic() + retry_after_seconds(e)
+                log_throttled(
+                    logger,
+                    "topic-probe-flood",
+                    "Topic probe hit flood control; backing off %.0fs",
+                    retry_after_seconds(e),
+                )
+                return
             else:
                 lifecycle_strategy.record_probe_failure(wid)
                 if not lifecycle_strategy.should_skip_probe(wid):

--- a/src/ccgram/telegram_request.py
+++ b/src/ccgram/telegram_request.py
@@ -15,6 +15,12 @@ logger = structlog.get_logger()
 # Without this, every failed poll (~5s apart) emits a warning, flooding logs.
 _RESET_WARN_INTERVAL_S: float = 30.0
 
+# Consecutive resets with no successful request in between mean the link is
+# really down, not that one connection was dropped. A lone drop is routine on
+# a laptop link (WiFi roam, NAT rebind, VPN rekey) and PTB recovers on the next
+# request, so it is logged at info; only a sustained run warrants a warning.
+_WARN_AFTER_CONSECUTIVE_RESETS: int = 3
+
 
 class ResilientPollingHTTPXRequest(HTTPXRequest):
     """Reset a Telegram HTTP client after transient transport failures.
@@ -24,9 +30,10 @@ class ResilientPollingHTTPXRequest(HTTPXRequest):
     fresh pool. Concurrent failures from the same stale client must perform one
     reset only; otherwise a late failure can close the replacement client.
 
-    The first reset after a successful request logs at warning; subsequent
-    resets within `_RESET_WARN_INTERVAL_S` log at debug to avoid floods during
-    sustained outages.
+    An isolated reset (one the next request recovers from) logs at info.
+    Once `_WARN_AFTER_CONSECUTIVE_RESETS` resets happen with no successful
+    request in between, the link is really down and resets log at warning,
+    throttled to one per `_RESET_WARN_INTERVAL_S` to avoid flooding.
     """
 
     def __init__(
@@ -40,6 +47,7 @@ class ResilientPollingHTTPXRequest(HTTPXRequest):
         self._on_success = on_success
         self.request_name = request_name
         self._last_reset_warn_ts: float | None = None
+        self._consecutive_resets = 0
         self._reset_lock = asyncio.Lock()
         self._client_close_tasks: set[asyncio.Task[None]] = set()
 
@@ -74,7 +82,9 @@ class ResilientPollingHTTPXRequest(HTTPXRequest):
         return True
 
     def _should_warn_for_reset(self, now: float) -> bool:
-        """Throttle: warn once per interval, then debug. Reset by success."""
+        """Warn only for a sustained outage, at most once per interval."""
+        if self._consecutive_resets < _WARN_AFTER_CONSECUTIVE_RESETS:
+            return False
         if (
             self._last_reset_warn_ts is None
             or now - self._last_reset_warn_ts >= _RESET_WARN_INTERVAL_S
@@ -87,6 +97,7 @@ class ResilientPollingHTTPXRequest(HTTPXRequest):
         result = await super().post(*args, **kwargs)
         # BaseRequest.post validates the Bot API response before returning.
         self._last_reset_warn_ts = None
+        self._consecutive_resets = 0
         if self._on_success is not None:
             self._on_success()
         return result
@@ -99,10 +110,11 @@ class ResilientPollingHTTPXRequest(HTTPXRequest):
             if await self._reset_client(
                 failed_client=failed_client, reason=exc.__class__.__name__
             ):
+                self._consecutive_resets += 1
                 log = (
                     logger.warning
                     if self._should_warn_for_reset(time.monotonic())
-                    else logger.debug
+                    else logger.info
                 )
                 log(
                     "Reset Telegram HTTP client (%s) after %s: %s",

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -12,6 +12,7 @@ from ccgram.handlers.topics.topic_lifecycle import (
     check_autoclose_timers,
     probe_topic_existence,
     prune_stale_state,
+    reset_probe_schedule,
 )
 from ccgram.handlers.polling.window_tick import (
     _handle_dead_window_notification,
@@ -73,10 +74,12 @@ def _get_autoclose(user_id: int, thread_id: int) -> tuple[str, float] | None:
 
 @pytest.fixture(autouse=True)
 def _reset():
+    reset_probe_schedule()
     _window_poll_state.clear()
     _topic_poll_state.clear()
     _dead_notified.clear()
     yield
+    reset_probe_schedule()
     _window_poll_state.clear()
     _topic_poll_state.clear()
     _dead_notified.clear()
@@ -766,6 +769,8 @@ class TestProbeFailures:
             mock_tr.iter_thread_bindings.return_value = [(1, 42, "@5")]
             mock_tr.resolve_chat_id.return_value = -100
             for _ in range(MAX_PROBE_FAILURES + 1):
+                # Stands in for PROBE_INTERVAL elapsing between poll cycles.
+                reset_probe_schedule()
                 await probe_topic_existence(bot)
         assert bot.unpin_all_forum_topic_messages.call_count == MAX_PROBE_FAILURES
         assert _window_poll_state["@5"].probe_failures == MAX_PROBE_FAILURES

--- a/tests/ccgram/handlers/topics/test_topic_lifecycle.py
+++ b/tests/ccgram/handlers/topics/test_topic_lifecycle.py
@@ -3,15 +3,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from telegram import Bot
-from telegram.error import BadRequest
+from telegram.error import BadRequest, RetryAfter
 
 from ccgram.window_view import WindowView
 
 from ccgram.handlers.topics.topic_lifecycle import (
+    PROBE_MAX_PER_CYCLE,
     check_autoclose_timers,
     check_unbound_window_ttl,
     probe_topic_existence,
     prune_stale_state,
+    reset_probe_schedule,
     rollback_legacy_herdr_binding,
 )
 from ccgram.handlers.polling.polling_state import (
@@ -22,10 +24,12 @@ from ccgram.handlers.polling.polling_state import (
 
 @pytest.fixture(autouse=True)
 def _clean_strategy_state():
+    reset_probe_schedule()
     terminal_poll_state._states.clear()
     lifecycle_strategy._states.clear()
     lifecycle_strategy._dead_notified.clear()
     yield
+    reset_probe_schedule()
     terminal_poll_state._states.clear()
     lifecycle_strategy._states.clear()
     lifecycle_strategy._dead_notified.clear()
@@ -327,6 +331,92 @@ class TestProbeTopicExistence:
             await probe_topic_existence(bot)
             mock_router.unbind_thread.assert_called_once_with(1, 100, chat_id=42)
             mock_tmux.kill_window.assert_not_called()
+
+    async def test_flood_control_backs_off_without_suspending(self):
+        """RetryAfter is chat-wide: it must not disable deleted-topic detection."""
+        from ccgram.handlers.topics import topic_lifecycle as tl
+
+        bot = AsyncMock(spec=Bot)
+        bot.unpin_all_forum_topic_messages = AsyncMock(side_effect=RetryAfter(3))
+        with (
+            patch.object(tl, "thread_router") as mock_router,
+            patch.object(tl, "lifecycle_strategy") as mock_strategy,
+        ):
+            mock_router.iter_thread_bindings.return_value = [(1, 100, "@0")]
+            mock_router.resolve_chat_id.return_value = 42
+            mock_strategy.should_skip_probe.return_value = False
+
+            await probe_topic_existence(bot)
+            mock_strategy.record_probe_failure.assert_not_called()
+
+            # Whole pass is paused while the chat is flood-limited.
+            bot.unpin_all_forum_topic_messages.reset_mock()
+            await probe_topic_existence(bot)
+            bot.unpin_all_forum_topic_messages.assert_not_called()
+
+    async def test_flood_control_stops_the_rest_of_the_pass(self):
+        bot = AsyncMock(spec=Bot)
+        bot.unpin_all_forum_topic_messages = AsyncMock(side_effect=RetryAfter(3))
+        with patch(
+            "ccgram.handlers.topics.topic_lifecycle.thread_router"
+        ) as mock_router:
+            mock_router.iter_thread_bindings.return_value = [
+                (1, 100 + i, f"@{i}") for i in range(PROBE_MAX_PER_CYCLE + 2)
+            ]
+            mock_router.resolve_chat_id.return_value = 42
+            await probe_topic_existence(bot)
+
+        assert bot.unpin_all_forum_topic_messages.call_count == 1
+
+    async def test_probe_budget_rotates_across_cycles(self):
+        """Bounded admin calls per cycle, least-recently-probed topic first."""
+        bot = AsyncMock(spec=Bot)
+        bot.unpin_all_forum_topic_messages = AsyncMock()
+        topics = [(1, 100 + i, f"@{i}") for i in range(3 * PROBE_MAX_PER_CYCLE)]
+        with patch(
+            "ccgram.handlers.topics.topic_lifecycle.thread_router"
+        ) as mock_router:
+            mock_router.iter_thread_bindings.return_value = topics
+            mock_router.resolve_chat_id.return_value = 42
+
+            probed = []
+            for _ in range(3):
+                bot.unpin_all_forum_topic_messages.reset_mock()
+                await probe_topic_existence(bot)
+                assert (
+                    bot.unpin_all_forum_topic_messages.call_count == PROBE_MAX_PER_CYCLE
+                )
+                probed += [
+                    c.kwargs["message_thread_id"]
+                    for c in bot.unpin_all_forum_topic_messages.call_args_list
+                ]
+
+        # Every topic probed exactly once — no repeats while others are due.
+        assert sorted(probed) == [t[1] for t in topics]
+
+    async def test_unprobeable_windows_do_not_hold_cycle_slots(self):
+        from ccgram.handlers.topics import topic_lifecycle as tl
+
+        bot = AsyncMock(spec=Bot)
+        bot.unpin_all_forum_topic_messages = AsyncMock()
+        blocked = [f"@blocked{i}" for i in range(PROBE_MAX_PER_CYCLE)]
+        tl._probe_pin_disabled.update(blocked)
+        try:
+            with patch.object(tl, "thread_router") as mock_router:
+                mock_router.iter_thread_bindings.return_value = [
+                    *[(1, 200 + i, wid) for i, wid in enumerate(blocked)],
+                    (1, 300, "@live"),
+                ]
+                mock_router.resolve_chat_id.return_value = 42
+                await probe_topic_existence(bot)
+        finally:
+            tl._probe_pin_disabled.difference_update(blocked)
+
+        bot.unpin_all_forum_topic_messages.assert_called_once()
+        assert (
+            bot.unpin_all_forum_topic_messages.call_args.kwargs["message_thread_id"]
+            == 300
+        )
 
     async def test_suspended_probe_skipped(self):
         bot = AsyncMock(spec=Bot)

--- a/tests/ccgram/handlers/topics/test_topic_lifecycle.py
+++ b/tests/ccgram/handlers/topics/test_topic_lifecycle.py
@@ -368,6 +368,25 @@ class TestProbeTopicExistence:
 
         assert bot.unpin_all_forum_topic_messages.call_count == 1
 
+    async def test_probes_run_shortly_after_boot(self):
+        """time.monotonic() starts near zero: never-probed must still be due."""
+        bot = AsyncMock(spec=Bot)
+        bot.unpin_all_forum_topic_messages = AsyncMock()
+        with (
+            patch(
+                "ccgram.handlers.topics.topic_lifecycle.thread_router"
+            ) as mock_router,
+            patch(
+                "ccgram.handlers.topics.topic_lifecycle.time.monotonic",
+                return_value=5.0,
+            ),
+        ):
+            mock_router.iter_thread_bindings.return_value = [(1, 100, "@0")]
+            mock_router.resolve_chat_id.return_value = 42
+            await probe_topic_existence(bot)
+
+        bot.unpin_all_forum_topic_messages.assert_called_once()
+
     async def test_probe_budget_rotates_across_cycles(self):
         """Bounded admin calls per cycle, least-recently-probed topic first."""
         bot = AsyncMock(spec=Bot)

--- a/tests/ccgram/test_telegram_request.py
+++ b/tests/ccgram/test_telegram_request.py
@@ -154,7 +154,12 @@ def _reset_log_calls(mock_logger, level: str) -> list:
 
 
 class TestResetWarningRateLimit:
-    async def test_first_reset_warns(self) -> None:
+    async def _fail(self, request) -> None:
+        with pytest.raises(TimedOut):
+            await request.do_request("https://example.com", "POST")
+
+    async def test_isolated_reset_logs_info_not_warning(self) -> None:
+        """A single dropped connection is routine; PTB recovers on the next try."""
         request = ResilientPollingHTTPXRequest()
         with (
             patch.object(
@@ -163,13 +168,13 @@ class TestResetWarningRateLimit:
                 AsyncMock(side_effect=TimedOut("t")),
             ),
             patch("ccgram.telegram_request.logger") as mock_logger,
-            pytest.raises(TimedOut),
         ):
-            await request.do_request("https://example.com", "POST")
-        assert len(_reset_log_calls(mock_logger, "warning")) == 1
-        assert _reset_log_calls(mock_logger, "debug") == []
+            await self._fail(request)
 
-    async def test_repeated_resets_within_interval_demoted_to_debug(self) -> None:
+        assert _reset_log_calls(mock_logger, "warning") == []
+        assert len(_reset_log_calls(mock_logger, "info")) == 1
+
+    async def test_sustained_outage_warns_once_per_interval(self) -> None:
         request = ResilientPollingHTTPXRequest()
         with (
             patch.object(
@@ -180,30 +185,36 @@ class TestResetWarningRateLimit:
             patch("ccgram.telegram_request.logger") as mock_logger,
         ):
             for _ in range(5):
-                with pytest.raises(TimedOut):
-                    await request.do_request("https://example.com", "POST")
+                await self._fail(request)
 
+        # Resets 1-2 are info; reset 3 crosses the threshold and warns; the
+        # rest fall back to info until the warn interval elapses.
         assert len(_reset_log_calls(mock_logger, "warning")) == 1
-        assert len(_reset_log_calls(mock_logger, "debug")) == 4
+        assert len(_reset_log_calls(mock_logger, "info")) == 4
 
-    async def test_success_resets_warn_eligibility(self) -> None:
+    async def test_success_resets_consecutive_counter(self) -> None:
         request = ResilientPollingHTTPXRequest()
         response = (200, b'{"ok": true, "result": []}')
-        mock = AsyncMock(side_effect=[TimedOut("t"), response, TimedOut("t")])
+        mock = AsyncMock(
+            side_effect=[TimedOut("t"), TimedOut("t"), response, TimedOut("t")]
+        )
 
         with (
             patch.object(HTTPXRequest, "do_request", mock),
             patch("ccgram.telegram_request.logger") as mock_logger,
         ):
-            with pytest.raises(TimedOut):
-                await request.post("u")
+            for _ in range(2):
+                with pytest.raises(TimedOut):
+                    await request.post("u")
             await request.post("u")
             with pytest.raises(TimedOut):
                 await request.post("u")
 
-        assert len(_reset_log_calls(mock_logger, "warning")) == 2
+        # The success cleared the streak, so the third failure is isolated.
+        assert _reset_log_calls(mock_logger, "warning") == []
 
-    async def test_first_reset_warns_before_monotonic_interval(self) -> None:
+    async def test_sustained_outage_warns_before_monotonic_interval(self) -> None:
+        """The first warning must not wait out the interval from process start."""
         request = ResilientPollingHTTPXRequest()
         with (
             patch.object(
@@ -213,9 +224,9 @@ class TestResetWarningRateLimit:
             ),
             patch("ccgram.telegram_request.time.monotonic", return_value=1.0),
             patch("ccgram.telegram_request.logger") as mock_logger,
-            pytest.raises(TimedOut),
         ):
-            await request.do_request("https://example.com", "POST")
+            for _ in range(3):
+                await self._fail(request)
 
         assert len(_reset_log_calls(mock_logger, "warning")) == 1
 


### PR DESCRIPTION
## Problem

From an overnight log:

```
15:35:21 [error] Rate limit hit after maximum of 5 retries [telegram.ext.AIORateLimiter]
telegram.error.RetryAfter: Flood control exceeded. Retry in 3 seconds
15:36:22 [error] ... (same)
15:37:22 [error] ... (same)
15:37:22 [info ] Suspending topic probe for herdr-session-v1-5c4cb… after 3 consecutive failures
```

`probe_topic_existence` ran every 60s and issued `unpin_all_forum_topic_messages` — a chat-admin write — once per bound topic. Every topic lives in the same supergroup, so the whole per-chat admin quota went on liveness checks and the losing calls came back `RetryAfter`.

Two consequences:

1. **Global stall.** `AIORateLimiter` retries 5× and calls `_retry_after_event.clear()` around each sleep, which pauses *every* Bot API request. One flood-limited probe froze outbound traffic for ~15s, once a minute. The traceback is PTB's own — it logs before it re-raises, so a `try/except` never could have removed it.
2. **Detection silently disabled.** `RetryAfter` counted as a probe failure, so three of them suspended deleted-topic detection for a topic that was perfectly alive.

## Changes

- Probe at most `PROBE_MAX_PER_CYCLE` (2) topics per cycle, least-recently-probed first, each topic no more than once per `PROBE_INTERVAL` (300s). Windows that can never be probed (no pin rights, suspended) are filtered *before* the slot budget so they can't starve the rest.
- `RetryAfter` gets its own branch: chat-wide backoff for the pass, not a per-window failure.
- `telegram_request`: isolated client resets log at `info`; `warning` only after 3 consecutive resets with no successful request in between. Every isolated network drop used to warn, which is why a night of routine WiFi/NAT drops read as a wall of warnings.
- Extracted `_unbind_deleted_topic`; promoted `message_sender._retry_after_seconds` to public `retry_after_seconds` rather than adding a third copy.

## Behavior change

Deleted-topic detection latency goes from ≤60s to ~5 min for ≤10 topics (`max(PROBE_INTERVAL, ceil(N/2) × 60s)`). Reactive detection on the next real send (`is_thread_gone`) is unchanged.

## Tests

`make check` clean. New coverage: flood control doesn't suspend the probe and pauses the pass, per-cycle budget rotates fairly across topics, unprobeable windows don't hold cycle slots, and the reset-log policy (isolated → info, sustained → one warning per interval).

https://claude.ai/code/session_013MtaN49sXd537CXFHqp2qb
