### PR TITLE
fix(herdr): split prompt text and Enter with a short delay

### DIFF
--- a/src/ccgram/multiplexer/herdr.py
+++ b/src/ccgram/multiplexer/herdr.py
@@ -141,6 +141,10 @@ HerdrStreamOpener = Callable[
 # Synthetic return codes from the default runner for non-exec failures.
 _RC_TIMEOUT = 124
 _RC_NO_BINARY = 127
+# Delay between sending prompt text and the Enter key (see _send_to): must
+# match herdr's own agent-prompt submit delay so agent TUIs register the Enter.
+AGENT_SUBMIT_DELAY_SECONDS = 0.3
+
 _CALL_TIMEOUT_SECONDS = 8.0
 
 # New Pi sessions have been observed to publish their agent_session in ~2.7s.
@@ -941,9 +945,19 @@ class HerdrManager:
             return bool(keys) and await self._call_ok(
                 ["pane", "send-keys", pane_id, *keys]
             )
-        return await self._call_ok(
-            ["pane", "run" if enter else "send-text", pane_id, text]
-        )
+        if enter:
+            # Split text and Enter into two writes with a short delay between
+            # them. A single atomic "pane run" wraps the text in bracketed
+            # paste (agents enable it) and glues a synthetic Enter to it,
+            # which agent TUIs (Claude Code) intermittently swallow: the text
+            # lands in the input line but is never submitted. herdr's own
+            # agent-prompt path uses the same split with a 300 ms delay
+            # (AGENT_PROMPT_SUBMIT_DELAY).
+            if not await self._call_ok(["pane", "send-text", pane_id, text]):
+                return False
+            await asyncio.sleep(AGENT_SUBMIT_DELAY_SECONDS)
+            return await self._call_ok(["pane", "send-keys", pane_id, "enter"])
+        return await self._call_ok(["pane", "send-text", pane_id, text])
 
     async def kill_window(self, window_id: str) -> bool:
         try:

--- a/tests/ccgram/test_herdr_backend.py
+++ b/tests/ccgram/test_herdr_backend.py
@@ -441,7 +441,12 @@ async def test_send_variants_guard_then_dispatch_to_live_pane() -> None:
     assert await mux.send(_target(), "C-c Up", literal=False)
     assert fake.calls == [
         ["agent", "list"],
-        ["pane", "run", "w7:p4", "hello"],
+        # Submit split: literal text goes out via send-text, then Enter
+        # arrives as a separate send-keys write (an atomic "pane run" glues
+        # a synthetic Enter to bracketed-pasted text, which agent TUIs
+        # intermittently swallow).
+        ["pane", "send-text", "w7:p4", "hello"],
+        ["pane", "send-keys", "w7:p4", "enter"],
         ["agent", "list"],
         ["pane", "send-text", "w7:p4", "partial"],
         ["agent", "list"],
@@ -654,11 +659,14 @@ async def test_raw_pane_helpers_cannot_bypass_target_guard() -> None:
 
 
 async def test_action_error_refreshes_guard_without_retargeting() -> None:
-    fake = _live_fake(_agent(pane_id="w2:p1")).on("pane", "run", rc=1, err="closed")
+    fake = _live_fake(_agent(pane_id="w2:p1")).on(
+        "pane", "send-text", rc=1, err="closed"
+    )
     assert not await _manager(fake).send(_target(), "hello")
     assert fake.calls == [
         ["agent", "list"],
-        ["pane", "run", "w2:p1", "hello"],
+        # Submit split: the text write failed, so no Enter is dispatched.
+        ["pane", "send-text", "w2:p1", "hello"],
         ["agent", "list"],
     ]
 
@@ -686,7 +694,8 @@ async def test_post_guard_dispatch_race_never_retargets_another_pane() -> None:
     assert not await HerdrManager(runner=runner).send(_target(), "hello")
     assert runner.calls == [
         ["agent", "list"],
-        ["pane", "run", "w2:p1", "hello"],
+        # Submit split: the text write failed, so no Enter is dispatched.
+        ["pane", "send-text", "w2:p1", "hello"],
         ["agent", "list"],
     ]
     assert not any(
@@ -1395,3 +1404,36 @@ async def test_a_still_live_target_is_never_published_as_superseded() -> None:
     windows = {w.window_id: w for w in await manager.list_windows()}
     assert _target("session-a") not in windows[_target("session-b")].alias_window_ids
     assert await manager.find_window_by_id(_target("session-a")) is not None
+
+
+async def test_submit_split_survives_text_failure_and_delays_enter() -> None:
+    """TASK-1: text and Enter are two writes; a failed text write means no
+    Enter, and the Enter follows only after the submit delay."""
+    import ccgram.multiplexer.herdr as herdr_mod
+
+    fake = _live_fake(_agent(pane_id="w7:p4")).on(
+        "pane", "send-text", rc=1, err="closed"
+    )
+    mux = _manager(fake)
+    assert not await mux.send(_target(), "hello")
+    assert ["pane", "send-text", "w7:p4", "hello"] in fake.calls
+    assert not any(c[:2] == ["pane", "send-keys"] for c in fake.calls)
+    assert not any(c[:2] == ["pane", "run"] for c in fake.calls)
+
+    delays: list[float] = []
+    real_sleep = herdr_mod.asyncio.sleep
+
+    async def fake_sleep(d: float) -> None:
+        delays.append(d)
+        await real_sleep(0)
+
+    ok_fake = (
+        _live_fake(_agent(pane_id="w7:p4"))
+        .on("pane", "send-text", out=_result(type="ok"))
+        .on("pane", "send-keys", out=_result(type="ok"))
+    )
+    with __import__("unittest.mock", fromlist=["patch"]).patch.object(
+        herdr_mod.asyncio, "sleep", fake_sleep
+    ):
+        assert await _manager(ok_fake).send(_target(), "hello")
+    assert delays == [herdr_mod.AGENT_SUBMIT_DELAY_SECONDS]


### PR DESCRIPTION
Closes #177.

The herdr backend sent literal text+Enter as one atomic `pane run` write. herdr wraps the text in bracketed-paste markers (agents enable them) and glues the synthetic Enter to the same write, which agent TUIs intermittently swallow: the text lands in the input line and is never submitted. From Telegram the agent just looks unresponsive.

Two data points that point at the atomic write:

- herdr's own `agent prompt` path sends the Enter behind a 300 ms delay (`AGENT_PROMPT_SUBMIT_DELAY`) for exactly this reason;
- the tmux backend's interactive path already splits text and Enter with a delay in between.

This PR splits the herdr interactive path the same way: `pane send-text`, a 300 ms delay matching herdr's submit delay, then `pane send-keys enter`. Launch commands in a fresh shell pane keep the atomic `pane run` (no bracketed paste there, and atomicity is what you want for launching).

Test plan: adapted the send-path expectations in `test_herdr_backend.py` to the two-write sequence (happy path, text-write failure dispatches no Enter, post-guard race targets no other pane) and added a focused test asserting the delay fires between the writes and no Enter follows a failed text write.