### PR TITLE
Fix transcript replay after false replacement signals

### DIFF
--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -51,6 +51,11 @@ class _StableRead(NamedTuple):
     reset_generation: bool
 
 
+class _GenerationCheck(NamedTuple):
+    changed: bool
+    consumed_intact: bool
+
+
 _MARKER_BYTES = 128
 
 
@@ -206,7 +211,12 @@ class TranscriptReader:
         return boundaries
 
     def _prepare_startup_boundary(
-        self, session_id: str, tracked: TrackedSession, st: Any
+        self,
+        session_id: str,
+        tracked: TrackedSession,
+        st: Any,
+        *,
+        consumed_intact: bool,
     ) -> _StartupBoundary | None:
         """Reset post-start replacements and return the activity boundary."""
         boundary = self._startup_file_boundaries.get(session_id)
@@ -216,7 +226,7 @@ class TranscriptReader:
             boundary.device,
             boundary.inode,
         )
-        if generation_changed or st.st_size < boundary.size:
+        if (generation_changed or st.st_size < boundary.size) and not consumed_intact:
             tracked.last_byte_offset = 0
             boundary = _StartupBoundary(
                 size=0,
@@ -225,6 +235,34 @@ class TranscriptReader:
             )
             self._startup_file_boundaries[session_id] = boundary
         return boundary
+
+    def _prefix_covers_consumed(self, session_id: str, consumed: int, st: Any) -> bool:
+        """True when the cached prefix digest spans every byte already delivered."""
+        saved = self._file_prefixes.get(session_id)
+        return (
+            consumed > 0
+            and saved is not None
+            and saved[0] >= consumed
+            and st.st_size >= consumed
+        )
+
+    async def _consumed_prefix_intact(
+        self, session_id: str, consumed: int, file_path: Path, st: Any
+    ) -> bool:
+        """True when every byte already delivered is still byte-identical on disk.
+
+        A replacement signal that fires while this holds is a false positive:
+        nothing we sent was replaced, so rewinding would replay the whole
+        transcript instead of the new content.
+        """
+        if not self._prefix_covers_consumed(session_id, consumed, st):
+            return False
+        size, digest = self._file_prefixes[session_id]
+        try:
+            current = await asyncio.to_thread(_prefix_digest, file_path, size)
+        except OSError:
+            return False
+        return current == digest
 
     async def _marker_changed(
         self, session_id: str, tracked: TrackedSession, file_path: Path
@@ -248,7 +286,7 @@ class TranscriptReader:
         st: Any,
         *,
         check_marker: bool,
-    ) -> bool:
+    ) -> _GenerationCheck:
         generation = (st.st_dev, st.st_ino)
         previous = self._file_generations.get(session_id)
         previous_ctime = self._file_ctimes.get(session_id)
@@ -256,6 +294,7 @@ class TranscriptReader:
         previous_size = self._file_sizes.get(session_id)
         previous_prefix = self._file_prefixes.get(session_id)
         prefix_changed = False
+        prefix_verified = False
         if previous_prefix is not None:
             try:
                 prefix_changed = (
@@ -266,6 +305,8 @@ class TranscriptReader:
                 )
             except OSError:
                 prefix_changed = False
