### PR TITLE
Stop the status env test leaking CCGRAM_MULTIPLEXER into its worker

### DIFF
--- a/tests/ccgram/test_status_cmd.py
+++ b/tests/ccgram/test_status_cmd.py
@@ -177,8 +177,13 @@ class TestStatusMainHerdr:
         # it counts herdr: keys and lists herdr panes — not default to tmux.
         monkeypatch.setenv("CCGRAM_DIR", str(tmp_path))
         monkeypatch.setenv("TMUX_SESSION_NAME", "ccgram")
-        # Registers the key so the load_dotenv-set value is restored on teardown.
-        monkeypatch.delenv("CCGRAM_MULTIPLEXER", raising=False)
+        # The key must be absent for load_dotenv to supply it (dotenv does not
+        # override an existing value), and it must be registered with monkeypatch
+        # or the value dotenv writes into os.environ outlives the test and every
+        # later test in this worker resolves the herdr backend. delenv alone does
+        # not register an absent key, so set it first: setenv always registers.
+        monkeypatch.setenv("CCGRAM_MULTIPLEXER", "tmux")
+        monkeypatch.delenv("CCGRAM_MULTIPLEXER")
         (tmp_path / ".env").write_text("CCGRAM_MULTIPLEXER=herdr\n")
 
         session_map = {"herdr:w2:p1": {"session_id": "abc-123", "cwd": "/tmp"}}


### PR DESCRIPTION
Previously `test_reads_multiplexer_from_config_dir_env` leaked `CCGRAM_MULTIPLEXER=herdr` into its xdist worker's environment, and roughly one full test run in three failed in an unrelated test.

The test writes that variable into a `.env` and lets `load_dotenv` put it in `os.environ`, which is the behaviour under test. It tried to register the key for teardown with `monkeypatch.delenv(raising=False)`, but `delenv` only registers a key that is already present, and this one is normally absent, so the call is a no-op and the value dotenv writes outlives the test.

Every later test in that worker then resolves the herdr backend. `TestDoctorMain.test_runs_without_crash` is the one that shows it: it pins no backend, so `doctor_main` runs the herdr check against a stubbed `shutil.which`, fails it and exits 1. Which test is hit depends on how tests distribute across workers, which is why it looks random.

After this change the key is set before it is deleted. `setenv` always registers, so the environment is left as the test needs it and restored afterwards.

## Verification

Eight consecutive full runs pass on the branch this was found on, and six more on `main` with only this fix applied. Before it, the failure appeared within three runs. Confirmed pre-existing by reverting the unrelated files under review and reproducing on the second attempt.
