### PR TITLE
fix: split herdr Enter, hide web_app in groups, close instead of delete on autoclose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.6.7] - 2026-08-26
+
+### Fixed
+
+- Send prompt text and Enter as separate Herdr calls so agent TUIs process the text before receiving Enter. Bundling both into one `pane run` call caused prompts to sit unsent in the input line ([#177](https://github.com/alexei-led/ccgram/issues/177)).
+- Hide the 🪟 Dashboard button from status-bubble keyboards in group chats and forum topics. Telegram rejects `web_app` buttons outside private chats, so every status-bubble edit in a supergroup raised a `TelegramError` and the bubble stopped updating ([#178](https://github.com/alexei-led/ccgram/issues/178)).
+- Close expired topics instead of deleting them. Autoclose now calls `close_forum_topic`; deleting a topic is irreversible and destroyed topic history when the 4.6 upgrade orphaned bindings and the autoclose timer fired ([#187](https://github.com/alexei-led/ccgram/issues/187)).
+
 ## [4.6.6] - 2026-08-26
 
 ### Fixed

--- a/src/ccgram/handlers/status/status_bubble.py
+++ b/src/ccgram/handlers/status/status_bubble.py
@@ -62,13 +62,17 @@ def build_status_keyboard(
     history: list[str] | None = None,
     *,
     user_id: int | None = None,
+    is_group: bool = False,
 ) -> InlineKeyboardMarkup:
     """Build inline keyboard for status messages.
 
     Layout:
       Row 1 (optional): up to 2 history-recall buttons
       Row 2: [⎋ Esc] [📸 Screenshot] [📄 Last] [📥 Get File]
-      Row 3 (optional): [🪟 Dashboard] when Mini App is enabled and user_id is set
+      Row 3 (optional): [🪟 Dashboard] when Mini App is enabled, user_id is set,
+        and the chat is private (``is_group=False``). Telegram rejects
+        ``web_app`` buttons in groups and supergroups, so the button is hidden
+        there to stop every status-bubble edit from raising a TelegramError.
     """
     # Lazy: command_history → messaging_pipeline → status → status_bubble
     # forms a cycle when imported at module top. Keep lazy.
@@ -130,7 +134,7 @@ def build_status_keyboard(
             ),
         ]
     )
-    if user_id is not None:
+    if user_id is not None and not is_group:
         dashboard = build_dashboard_button(window_id, user_id)
         if dashboard is not None:
             rows.append([dashboard])
@@ -318,6 +322,7 @@ async def send_status_text(
         window_id,
         history=history,
         user_id=user_id,
+        is_group=(thread_id_or_0 != 0),
     )
 
     existing = _status_msg_info.get(skey)

--- a/src/ccgram/handlers/topics/topic_lifecycle.py
+++ b/src/ccgram/handlers/topics/topic_lifecycle.py
@@ -114,28 +114,17 @@ async def _close_expired_topic(
     chat_id = scoped_chat_id or thread_router.resolve_chat_id(user_id, thread_id)
     removed = False
     try:
-        await client.delete_forum_topic(chat_id=chat_id, message_thread_id=thread_id)
+        await client.close_forum_topic(chat_id=chat_id, message_thread_id=thread_id)
         removed = True
     except TelegramError as e:
         if is_thread_gone(e):
             removed = True
         else:
-            try:
-                await client.close_forum_topic(
-                    chat_id=chat_id, message_thread_id=thread_id
-                )
-                removed = True
-            except TelegramError as close_err:
-                if is_thread_gone(close_err):
-                    removed = True
-                else:
-                    logger.debug(
-                        "autoclose_failed", thread_id=thread_id, error=str(close_err)
-                    )
+            logger.debug("autoclose_failed", thread_id=thread_id, error=str(e))
     if removed:
         lifecycle_strategy.clear_autoclose_timer(user_id, thread_id)
         logger.info(
-            "auto_removed_topic", chat_id=chat_id, thread_id=thread_id, user_id=user_id
+            "auto_closed_topic", chat_id=chat_id, thread_id=thread_id, user_id=user_id
         )
         cleanup_kwargs: dict = {"window_id": window_id, "window_dead": True}
         if scoped_chat_id is not None:

--- a/src/ccgram/multiplexer/herdr.py
+++ b/src/ccgram/multiplexer/herdr.py
@@ -148,6 +148,14 @@ _CALL_TIMEOUT_SECONDS = 8.0
 _CREATED_SESSION_DISCOVERY_TIMEOUT_SECONDS = 5.0
 _CREATED_SESSION_POLL_INTERVAL_SECONDS = 0.1
 
+# Agent TUIs (Claude Code, Codex, Pi) read a submit key that arrives in the
+# same input batch as the prompt text as a literal newline, so the prompt is
+# typed but never sent. ``pane run`` delivers exactly that batch, so a literal
+# submit is split into ``send-text`` + a separate ``Enter``, with this gap for
+# the TUI to consume the text first. Mirrors the tmux backend's 0.5s delay in
+# ``_send_literal_then_enter``.
+_SEND_ENTER_DELAY_SECONDS = 0.5
+
 # Event-stream reconnect backoff (seconds): exponential, capped.
 _STREAM_BACKOFF_BASE = 1.0
 _STREAM_BACKOFF_MAX = 30.0
@@ -971,9 +979,13 @@ class HerdrManager:
             return bool(keys) and await self._call_ok(
                 ["pane", "send-keys", pane_id, *keys]
             )
-        return await self._call_ok(
-            ["pane", "run" if enter else "send-text", pane_id, text]
-        )
+        if not await self._call_ok(["pane", "send-text", pane_id, text]):
+            return False
+        if not enter:
+            return True
+        # Never collapse back into ``pane run``: the batched Enter is the bug.
+        await asyncio.sleep(_SEND_ENTER_DELAY_SECONDS)
+        return await self._call_ok(["pane", "send-keys", pane_id, "Enter"])
 
     async def kill_window(self, window_id: str) -> bool:
         try:

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -108,9 +108,10 @@ class TestAutocloseTimers:
             mock_time.monotonic.return_value = elapsed
             mock_tr.resolve_chat_id.return_value = -100
             await check_autoclose_timers(bot)
-        bot.delete_forum_topic.assert_called_once_with(
+        bot.close_forum_topic.assert_called_once_with(
             chat_id=-100, message_thread_id=42
         )
+        bot.delete_forum_topic.assert_not_called()
         mock_tr.unbind_thread.assert_called_once_with(1, 42)
         assert not _has_autoclose(1, 42)
 
@@ -141,7 +142,8 @@ class TestAutocloseTimers:
             await check_autoclose_timers(bot)
         bot.close_forum_topic.assert_not_called()
 
-    async def test_check_telegram_error_handled(self) -> None:
+    async def test_check_telegram_error_does_not_clear_timer(self) -> None:
+        """A non-fatal TelegramError leaves the timer so the next cycle retries."""
         _start_autoclose_timer(1, 42, "done", 0.0)
         bot = AsyncMock(spec=Bot)
         bot.close_forum_topic.side_effect = TelegramError("fail")
@@ -155,12 +157,14 @@ class TestAutocloseTimers:
             mock_time.monotonic.return_value = 30 * 60 + 1
             mock_tr.resolve_chat_id.return_value = -100
             await check_autoclose_timers(bot)
-        assert not _has_autoclose(1, 42)
+        # Timer must stay so the next cycle can retry.
+        assert _has_autoclose(1, 42)
 
     async def test_check_treats_missing_topic_as_removed(self) -> None:
+        """A gone topic is cleaned up whether close_forum_topic says it's gone."""
         _start_autoclose_timer(1, 42, "done", 0.0)
         bot = AsyncMock(spec=Bot)
-        bot.delete_forum_topic.side_effect = BadRequest("Topic_id_invalid")
+        bot.close_forum_topic.side_effect = BadRequest("Topic_id_invalid")
         with (
             patch("ccgram.handlers.topics.topic_lifecycle.config") as mock_config,
             patch("ccgram.handlers.topics.topic_lifecycle.thread_router") as mock_tr,
@@ -178,7 +182,10 @@ class TestAutocloseTimers:
 
             await check_autoclose_timers(bot)
 
-        bot.close_forum_topic.assert_not_called()
+        bot.close_forum_topic.assert_called_once_with(
+            chat_id=-100, message_thread_id=42
+        )
+        bot.delete_forum_topic.assert_not_called()
         mock_tr.unbind_thread.assert_called_once_with(1, 42)
         mock_clear.assert_awaited_once()
         assert not _has_autoclose(1, 42)

--- a/tests/ccgram/handlers/status/test_status_bubble.py
+++ b/tests/ccgram/handlers/status/test_status_bubble.py
@@ -618,3 +618,63 @@ class TestFormatClaudeTaskStatusWithPanes:
         assert lines[0] == "Running"
         assert lines[1].startswith("└ ")
         assert "1 tasks (0 done, 1 open)" in lines[2]
+
+
+# Patch target for the lazily-imported build_dashboard_button (loaded inside
+# build_status_keyboard at call time from status_bar_actions, not at module level).
+_DASH_PATCH = "ccgram.handlers.status.status_bar_actions.build_dashboard_button"
+
+
+class TestBuildStatusKeyboardGroupVsPrivate:
+    """#178: web_app (Dashboard) button must not appear in group/topic chats."""
+
+    @patch(_DASH_PATCH)
+    def test_private_chat_shows_dashboard_button(self, mock_dash):
+        """is_group=False → private chat → build_dashboard_button is consulted."""
+        from ccgram.handlers.status.status_bubble import build_status_keyboard
+
+        mock_dash.return_value = MagicMock(web_app=MagicMock(), callback_data=None)
+        build_status_keyboard(WINDOW_ID, user_id=USER_ID, is_group=False)
+        mock_dash.assert_called_once_with(WINDOW_ID, USER_ID)
+
+    @patch(_DASH_PATCH)
+    def test_group_chat_hides_dashboard_button(self, mock_dash):
+        """is_group=True → Telegram rejects web_app → build_dashboard_button skipped."""
+        from ccgram.handlers.status.status_bubble import build_status_keyboard
+
+        mock_dash.return_value = MagicMock(web_app=MagicMock(), callback_data=None)
+        build_status_keyboard(WINDOW_ID, user_id=USER_ID, is_group=True)
+        mock_dash.assert_not_called()
+
+    @patch("ccgram.handlers.status.status_bubble.config", create=True)
+    @patch("ccgram.handlers.status.status_bubble.thread_router")
+    @patch(_DASH_PATCH)
+    async def test_send_in_thread_does_not_call_dashboard_button(
+        self, mock_dash, mock_router, mock_config
+    ):
+        """send_status_text with non-zero thread_id suppresses the dashboard button."""
+        mock_config.hide_status = False
+        mock_router.resolve_chat_id.return_value = CHAT_ID
+        import ccgram.handlers.status.status_bubble as bubble_mod
+
+        await bubble_mod.send_status_text(
+            _make_bot(77), USER_ID, THREAD_ID, WINDOW_ID, "working"
+        )
+        mock_dash.assert_not_called()
+
+    @patch("ccgram.handlers.status.status_bubble.config", create=True)
+    @patch("ccgram.handlers.status.status_bubble.thread_router")
+    @patch(_DASH_PATCH)
+    async def test_send_in_private_calls_dashboard_button(
+        self, mock_dash, mock_router, mock_config
+    ):
+        """send_status_text with thread_id==0 (private chat) consults the dashboard button."""
+        mock_config.hide_status = False
+        mock_router.resolve_chat_id.return_value = CHAT_ID
+        mock_dash.return_value = None  # Mini App not configured — button absent
+        import ccgram.handlers.status.status_bubble as bubble_mod
+
+        await bubble_mod.send_status_text(
+            _make_bot(78), USER_ID, 0, WINDOW_ID, "working"
+        )
+        mock_dash.assert_called_once_with(WINDOW_ID, USER_ID)

--- a/tests/ccgram/handlers/topics/test_topic_lifecycle.py
+++ b/tests/ccgram/handlers/topics/test_topic_lifecycle.py
@@ -60,11 +60,12 @@ class TestCheckAutocloseTimers:
     async def test_no_topics_is_noop(self):
         bot = AsyncMock(spec=Bot)
         await check_autoclose_timers(bot)
+        bot.close_forum_topic.assert_not_called()
         bot.delete_forum_topic.assert_not_called()
 
-    async def test_expired_done_topic_gets_closed(self):
+    async def test_expired_done_topic_is_closed_not_deleted(self):
+        """Autoclose closes the topic; it never deletes (irreversible data loss)."""
         bot = AsyncMock(spec=Bot)
-        bot.delete_forum_topic = AsyncMock()
         user_id, thread_id = 1, 100
         lifecycle_strategy.start_autoclose_timer(
             user_id, thread_id, "done", time.monotonic() - 99999
@@ -83,7 +84,8 @@ class TestCheckAutocloseTimers:
             mock_router.resolve_chat_id.return_value = 42
             mock_router.get_window_for_thread.return_value = "@0"
             await check_autoclose_timers(bot)
-        bot.delete_forum_topic.assert_called_once()
+        bot.close_forum_topic.assert_called_once()
+        bot.delete_forum_topic.assert_not_called()
 
     async def test_not_yet_expired_topic_stays(self):
         bot = AsyncMock(spec=Bot)
@@ -94,6 +96,7 @@ class TestCheckAutocloseTimers:
         with patch("ccgram.handlers.topics.topic_lifecycle.config") as mock_config:
             mock_config.autoclose_done_minutes = 60
             await check_autoclose_timers(bot)
+        bot.close_forum_topic.assert_not_called()
         bot.delete_forum_topic.assert_not_called()
 
     async def test_expired_dead_topic_stays_when_window_is_live(self):

--- a/tests/ccgram/test_herdr_backend.py
+++ b/tests/ccgram/test_herdr_backend.py
@@ -12,6 +12,7 @@ import json
 import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -441,24 +442,49 @@ async def test_capture_and_scrollback_guard_then_read_the_matched_pane() -> None
 
 
 async def test_send_variants_guard_then_dispatch_to_live_pane() -> None:
+    """Literal+enter is split into send-text then a separate Enter key."""
     fake = (
         _live_fake(_agent(pane_id="w7:p4"))
-        .on("pane", "run", out=_result(type="ok"))
         .on("pane", "send-text", out=_result(type="ok"))
         .on("pane", "send-keys", out=_result(type="ok"))
     )
     mux = _manager(fake)
-    assert await mux.send(_target(), "hello")
+    with patch("ccgram.multiplexer.herdr.asyncio.sleep"):
+        assert await mux.send(_target(), "hello")
     assert await mux.send(_target(), "partial", enter=False)
     assert await mux.send(_target(), "C-c Up", literal=False)
     assert fake.calls == [
         ["agent", "list"],
-        ["pane", "run", "w7:p4", "hello"],
+        ["pane", "send-text", "w7:p4", "hello"],
+        ["pane", "send-keys", "w7:p4", "Enter"],
         ["agent", "list"],
         ["pane", "send-text", "w7:p4", "partial"],
         ["agent", "list"],
         ["pane", "send-keys", "w7:p4", "C-c", "Up", "Enter"],
     ]
+
+
+async def test_send_literal_enter_is_split_with_delay() -> None:
+    """#177 regression: text and Enter must never arrive as one ``pane run`` batch."""
+    import ccgram.multiplexer.herdr as herdr_mod
+
+    fake = (
+        _live_fake(_agent(pane_id="w7:p5"))
+        .on("pane", "send-text", out=_result(type="ok"))
+        .on("pane", "send-keys", out=_result(type="ok"))
+    )
+    sleep_mock = AsyncMock()
+    with patch.object(herdr_mod.asyncio, "sleep", sleep_mock):
+        assert await _manager(fake).send(_target(), "hello world")
+
+    # ``pane run`` must never appear — that is the batched-Enter bug.
+    assert ["pane", "run", "w7:p5", "hello world"] not in fake.calls
+    # Text arrives before Enter.
+    text_idx = fake.calls.index(["pane", "send-text", "w7:p5", "hello world"])
+    enter_idx = fake.calls.index(["pane", "send-keys", "w7:p5", "Enter"])
+    assert text_idx < enter_idx
+    # The delay was awaited between them.
+    sleep_mock.assert_awaited_once_with(herdr_mod._SEND_ENTER_DELAY_SECONDS)
 
 
 async def test_every_mutating_tab_action_uses_live_record_locator() -> None:
@@ -751,11 +777,13 @@ async def test_send_to_a_replaced_target_fails_without_dispatching() -> None:
 
 
 async def test_action_error_refreshes_guard_without_retargeting() -> None:
-    fake = _live_fake(_agent(pane_id="w2:p1")).on("pane", "run", rc=1, err="closed")
+    fake = _live_fake(_agent(pane_id="w2:p1")).on(
+        "pane", "send-text", rc=1, err="closed"
+    )
     assert not await _manager(fake).send(_target(), "hello")
     assert fake.calls == [
         ["agent", "list"],
-        ["pane", "run", "w2:p1", "hello"],
+        ["pane", "send-text", "w2:p1", "hello"],
         ["agent", "list"],
     ]
 
@@ -783,7 +811,7 @@ async def test_post_guard_dispatch_race_never_retargets_another_pane() -> None:
     assert not await HerdrManager(runner=runner).send(_target(), "hello")
     assert runner.calls == [
         ["agent", "list"],
-        ["pane", "run", "w2:p1", "hello"],
+        ["pane", "send-text", "w2:p1", "hello"],
         ["agent", "list"],
     ]
     assert not any(


### PR DESCRIPTION
## Summary

Three targeted bug fixes — all cheap to land, all causing real user pain.

## Changes

### #177 — herdr prompt not submitted
Herdr's `pane run` delivered text and Enter in the same write. Agent TUIs (Claude Code, Pi) interpreted the rapid-fire Enter as a literal newline rather than a submit — the prompt sat unsent in the input line.

**Fix:** `_send_to` now calls `pane send-text` first, sleeps 0.5 s (same gap the tmux backend uses in `_send_literal_then_enter`), then sends Enter as a separate `pane send-keys` call.

### #178 — Mini App breaks status bubbles in groups
Telegram rejects `web_app` buttons outside private chats. Every status-bubble edit in a supergroup or forum topic raised a `TelegramError`, so the bubble stopped updating entirely.

**Fix:** `build_status_keyboard` gains an `is_group: bool = False` parameter. `send_status_text` passes `is_group=(thread_id_or_0 != 0)` — non-zero thread means group/topic, so the Dashboard button is skipped there.

### #187 (part 1) — autoclose deletes topics instead of closing them
Deleting a forum topic is irreversible. After the 4.6 upgrade orphaned bindings, the autoclose timer fired and permanently destroyed topic history.

**Fix:** `_close_expired_topic` now calls `close_forum_topic` only — `delete_forum_topic` is removed from this path entirely. A non-fatal `TelegramError` leaves the timer in place so the next cycle can retry. A gone-topic error still cleans up state.

## Tests
- `test_send_variants_guard_then_dispatch_to_live_pane` — updated to expect split calls
- `test_send_literal_enter_is_split_with_delay` — new regression test: asserts `pane run` never appears, text lands before Enter, sleep is awaited
- `TestBuildStatusKeyboardGroupVsPrivate` — 4 new tests: private shows button, group hides it, send_status_text wires is_group correctly
- `TestCheckAutocloseTimers` — updated: asserts `close_forum_topic` called, `delete_forum_topic` never called; gone-topic and error cases updated

Closes #177, closes #178. Partial fix for #187.