+            else:
+                prefix_verified = True
         changed = (
             changed
             or prefix_changed
@@ -279,10 +320,25 @@ class TranscriptReader:
         changed = changed or st.st_size < tracked.last_byte_offset
         if not changed and check_marker:
             changed = await self._marker_changed(session_id, tracked, file_path)
+        consumed_intact = False
         if changed:
-            tracked.last_byte_offset = 0
-            self._startup_file_boundaries.pop(session_id, None)
-        return changed
+            consumed_intact = (
+                check_marker
+                and prefix_verified
+                and not prefix_changed
+                and self._prefix_covers_consumed(
+                    session_id, tracked.last_byte_offset, st
+                )
+            )
+            if consumed_intact:
+                logger.debug(
+                    "Ignoring transcript replacement signal, delivered bytes intact: %s",
+                    session_id,
+                )
+            else:
+                tracked.last_byte_offset = 0
+                self._startup_file_boundaries.pop(session_id, None)
+        return _GenerationCheck(changed and not consumed_intact, consumed_intact)
 
     async def _read_session_entries(
         self,
@@ -319,6 +375,23 @@ class TranscriptReader:
                     return None
                 marker_changed = marker != saved[1]
             if same_generation and not rewritten_in_place and not marker_changed:
+                return _StableRead(entries, after, reset_generation)
+            consumed_survived = (
+                same_generation
+                and not marker_changed
+                and saved is not None
+                and saved[0] == start_offset
+                and start_offset > 0
+                and after.st_size >= start_offset
+            ) or (
+                check_marker
+                and await self._consumed_prefix_intact(
+                    session_id, start_offset, file_path, after
+                )
+            )
+            if consumed_survived:
+                # Concurrent append or metadata churn, not a replacement: the
+                # bytes already delivered survived, so keep this read.
                 return _StableRead(entries, after, reset_generation)
             tracked.last_byte_offset = 0
             self._startup_file_boundaries.pop(session_id, None)
@@ -498,7 +571,7 @@ class TranscriptReader:
         except OSError:
             return
 
-        generation_changed = await self._prepare_observed_generation(
+        generation_changed, consumed_intact = await self._prepare_observed_generation(
             session_id,
             tracked,
             file_path,
@@ -519,7 +592,12 @@ class TranscriptReader:
         startup_boundary = (
             None
             if generation_changed or not provider.capabilities.supports_incremental_read
-            else self._prepare_startup_boundary(session_id, tracked, st)
+            else self._prepare_startup_boundary(
+                session_id,
+                tracked,
+                st,
+                consumed_intact=consumed_intact,
+            )
         )
         stable_read = await self._read_session_entries(
             session_id,

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -376,18 +376,8 @@ class TranscriptReader:
                 marker_changed = marker != saved[1]
             if same_generation and not rewritten_in_place and not marker_changed:
                 return _StableRead(entries, after, reset_generation)
-            consumed_survived = (
-                same_generation
-                and not marker_changed
-                and saved is not None
-                and saved[0] == start_offset
-                and start_offset > 0
-                and after.st_size >= start_offset
-            ) or (
-                check_marker
-                and await self._consumed_prefix_intact(
-                    session_id, start_offset, file_path, after
-                )
+            consumed_survived = check_marker and await self._consumed_prefix_intact(
+                session_id, start_offset, file_path, after
             )
             if consumed_survived:
                 # Concurrent append or metadata churn, not a replacement: the

--- a/tests/ccgram/test_transcript_reader.py
+++ b/tests/ccgram/test_transcript_reader.py
@@ -389,17 +389,59 @@ async def test_append_during_read_does_not_replay_transcript(tmp_path) -> None:
         return await original_read(*args, **kwargs)
 
     messages = []
-    with (
-        patch.object(reader, "_read_new_lines", side_effect=append_then_read),
-        patch.object(
-            reader, "_consumed_prefix_intact", new=AsyncMock(return_value=False)
-        ) as digest,
-    ):
+    with patch.object(reader, "_read_new_lines", side_effect=append_then_read):
         await reader._process_session_file(
             "sess", session_file, messages, window_id="@1"
         )
 
     assert [msg.text for msg in messages] == ["fresh"]
-    # The cached tail marker settles it; re-digesting the whole file would cost
-    # a full read of the transcript on every concurrent append.
-    digest.assert_not_awaited()
+
+
+async def test_rewrite_before_tail_marker_is_detected_during_read(tmp_path) -> None:
+    """A rewrite outside the tail marker must not be skipped as an append."""
+    history = "".join(
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"h%d"}]}}\n'
+        % index
+        for index in range(5)
+    )
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(history, newline="\n")
+
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess",
+            file_path=str(session_file),
+            last_byte_offset=session_file.stat().st_size,
+        )
+    )
+    reader = TranscriptReader(state, IdleTracker())
+    await reader._process_session_file("sess", session_file, [], window_id="@1")
+    reader._file_mtimes["sess"] = 0.0
+
+    original_read = reader._read_new_lines
+    rewritten = False
+
+    async def rewrite_then_read(*args, **kwargs):
+        nonlocal rewritten
+        if not rewritten:
+            session_file.write_text(
+                session_file.read_text().replace('"h0"', '"changed"', 1),
+                newline="\n",
+            )
+            rewritten = True
+        return await original_read(*args, **kwargs)
+
+    messages = []
+    with patch.object(reader, "_read_new_lines", side_effect=rewrite_then_read):
+        await reader._process_session_file(
+            "sess", session_file, messages, window_id="@1"
+        )
+
+    assert [msg.text for msg in messages] == [
+        "changed",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+    ]

