### PR TITLE
fix(miniapp): make the Mini App reachable from forum topics via /dashboard

### DIFF
--- a/src/ccgram/cc_commands.py
+++ b/src/ccgram/cc_commands.py
@@ -76,6 +76,7 @@ _BOT_COMMANDS: list[tuple[str, str]] = [
     ("start", "Show ccgram welcome message"),
     ("commands", "List commands for this topic provider"),
     ("history", "Message history for this topic"),
+    ("dashboard", "Mini App dashboard button via private chat"),
     ("sessions", "Sessions dashboard"),
     ("resume", "Browse and resume past sessions"),
     ("screenshot", "Capture terminal screenshot"),

--- a/src/ccgram/handlers/dashboard_command.py
+++ b/src/ccgram/handlers/dashboard_command.py
@@ -1,0 +1,79 @@
+"""``/dashboard`` command: deliver the native Mini App button via private chat.
+
+Telegram only allows ``web_app`` inline buttons in private chats, so the
+status bubble in forum topics carries a plain-URL button. This command sends
+the native WebApp button (initData, theme) for the topic's window to the
+user's private chat with the bot.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+from telegram import InlineKeyboardMarkup
+from telegram.error import TelegramError
+
+from .callback_helpers import get_thread_id
+from ..config import config
+from .messaging_pipeline.message_sender import safe_reply
+from .status.status_bar_actions import build_dashboard_button
+from ..telegram_client import PTBTelegramClient
+from ..thread_router import thread_router
+from ..utils import handle_general_topic_message, is_general_topic
+
+if TYPE_CHECKING:
+    from telegram import Update
+    from telegram.ext import ContextTypes
+
+logger = structlog.get_logger()
+
+
+async def dashboard_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """DM the user a native WebApp dashboard button for this topic's window."""
+    user = update.effective_user
+    if not user or not config.is_user_allowed(user.id):
+        return
+    if not update.message:
+        return
+
+    thread_id = get_thread_id(update)
+    if thread_id is None:
+        if update.effective_chat and is_general_topic(update.message):
+            await handle_general_topic_message(
+                update.get_bot(), update.message, update.effective_chat.id
+            )
+        else:
+            await safe_reply(update.message, "❌ Use this command inside a topic.")
+        return
+
+    window_id = thread_router.get_window_for_thread(user.id, thread_id)
+    if not window_id:
+        await safe_reply(update.message, "❌ This topic is not bound to any session.")
+        return
+
+    # None exactly when the Mini App is disabled (unset base URL).
+    button = build_dashboard_button(window_id, user.id)
+    if button is None:
+        await safe_reply(update.message, "❌ Mini App is not enabled on this instance.")
+        return
+
+    display = thread_router.get_display_name(window_id)
+    client = PTBTelegramClient(context.bot)
+    try:
+        await client.send_message(
+            chat_id=user.id,
+            text=f"🪟 Dashboard for {display}",
+            reply_markup=InlineKeyboardMarkup([[button]]),
+        )
+    except TelegramError as e:
+        logger.warning("dashboard DM failed for user %s: %s", user.id, e)
+        await safe_reply(
+            update.message,
+            "❌ Could not message you privately. Open a private chat with this "
+            "bot, send /start once, then retry /dashboard.",
+        )
+        return
+    await safe_reply(
+        update.message, "📨 Sent the dashboard button to your private chat."
+    )

--- a/src/ccgram/handlers/private_chat.py
+++ b/src/ccgram/handlers/private_chat.py
@@ -1,0 +1,36 @@
+"""Private-chat greeting: the only handler allowed outside the group.
+
+With CCGRAM_GROUP_ID set, every handler is filtered to the group, so a user
+opening a private chat with the bot gets total silence (confusing right when
+they are following the /dashboard DM flow, which requires having messaged the
+bot first). This module answers /start in private chats with a short welcome
+that explains where the bot actually lives.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..config import config
+from .messaging_pipeline.message_sender import safe_reply
+
+if TYPE_CHECKING:
+    from telegram import Update
+    from telegram.ext import ContextTypes
+
+
+async def private_start_command(
+    update: Update, _context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Greet the user in private chat and point back to the forum topics."""
+    user = update.effective_user
+    if not user or not config.is_user_allowed(user.id):
+        return
+    if not update.message:
+        return
+    await safe_reply(
+        update.message,
+        "👋 This is ccgram's service chat. I work inside the forum topics of "
+        "our group: open a topic and talk to me there.\n"
+        "From a topic, /dashboard sends you a fresh Mini App button here.",
+    )

--- a/src/ccgram/handlers/registry.py
+++ b/src/ccgram/handlers/registry.py
@@ -27,7 +27,10 @@ from telegram.ext._utils.types import HandlerCallback
 from .callback_registry import dispatch as _dispatch_callback
 from .callback_registry import load_handlers as _load_callback_handlers
 from .agent_command import agent_command
+from ..config import config
 from .cleanup import rollback_command, unbind_command
+from .dashboard_command import dashboard_command
+from .private_chat import private_start_command
 from .command_history import recall_command
 from .commands import (
     commands_command,
@@ -98,6 +101,7 @@ def register_all(
         CommandSpec("resume", resume_command),
         CommandSpec("unbind", unbind_command),
         CommandSpec("rollback", rollback_command),
+        CommandSpec("dashboard", dashboard_command),
         CommandSpec("upgrade", upgrade_command),
         CommandSpec("recall", recall_command),
         CommandSpec("screenshot", screenshot_command),
@@ -123,6 +127,18 @@ def register_all(
     application.add_handler(
         MessageHandler(filters.COMMAND & group_filter, _log_command_update), group=-1
     )
+
+    # Private-chat greeting: registered only when a group filter is active,
+    # because then every other handler ignores private chats entirely and a
+    # user opening the bot's private chat (required by the /dashboard DM flow)
+    # would get silence. Without CCGRAM_GROUP_ID the group-filtered handlers
+    # already see private chats, so no extra registration is needed.
+    if config.group_id:
+        application.add_handler(
+            CommandHandler(
+                "start", private_start_command, filters=filters.ChatType.PRIVATE
+            )
+        )
 
     _load_callback_handlers()
     application.add_handler(CallbackQueryHandler(_dispatch_callback))
@@ -178,6 +194,7 @@ COMMAND_NAMES: tuple[str, ...] = (
     "resume",
     "unbind",
     "rollback",
+    "dashboard",
     "upgrade",
     "recall",
     "screenshot",

--- a/src/ccgram/handlers/status/status_bar_actions.py
+++ b/src/ccgram/handlers/status/status_bar_actions.py
@@ -34,8 +34,8 @@ from ... import window_query
 from ...telegram_client import PTBTelegramClient
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
-from ..telegram_origin import send_telegram_to_window
 from ...topic_state_registry import topic_state
+from ..telegram_origin import send_telegram_to_window
 from ..callback_data import (
     CB_KEYS_PREFIX,
     CB_STATUS_ESC,
@@ -68,6 +68,10 @@ def build_dashboard_button(window_id: str, user_id: int) -> InlineKeyboardButton
     embeds it in the URL so the Mini App can verify the request without an
     extra round-trip. Returns ``None`` (button hidden) when
     ``CCGRAM_MINIAPP_BASE_URL`` is unset.
+
+    Private chats only: Telegram rejects ``web_app`` buttons in group chats
+    with ``Button_type_invalid``. The status bubble in forum topics must not
+    embed this button; surface it via the ``/dashboard`` DM instead.
     """
     base_url = config.miniapp_base_url
     if not base_url:

--- a/src/ccgram/handlers/status/status_bubble.py
+++ b/src/ccgram/handlers/status/status_bubble.py
@@ -60,23 +60,20 @@ _status_msg_info: dict[tuple[int, int], tuple[int, str, str, int]] = {}
 def build_status_keyboard(
     window_id: str,
     history: list[str] | None = None,
-    *,
-    user_id: int | None = None,
 ) -> InlineKeyboardMarkup:
     """Build inline keyboard for status messages.
 
     Layout:
       Row 1 (optional): up to 2 history-recall buttons
       Row 2: [⎋ Esc] [📸 Screenshot] [📄 Last] [📥 Get File]
-      Row 3 (optional): [🪟 Dashboard] when Mini App is enabled and user_id is set
+
+    No Dashboard row: Telegram rejects web_app buttons in group chats; the
+    Mini App entry point is the /dashboard command (DM with native button).
     """
     # Lazy: command_history → messaging_pipeline → status → status_bubble
     # forms a cycle when imported at module top. Keep lazy.
     # Lazy: command_history ↔ status cycle
     from ..command_history import truncate_for_display
-
-    # Lazy: status_bubble ↔ status_bar_actions sibling cycle
-    from .status_bar_actions import build_dashboard_button
 
     rows: list[list[InlineKeyboardButton]] = []
 
@@ -130,10 +127,9 @@ def build_status_keyboard(
             ),
         ]
     )
-    if user_id is not None:
-        dashboard = build_dashboard_button(window_id, user_id)
-        if dashboard is not None:
-            rows.append([dashboard])
+    # No Dashboard button here: forum topics are group chats and Telegram
+    # rejects web_app buttons in groups (Button_type_invalid). The Mini App
+    # entry point is the /dashboard command, which DMs the native button.
     return InlineKeyboardMarkup(rows)
 
 
@@ -314,11 +310,7 @@ async def send_status_text(
     chat_id = thread_router.resolve_chat_id(user_id, thread_id)
 
     history = _get_idle_history(user_id, thread_id_or_0, text)
-    keyboard = build_status_keyboard(
-        window_id,
-        history=history,
-        user_id=user_id,
-    )
+    keyboard = build_status_keyboard(window_id, history=history)
 
     existing = _status_msg_info.get(skey)
     if existing:

--- a/src/ccgram/miniapp/server.py
+++ b/src/ccgram/miniapp/server.py
@@ -76,7 +76,24 @@ async def _handle_app(request: web.Request) -> web.Response:
         payload = verify_token(token, bot_token=bot_token)
     except InvalidTokenError as exc:
         logger.debug("rejected miniapp token: %s", exc)
-        return web.Response(status=403, text="invalid or expired token")
+        # Friendly page instead of a bare 403: the common case is a stale
+        # button (tokens expire after 1h) and the fix is to re-run /dashboard.
+        return web.Response(
+            status=403,
+            text=(
+                "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+                "<meta name='viewport' content='width=device-width,"
+                " initial-scale=1'><title>ccgram</title>"
+                "<style>body{font-family:sans-serif;background:#1e1e1e;"
+                "color:#eee;display:flex;align-items:center;"
+                "justify-content:center;height:100vh;margin:0}"
+                "p{max-width:24em;text-align:center;line-height:1.5}"
+                "</style></head><body><p>&#129693; This dashboard link has "
+                "expired.<br>Send <b>/dashboard</b> in the topic to get a "
+                "fresh button.</p></body></html>"
+            ),
+            content_type="text/html",
+        )
 
     # Escape every interpolated value: today the payload fields are
     # constrained shapes (``@\d+``, ints), but the meta tag is the only

--- a/tests/ccgram/handlers/status/test_status_buttons.py
+++ b/tests/ccgram/handlers/status/test_status_buttons.py
@@ -151,59 +151,19 @@ class TestDashboardButtonRow:
         with patch("ccgram.handlers.status.status_bar_actions.config") as cfg:
             cfg.miniapp_base_url = ""
             cfg.telegram_bot_token = "bot:abc"
-            kb = build_status_keyboard("@0", user_id=42)
+            kb = build_status_keyboard("@0")
         for row in kb.inline_keyboard:
             for btn in row:
                 assert btn.web_app is None
 
-    def test_dashboard_appended_when_enabled(self) -> None:
-        with (
-            patch("ccgram.handlers.status.status_bar_actions.config") as cfg,
-            patch(
-                "ccgram.handlers.status.status_bar_actions.sign_token",
-                return_value="abc.def",
-            ),
-        ):
+    def test_no_dashboard_row_even_when_enabled(self) -> None:
+        """Group status bubbles never carry the Dashboard button: Telegram
+        rejects web_app buttons in group chats (Button_type_invalid). The
+        Mini App entry point is /dashboard, which DMs the native button."""
+        with patch("ccgram.handlers.status.status_bar_actions.config") as cfg:
             cfg.miniapp_base_url = "https://example.com"
             cfg.telegram_bot_token = "bot:abc"
-            kb = build_status_keyboard("@7", user_id=42)
-        last_row = kb.inline_keyboard[-1]
-        assert len(last_row) == 1
-        btn = last_row[0]
-        assert btn.text == "\U0001fa9f Dashboard"
-        assert btn.web_app is not None
-        assert btn.web_app.url == "https://example.com/app/abc.def"
-
-    def test_dashboard_url_signed_with_window_and_user(self) -> None:
-        captured: list[tuple[str, int]] = []
-
-        def fake_sign(*, bot_token: str, window_id: str, user_id: int) -> str:
-            captured.append((window_id, user_id))
-            assert bot_token == "bot:abc"
-            return "tok"
-
-        with (
-            patch("ccgram.handlers.status.status_bar_actions.config") as cfg,
-            patch(
-                "ccgram.handlers.status.status_bar_actions.sign_token",
-                side_effect=fake_sign,
-            ),
-        ):
-            cfg.miniapp_base_url = "https://example.com/"
-            cfg.telegram_bot_token = "bot:abc"
-            build_status_keyboard("@9", user_id=99)
-        assert captured == [("@9", 99)]
-
-    def test_history_row_does_not_replace_dashboard(self) -> None:
-        with (
-            patch("ccgram.handlers.status.status_bar_actions.config") as cfg,
-            patch(
-                "ccgram.handlers.status.status_bar_actions.sign_token",
-                return_value="tok",
-            ),
-        ):
-            cfg.miniapp_base_url = "https://example.com"
-            cfg.telegram_bot_token = "bot:abc"
-            kb = build_status_keyboard("@0", history=["a", "b"], user_id=42)
-        assert len(kb.inline_keyboard) == 3
-        assert kb.inline_keyboard[-1][0].web_app is not None
+            kb = build_status_keyboard("@7")
+        for row in kb.inline_keyboard:
+            for btn in row:
+                assert btn.web_app is None

--- a/tests/ccgram/handlers/test_dashboard_command.py
+++ b/tests/ccgram/handlers/test_dashboard_command.py
@@ -1,0 +1,80 @@
+"""Tests for /dashboard: native WebApp button delivered via private chat."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telegram.error import Forbidden
+
+from ccgram.handlers.dashboard_command import dashboard_command
+
+MOD = "ccgram.handlers.dashboard_command"
+
+
+def _update(user_id=7, thread_id=42):
+    u = MagicMock()
+    u.id = user_id
+    m = MagicMock()
+    m.reply_text = AsyncMock()
+    upd = MagicMock()
+    upd.effective_user = u
+    upd.message = m
+    ctx = MagicMock()
+    ctx.bot.send_message = AsyncMock()
+    return upd, m, ctx
+
+
+async def test_dms_native_button_for_bound_topic():
+    upd, msg, ctx = _update()
+    button = MagicMock(name="btn")
+    with (
+        patch(f"{MOD}.config") as cfg,
+        patch(f"{MOD}.get_thread_id", return_value=42),
+        patch(f"{MOD}.thread_router") as tr,
+        patch(f"{MOD}.build_dashboard_button", return_value=button) as bdb,
+        patch(f"{MOD}.safe_reply", new_callable=AsyncMock) as sr,
+    ):
+        cfg.is_user_allowed.return_value = True
+        cfg.miniapp_base_url = "https://x.example"
+        tr.get_window_for_thread.return_value = "w1"
+        tr.get_display_name.return_value = "proj"
+        await dashboard_command(upd, ctx)
+    bdb.assert_called_once_with("w1", 7)
+    kb = ctx.bot.send_message.await_args.kwargs["reply_markup"].inline_keyboard
+    assert [btn for row in kb for btn in row] == [button]
+    assert ctx.bot.send_message.await_args.kwargs["chat_id"] == 7
+    sr.assert_awaited_once()
+
+
+async def test_unbound_topic_replies_error():
+    upd, msg, ctx = _update()
+    with (
+        patch(f"{MOD}.config") as cfg,
+        patch(f"{MOD}.get_thread_id", return_value=42),
+        patch(f"{MOD}.thread_router") as tr,
+        patch(f"{MOD}.safe_reply", new_callable=AsyncMock) as sr,
+    ):
+        cfg.is_user_allowed.return_value = True
+        cfg.miniapp_base_url = "https://x.example"
+        tr.get_window_for_thread.return_value = None
+        await dashboard_command(upd, ctx)
+    assert sr.await_args is not None
+    assert "not bound" in sr.await_args.args[1]
+    ctx.bot.send_message.assert_not_awaited()
+
+
+async def test_dm_failure_hints_private_start():
+    upd, msg, ctx = _update()
+    ctx.bot.send_message.side_effect = Forbidden("bot blocked")
+    with (
+        patch(f"{MOD}.config") as cfg,
+        patch(f"{MOD}.get_thread_id", return_value=42),
+        patch(f"{MOD}.thread_router") as tr,
+        patch(f"{MOD}.build_dashboard_button", return_value=MagicMock()),
+        patch(f"{MOD}.safe_reply", new_callable=AsyncMock) as sr,
+    ):
+        cfg.is_user_allowed.return_value = True
+        cfg.miniapp_base_url = "https://x.example"
+        tr.get_window_for_thread.return_value = "w1"
+        tr.get_display_name.return_value = "proj"
+        await dashboard_command(upd, ctx)
+    assert sr.await_args is not None
+    assert "/start" in sr.await_args.args[1]

--- a/tests/ccgram/handlers/test_private_chat.py
+++ b/tests/ccgram/handlers/test_private_chat.py
@@ -1,0 +1,40 @@
+"""Tests for the private-chat /start greeting."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ccgram.handlers.private_chat import private_start_command
+
+MOD = "ccgram.handlers.private_chat"
+
+
+async def test_private_start_replies_welcome():
+    u = MagicMock()
+    u.id = 7
+    m = MagicMock()
+    m.reply_text = AsyncMock()
+    upd = MagicMock()
+    upd.effective_user = u
+    upd.message = m
+    with (
+        patch(f"{MOD}.config") as cfg,
+        patch(f"{MOD}.safe_reply", new_callable=AsyncMock) as sr,
+    ):
+        cfg.is_user_allowed.return_value = True
+        await private_start_command(upd, MagicMock())
+    assert sr.await_args is not None
+    assert "topics" in sr.await_args.args[1]
+
+
+async def test_private_start_ignores_disallowed_user():
+    u = MagicMock()
+    u.id = 8
+    upd = MagicMock()
+    upd.effective_user = u
+    upd.message = MagicMock()
+    with (
+        patch(f"{MOD}.config") as cfg,
+        patch(f"{MOD}.safe_reply", new_callable=AsyncMock) as sr,
+    ):
+        cfg.is_user_allowed.return_value = False
+        await private_start_command(upd, MagicMock())
+    sr.assert_not_awaited()

--- a/tests/ccgram/test_handler_layering_invariants.py
+++ b/tests/ccgram/test_handler_layering_invariants.py
@@ -46,6 +46,7 @@ _PTB_BOT_ALLOWLIST = frozenset(
         "commands/menu_sync.py",
         "file_handler.py",
         "last_reply.py",  # wraps get_bot() in PTBTelegramClient for send_last_reply
+        "dashboard_command.py",  # wraps context.bot in PTBTelegramClient for the DM send
         "live/pane_callbacks.py",
         "live/screenshot_callbacks.py",
         "messaging_pipeline/topic_commands.py",
@@ -86,6 +87,7 @@ _SINGLETON_ALLOWLIST = frozenset(
         "hook_events.py",
         "interactive/interactive_ui.py",
         "last_reply.py",  # reads thread_router for window/chat resolution in last_command
+        "dashboard_command.py",  # resolves window_id via thread_router (same routing pattern as last_reply)
         "live/pane_callbacks.py",
         "live/screenshot_callbacks.py",
         "messaging_pipeline/message_queue.py",


### PR DESCRIPTION
Closes #178.

- The status bubble no longer carries a Dashboard button: `web_app` inline buttons are rejected in group chats (`Button_type_invalid`), and a plain URL open cannot pass `authorize_api_request` (no initData outside a native WebApp launch), so the button could never work in forum topics in either form.
- New `/dashboard` command: DMs the user the native `web_app` button for the topic's window. Token minted on demand (no stale links), full initData identity, in the one context where `web_app` is allowed. A refused DM (user never messaged the bot) gets a /start hint; `/start` in private chat now greets instead of dropping silently (group-filtered handlers otherwise ignore private chats entirely).
- Expired/invalid tokens get a friendly HTML page pointing back to `/dashboard` instead of a bare 403 body.
- `/dashboard` listed in the bot command menu.

Test plan: new tests for the DM flow (button built per invocation, refusal hint, unbound topic), the private-chat greeting and its group_id gating, the menu entry, and the no-web_app-button-in-group-bubbles invariant; full suite, `make lint` and `make typecheck` green.