### PR TITLE
Pause chat renames on flood control, pace the rename burst (#199)

### DIFF
--- a/src/ccgram/handlers/status/topic_emoji.py
+++ b/src/ccgram/handlers/status/topic_emoji.py
@@ -352,10 +352,23 @@ async def sync_topic_name(
         now = time.monotonic()
         if _flood_paused(chat_id, now):
             return
-        last = _last_chat_edit.get(chat_id)
-        if last is not None and now - last[0] < CHAT_EDIT_MIN_INTERVAL:
+        # Re-check the stamp after each sleep: the poll task renames other
+        # topics without this lock and moves it, so a single sleep-then-send
+        # could land inside the interval it just waited out (#206 review).
+        # Bounded retries: a pathological interleaving degrades to the
+        # unspaced send rather than starving the command forever.
+        for _ in range(3):
+            last = _last_chat_edit.get(chat_id)
+            if (
+                last is None
+                or last[1] == key
+                or now - last[0] >= CHAT_EDIT_MIN_INTERVAL
+            ):
+                break
             await asyncio.sleep(CHAT_EDIT_MIN_INTERVAL - (now - last[0]))
             now = time.monotonic()
+            if _flood_paused(chat_id, now):
+                return
         _last_chat_edit[chat_id] = (now, key)
         await _edit_topic_name(
             client,
@@ -497,11 +510,11 @@ _MAX_DISABLED_CHATS = 1000
 @topic_state.register("chat")
 def clear_disabled_chat(chat_id: int, _thread_id: int = 0) -> None:
     """Clear chat-scoped rename state on topic cleanup: the permission
-    disabled set and the rename pacing stamp. The flood cooldown is NOT
-    cleared here: it is chat-wide and must outlive any single topic's
-    teardown until it lazily expires (#199)."""
+    disabled set only. The flood cooldown and the pacing stamp are NOT
+    cleared here: both are chat-wide and must outlive any single topic's
+    teardown (a stale stamp ages out of the spacing check on its own;
+    the cooldown expires lazily) (#199, #206 review)."""
     _disabled_chats.discard(chat_id)
-    _last_chat_edit.pop(chat_id, None)
     if len(_disabled_chats) > _MAX_DISABLED_CHATS:
         _disabled_chats.clear()
 

--- a/src/ccgram/handlers/status/topic_emoji.py
+++ b/src/ccgram/handlers/status/topic_emoji.py
@@ -8,23 +8,28 @@ Updates topic names with status emoji prefixes to reflect session state:
 
 Tracks per-topic state to avoid redundant API calls. Debounces transitions
 to prevent rapid active/idle toggling from flooding the chat with rename
-messages. Gracefully degrades when the bot lacks editForumTopic permission.
+messages. Spaces renames of different topics in a chat by a minimum
+interval (poll path defers, /sync sleeps it out) and pauses a chat's
+renames entirely for a cooldown after flood control (#199). Gracefully
+degrades when the bot lacks editForumTopic permission.
 
 Key functions:
   - update_topic_emoji: Update emoji for a specific topic (debounced)
   - clear_topic_emoji_state: Clean up tracking for a topic
 """
 
+import asyncio
 import time
 
 import structlog
-from telegram.error import BadRequest, TelegramError
+from telegram.error import BadRequest, RetryAfter, TelegramError
 
 from ...config import config
 from ...telegram_client import TelegramClient
 from ...thread_router import thread_router
 from ...topic_state_registry import topic_state
 from ...window_query import get_approval_mode
+from ..messaging_pipeline.message_sender import retry_after_seconds
 
 logger = structlog.get_logger()
 
@@ -90,7 +95,12 @@ _DEBOUNCE_BY_STATE: dict[str, float] = {
 # Topic state tracking: (chat_id, thread_id) -> (state, approval_mode, rc_active)
 _topic_states: dict[tuple[int, int], tuple[str, str, bool]] = {}
 
-# Pending transitions: (chat_id, thread_id) -> (desired_state, first_seen_monotonic)
+# Pending transitions: (chat_id, thread_id) -> (desired_state, first_seen_monotonic).
+# first_seen may be BACKDATED (now - debounce) as a "fire next cycle" marker:
+# the rename pacing re-arms this way so a spaced-out transition applies on
+# the next poll cycle without sitting through a full debounce again. The
+# marker is only honored while the state token is unapplied; a paced-out
+# NAME change (same token) is carried by the _topic_names rollback instead.
 _pending_transitions: dict[tuple[int, int], tuple[str, float]] = {}
 
 # Topics inherited at process startup. Their first observed state replaces the
@@ -104,6 +114,56 @@ _topic_names: dict[tuple[int, int], str] = {}
 
 # Chats where editForumTopic is disabled due to permission errors
 _disabled_chats: set[int] = set()
+
+# Flood-control cooldown (upstream #199): after a RetryAfter on a topic
+# rename, renames for that chat pause entirely for this long. Without it,
+# the unapplied state re-arms the debounce every cycle and re-attempts the
+# rename forever; each attempt holds PTB's shared retry-after event closed
+# for ~20s, starving ALL Bot API traffic, not just renames.
+FLOOD_COOLDOWN_SECONDS = 300.0
+
+# Minimum spacing between renames of DIFFERENT topics in the same chat.
+# The startup first paint applies one rename per inherited topic in a
+# single poll cycle (by design, no debounce); unspaced, that is a burst of
+# N editForumTopic calls that trips the per-chat method bucket (#199).
+# Same-topic updates bypass the spacing: one rename is never a burst.
+CHAT_EDIT_MIN_INTERVAL = 1.5
+
+# chat_id -> monotonic time until which renames are paused (lazily expires).
+_flood_cooldown_until: dict[int, float] = {}
+# chat_id -> (monotonic time of the last rename attempt, its topic key).
+_last_chat_edit: dict[int, tuple[float, tuple[int, int]]] = {}
+
+# Serializes sync_topic_name renames: /sync gathers several per chat
+# concurrently, and without the lock they would all wake from the same
+# pacing stamp at once (#199).
+_sync_rename_lock = asyncio.Lock()
+
+
+def _flood_paused(chat_id: int, now: float) -> bool:
+    """True while the chat's renames are paused after flood control."""
+    until = _flood_cooldown_until.get(chat_id)
+    if until is None:
+        return False
+    if now >= until:
+        _flood_cooldown_until.pop(chat_id, None)
+        return False
+    return True
+
+
+def _pause_renames_for_flood(chat_id: int) -> None:
+    """Start (or extend) the chat-wide rename flood cooldown."""
+    _flood_cooldown_until[chat_id] = time.monotonic() + FLOOD_COOLDOWN_SECONDS
+
+
+def _paced_out(chat_id: int, key: tuple[int, int], now: float) -> bool:
+    """True when a rename of ``key`` must wait: a different topic of the
+    same chat was renamed within CHAT_EDIT_MIN_INTERVAL."""
+    last = _last_chat_edit.get(chat_id)
+    if last is None:
+        return False
+    last_ts, last_key = last
+    return last_key != key and now - last_ts < CHAT_EDIT_MIN_INTERVAL
 
 
 def _resolve_topic_name(key: tuple[int, int], display_name: str) -> tuple[str, bool]:
@@ -201,6 +261,19 @@ async def _edit_topic_name(
             state or "sync",
             new_name,
         )
+    except RetryAfter as exc:
+        # Flood control: pause this chat's renames instead of letting the
+        # unapplied state re-arm the debounce and retry forever (#199). The
+        # flat floor subsumes Telegram's own retry_after: a still-flooded
+        # resume re-arms the cooldown, which is the self-correcting path.
+        _pause_renames_for_flood(chat_id)
+        logger.warning(
+            "Flood control on topic rename for chat %d (retry_after %ss): "
+            "pausing this chat's renames for %.0fs",
+            chat_id,
+            retry_after_seconds(exc),
+            FLOOD_COOLDOWN_SECONDS,
+        )
     except BadRequest as e:
         if "Not enough rights" in e.message:
             _disabled_chats.add(chat_id)
@@ -271,15 +344,28 @@ async def sync_topic_name(
         approval_mode=approval_mode,
         rc_active=rc_active,
     )
-    await _edit_topic_name(
-        client,
-        chat_id,
-        thread_id,
-        key,
-        new_name,
-        state_token=state_token,
-        state=state,
-    )
+    # /sync drives one rename per binding concurrently (semaphore 5); in
+    # this command context the per-chat spacing is slept out rather than
+    # deferred like the poll path, and the lock keeps gathered syncs from
+    # waking from one stamp together (#199).
+    async with _sync_rename_lock:
+        now = time.monotonic()
+        if _flood_paused(chat_id, now):
+            return
+        last = _last_chat_edit.get(chat_id)
+        if last is not None and now - last[0] < CHAT_EDIT_MIN_INTERVAL:
+            await asyncio.sleep(CHAT_EDIT_MIN_INTERVAL - (now - last[0]))
+            now = time.monotonic()
+        _last_chat_edit[chat_id] = (now, key)
+        await _edit_topic_name(
+            client,
+            chat_id,
+            thread_id,
+            key,
+            new_name,
+            state_token=state_token,
+            state=state,
+        )
 
 
 async def update_topic_emoji(
@@ -306,6 +392,7 @@ async def update_topic_emoji(
         return
 
     key = (chat_id, thread_id)
+    prev_name = _topic_names.get(key)
     clean_name, name_changed = _resolve_topic_name(key, display_name)
 
     approval_mode = _resolve_approval_mode(chat_id, thread_id)
@@ -317,6 +404,8 @@ async def update_topic_emoji(
         return
 
     now = time.monotonic()
+    if _flood_paused(chat_id, now):
+        return
     if not _should_apply_update(
         key,
         state,
@@ -325,6 +414,25 @@ async def update_topic_emoji(
         now=now,
     ):
         return
+    if _paced_out(chat_id, key, now):
+        # A different topic of this chat was renamed moments ago: defer to
+        # the next poll cycle instead of bursting (#199). Two things must
+        # survive the deferral. The pending state transition is re-armed
+        # as if its debounce had just elapsed (fires next cycle). A name
+        # change must have its write-through cache update rolled back,
+        # else the next cycle would see name_changed=False and drop the
+        # rename entirely (the token-match branch consults name_changed).
+        _pending_transitions[key] = (
+            state,
+            now - _DEBOUNCE_BY_STATE.get(state, DEBOUNCE_TO_IDLE_SECONDS),
+        )
+        if name_changed:
+            if prev_name is None:
+                _topic_names.pop(key, None)
+            else:
+                _topic_names[key] = prev_name
+        return
+    _last_chat_edit[chat_id] = (now, key)
 
     new_name = _compose_topic_name(
         clean_name,
@@ -388,8 +496,12 @@ _MAX_DISABLED_CHATS = 1000
 
 @topic_state.register("chat")
 def clear_disabled_chat(chat_id: int, _thread_id: int = 0) -> None:
-    """Remove a chat from the disabled set (called on topic cleanup)."""
+    """Clear chat-scoped rename state on topic cleanup: the permission
+    disabled set and the rename pacing stamp. The flood cooldown is NOT
+    cleared here: it is chat-wide and must outlive any single topic's
+    teardown until it lazily expires (#199)."""
     _disabled_chats.discard(chat_id)
+    _last_chat_edit.pop(chat_id, None)
     if len(_disabled_chats) > _MAX_DISABLED_CHATS:
         _disabled_chats.clear()
 
@@ -401,3 +513,5 @@ def reset_all_state() -> None:
     _awaiting_first_paint.clear()
     _disabled_chats.clear()
     _topic_names.clear()
+    _flood_cooldown_until.clear()
+    _last_chat_edit.clear()

--- a/tests/ccgram/handlers/status/test_topic_emoji.py
+++ b/tests/ccgram/handlers/status/test_topic_emoji.py
@@ -715,9 +715,66 @@ class TestFirstPaintPacing:
             await update_topic_emoji(bot, -100, 1, "idle", "alpha")
             assert bot.edit_forum_topic.await_count == 1
 
-            mock_monotonic.return_value = 0.2
-            with patch(f"{MOD}.asyncio") as aio:
-                aio.sleep = AsyncMock()
+            clock = {"now": 0.2}
+            mock_monotonic.side_effect = lambda: clock["now"]
+
+            async def advance(seconds: float) -> None:
+                clock["now"] += seconds
+
+            with patch(
+                f"{MOD}.asyncio.sleep", new=AsyncMock(side_effect=advance)
+            ) as sleep_mock:
                 await sync_topic_name(bot, -100, 2, "beta")
-        aio.sleep.assert_awaited_once_with(CHAT_EDIT_MIN_INTERVAL - 0.2)
+        sleep_mock.assert_awaited_once_with(CHAT_EDIT_MIN_INTERVAL - 0.2)
         assert bot.edit_forum_topic.await_count == 2
+
+    async def test_sync_rechecks_stamp_after_sleeping(self) -> None:
+        """Greptile #206 P1: while /sync sleeps out the spacing, the poll
+        task may rename another topic and move the stamp; sync must
+        re-check and sleep again rather than send inside the interval."""
+        from ccgram.handlers.status.topic_emoji import (
+            CHAT_EDIT_MIN_INTERVAL,
+            _last_chat_edit,
+        )
+
+        bot = AsyncMock()
+        _last_chat_edit[-100] = (0.0, (-100, 1))
+        clock = {"now": 0.2}
+
+        async def poll_renames_during_sleep(_seconds: float) -> None:
+            # The poll task (no sync lock) renames another topic just as
+            # sync wakes, then time advances by the spacing interval.
+            clock["now"] += CHAT_EDIT_MIN_INTERVAL
+            _last_chat_edit[-100] = (clock["now"], (-100, 3))
+
+        with (
+            patch(_PATCH_MONOTONIC, side_effect=lambda: clock["now"]),
+            patch(
+                f"{MOD}.asyncio.sleep",
+                new=AsyncMock(side_effect=poll_renames_during_sleep),
+            ) as sleep_mock,
+        ):
+            await sync_topic_name(bot, -100, 2, "beta")
+
+        # Every sleep is undercut by a fresh different-topic stamp, so the
+        # bounded loop sleeps three times and then sends (degrading to the
+        # unspaced send rather than starving the command).
+        assert sleep_mock.await_count == 3
+        assert bot.edit_forum_topic.await_count == 1
+
+    def test_topic_cleanup_keeps_chat_pacing_stamp(self) -> None:
+        """Greptile #206: the pacing stamp is chat-scoped and must survive
+        a single topic's teardown (only the permission set is cleared)."""
+        from ccgram.handlers.status.topic_emoji import (
+            _disabled_chats,
+            _last_chat_edit,
+            clear_disabled_chat,
+        )
+
+        _disabled_chats.add(-100)
+        _last_chat_edit[-100] = (0.0, (-100, 1))
+
+        clear_disabled_chat(-100, 42)
+
+        assert -100 not in _disabled_chats
+        assert _last_chat_edit[-100] == (0.0, (-100, 1))

--- a/tests/ccgram/handlers/status/test_topic_emoji.py
+++ b/tests/ccgram/handlers/status/test_topic_emoji.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from telegram.error import BadRequest, TelegramError
+from telegram.error import BadRequest, RetryAfter, TelegramError
 
 from _helpers import make_mock_provider
 
@@ -602,3 +602,122 @@ class TestStatusMode:
             message_thread_id=42,
             name=f"{EMOJI_GREEN_CIRCLE} myproject",
         )
+
+
+MOD = "ccgram.handlers.status.topic_emoji"
+
+
+class TestFloodControlCooldown:
+    """Upstream #199: a RetryAfter on a topic rename must pause the chat's
+    renames instead of silently re-arming the debounce forever."""
+
+    async def test_retry_after_pauses_renames_for_the_chat(self) -> None:
+        from ccgram.handlers.status.topic_emoji import FLOOD_COOLDOWN_SECONDS
+
+        bot = AsyncMock()
+        bot.edit_forum_topic.side_effect = RetryAfter(3)
+        mark_awaiting_first_paint(-100, 42)
+
+        with patch(_PATCH_MONOTONIC) as mock_monotonic:
+            mock_monotonic.return_value = 0.0
+            # First paint hits flood control: cooldown starts, no crash.
+            await update_topic_emoji(bot, -100, 42, "idle", "myproject")
+
+            bot.edit_forum_topic.reset_mock()
+            bot.edit_forum_topic.side_effect = None
+            # While paused: no rename attempt for this chat, by any path.
+            await update_topic_emoji(bot, -100, 42, "active", "myproject")
+            await sync_topic_name(bot, -100, 42, "myproject")
+            bot.edit_forum_topic.assert_not_called()
+
+            # After the cooldown lapses, debounced renames apply again.
+            mock_monotonic.return_value = FLOOD_COOLDOWN_SECONDS + 0.1
+            await update_topic_emoji(bot, -100, 42, "active", "myproject")
+            mock_monotonic.return_value = (
+                FLOOD_COOLDOWN_SECONDS + 0.1 + _debounce_for("active") + 0.1
+            )
+            await update_topic_emoji(bot, -100, 42, "active", "myproject")
+        bot.edit_forum_topic.assert_called_once()
+
+
+class TestFirstPaintPacing:
+    """Upstream #199: the inherited-topic repaint burst at startup must be
+    spaced across poll cycles, one topic per chat at a time."""
+
+    async def test_burst_of_inherited_topics_is_paced(self) -> None:
+        from ccgram.handlers.status.topic_emoji import CHAT_EDIT_MIN_INTERVAL
+
+        bot = AsyncMock()
+        mark_awaiting_first_paint(-100, 1)
+        mark_awaiting_first_paint(-100, 2)
+
+        with patch(_PATCH_MONOTONIC) as mock_monotonic:
+            mock_monotonic.return_value = 0.0
+            await update_topic_emoji(bot, -100, 1, "idle", "alpha")
+            await update_topic_emoji(bot, -100, 2, "idle", "beta")
+            # Only the first rename of the burst goes out immediately.
+            assert bot.edit_forum_topic.await_count == 1
+
+            mock_monotonic.return_value = CHAT_EDIT_MIN_INTERVAL + 0.1
+            await update_topic_emoji(bot, -100, 2, "idle", "beta")
+        assert bot.edit_forum_topic.await_count == 2
+
+    async def test_same_topic_updates_are_not_paced(self) -> None:
+        bot = AsyncMock()
+        with patch(_PATCH_MONOTONIC) as mock_monotonic:
+            mock_monotonic.return_value = 0.0
+            mark_awaiting_first_paint(-100, 1)
+            await update_topic_emoji(bot, -100, 1, "idle", "alpha")
+            # Same key, immediate follow-up (name change): never deferred.
+            mock_monotonic.return_value = 0.2
+            await update_topic_emoji(bot, -100, 1, "idle", "alpha2")
+        assert bot.edit_forum_topic.await_count == 2
+
+    async def test_paced_name_change_survives_deferral(self) -> None:
+        """Regression (comment-compliance review 2026-08-29): a name change
+        arriving inside another topic's spacing window must defer, not be
+        dropped. The deferral rolls back the write-through name cache so
+        the next cycle re-detects the rename instead of consuming it."""
+        from ccgram.handlers.status.topic_emoji import (
+            CHAT_EDIT_MIN_INTERVAL,
+            _topic_states,
+        )
+
+        bot = AsyncMock()
+        _topic_states[(-100, 2)] = ("idle", "normal", False)
+        with patch(_PATCH_MONOTONIC) as mock_monotonic:
+            mock_monotonic.return_value = 0.0
+            mark_awaiting_first_paint(-100, 1)
+            await update_topic_emoji(bot, -100, 1, "idle", "alpha")
+            assert bot.edit_forum_topic.await_count == 1
+
+            # Topic 2's rename (token unchanged, name changed) lands inside
+            # topic 1's spacing window: deferred this cycle...
+            mock_monotonic.return_value = 0.1
+            await update_topic_emoji(bot, -100, 2, "idle", "beta-renamed")
+            assert bot.edit_forum_topic.await_count == 1
+
+            # ...and actually sent on the next one.
+            mock_monotonic.return_value = CHAT_EDIT_MIN_INTERVAL + 0.2
+            await update_topic_emoji(bot, -100, 2, "idle", "beta-renamed")
+        assert bot.edit_forum_topic.await_count == 2
+
+    async def test_sync_sleeps_out_chat_spacing(self) -> None:
+        """The /sync path cannot defer to a later poll cycle; it sleeps
+        out the per-chat spacing instead, so a sync rename cannot land
+        inside the interval opened by another topic's rename (#199)."""
+        from ccgram.handlers.status.topic_emoji import CHAT_EDIT_MIN_INTERVAL
+
+        bot = AsyncMock()
+        with patch(_PATCH_MONOTONIC) as mock_monotonic:
+            mock_monotonic.return_value = 0.0
+            mark_awaiting_first_paint(-100, 1)
+            await update_topic_emoji(bot, -100, 1, "idle", "alpha")
+            assert bot.edit_forum_topic.await_count == 1
+
+            mock_monotonic.return_value = 0.2
+            with patch(f"{MOD}.asyncio") as aio:
+                aio.sleep = AsyncMock()
+                await sync_topic_name(bot, -100, 2, "beta")
+        aio.sleep.assert_awaited_once_with(CHAT_EDIT_MIN_INTERVAL - 0.2)
+        assert bot.edit_forum_topic.await_count == 2


### PR DESCRIPTION
Implements the proposed direction from #199. Running in production on our bridge since 2026-08-29 (two days, through restarts and an active 16-topic forum).

## What it does

- **RetryAfter on a rename starts a chat-wide rename cooldown** instead of falling into the blanket `except TelegramError: pass`. Previously the unapplied state re-armed the debounce every cycle and retried forever; each attempt also held the shared rate limiter's retry-after event closed, starving all Bot API traffic ~20s per cycle (the "bot went mute" symptom in the issue).
- **Renames of different topics in one chat are spaced apart**, covering the startup first paint: inherited topics apply their first state with no debounce, so a restart with N topics issued N `editForumTopic` calls in a single poll cycle and saturated the per-chat method bucket.
  - The poll path defers a spaced-out rename to the next cycle (pending transition re-armed as elapsed, plus a rollback of the write-through name cache so a paced-out *name change* is re-detected next cycle instead of dropped; regression-tested red-green).
  - `/sync` gathers renames concurrently, so `sync_topic_name` sleeps the interval out under a lock instead of deferring.

## Notes

- The cooldown is chat-wide, survives single-topic teardown (lazy expiry), and one warning is logged per activation.
- Tests: 5 new (cooldown pause/resume incl. both entry points, burst pacing, same-topic bypass, paced name-change survival); suite green (6578), ruff/pyright clean.

The 429-retry amplifier inside PTB's `AIORateLimiter` (the shared retry-after event) is a related but separate mechanism we have a local fix for; happy to follow up in its own PR if this lands.

Per CONTRIBUTING: one thing per PR; this is the #199 clause pair only.