--- a/tests/ccgram/test_transcript_reader.py
+++ b/tests/ccgram/test_transcript_reader.py
@@ -323,3 +323,83 @@ async def test_failed_startup_read_preserves_catch_up_boundary(tmp_path) -> None
 
     assert [msg.text for msg in messages] == ["b"]
     assert idle.get_last_activity("sess") is None
+
+
+async def test_metadata_only_ctime_bump_does_not_replay_transcript(tmp_path) -> None:
+    """A ctime bump that leaves consumed bytes intact is not a replacement."""
+    history = "".join(
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"h%d"}]}}\n'
+        % index
+        for index in range(5)
+    )
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(history, newline="\n")
+
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess",
+            file_path=str(session_file),
+            last_byte_offset=session_file.stat().st_size,
+        )
+    )
+    reader = TranscriptReader(state, IdleTracker())
+    os.chmod(session_file, 0o600)
+
+    messages = []
+    await reader._process_session_file("sess", session_file, messages, window_id="@1")
+
+    assert messages == []
+    tracked = state.get_session("sess")
+    assert tracked is not None
+    assert tracked.last_byte_offset == session_file.stat().st_size
+
+
+async def test_append_during_read_does_not_replay_transcript(tmp_path) -> None:
+    """A concurrent append mid-read must deliver the new entry, not the file."""
+    history = "".join(
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"h%d"}]}}\n'
+        % index
+        for index in range(5)
+    )
+    fresh = (
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"fresh"}]}}\n'
+    )
+    session_file = tmp_path / "transcript.jsonl"
+    session_file.write_text(history, newline="\n")
+
+    state = MonitorState(state_file=tmp_path / "monitor_state.json")
+    state.update_session(
+        TrackedSession(
+            session_id="sess",
+            file_path=str(session_file),
+            last_byte_offset=session_file.stat().st_size,
+        )
+    )
+    reader = TranscriptReader(state, IdleTracker())
+    original_read = reader._read_new_lines
+    appended = False
+
+    async def append_then_read(*args, **kwargs):
+        nonlocal appended
+        if not appended:
+            with session_file.open("a") as transcript:
+                transcript.write(fresh)
+            appended = True
+        return await original_read(*args, **kwargs)
+
+    messages = []
+    with (
+        patch.object(reader, "_read_new_lines", side_effect=append_then_read),
+        patch.object(
+            reader, "_consumed_prefix_intact", new=AsyncMock(return_value=False)
+        ) as digest,
+    ):
+        await reader._process_session_file(
+            "sess", session_file, messages, window_id="@1"
+        )
+
+    assert [msg.text for msg in messages] == ["fresh"]
+    # The cached tail marker settles it; re-digesting the whole file would cost
+    # a full read of the transcript on every concurrent append.
+    digest.assert_not_awaited()


### PR DESCRIPTION
## Summary

- prevent false ctime and mid-read replacement signals from replaying consumed transcript history
- verify the delivered prefix before rewinding at all transcript reset sites
- add regressions for metadata-only ctime changes and concurrent appends

Fixes #168

## Validation

- `PYTHONPATH=src uv run pytest -q tests/ccgram/test_transcript_reader.py` — 12 passed
- `PYTHONPATH=src uv run pytest -q -m 'not integration and not e2e'` — 6238 passed, 30 skipped
- `make arch-guard` — 817 passed
- `make arch-check` — pass, 0 blocking findings
