### PR TITLE
feat: add Telegram backlog controls and topic cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Each Telegram topic maps to one tmux window. With Herdr, it maps instead to one 
 - **Send workspace files** — Share files to Telegram via `/send` (glob, path, or substring search)
 - **Action toolbar** — Provider-specific buttons for common actions (Screenshot, Mode, Esc, Enter, etc.)
 
+## Delivery and Sync Safety
+
+CCGram losslessly combines only eligible consecutive transcript text deliveries for the same chat, topic, window, role, and source session. It preserves each item's formatting and keeps tool updates, media, status updates, and other boundaries separate. The status bubble shows queue progress; at a severe backlog (100 pending items or an oldest item aged 5 minutes), its inline **Jump to live** action requires confirmation and posts a skipped-range notice. The raw provider transcript is never deleted. Delivery is at-least-once, so a Telegram failure or restart before acknowledgement can repeat a transcript message rather than silently losing it.
+
+`/sync` can clean up only locally recorded, eligible retired topics. It never discovers or enumerates arbitrary Telegram topics; an active or rebound topic is protected before any cleanup request. See the [delivery, backlog, and Sync guide](docs/guides.md#delivery-backlog-and-jump-to-live) for boundaries, safety guarantees, and Telegram admin permissions.
+
 ---
 
 ## Quick Start
@@ -131,8 +137,9 @@ Native Windows does not provide the Unix file locking, signal handling, and term
 
 ## Documentation
 
-- **[Guides](docs/guides.md)** — CLI reference, configuration, voice transcription, multi-instance setup, session recovery, testing
-- **[Providers](docs/providers.md)** — Claude Code, Codex, Gemini, Pi, Shell; session modes, LLM config, custom commands, git worktrees
+- **[Guides](docs/guides.md)** — CLI reference, configuration, delivery/backlog safety, `/sync`, voice transcription, multi-instance setup, session recovery, testing
+- **[Providers](docs/providers.md)** — Claude Code, Codex, Gemini, Pi, Shell; transcript delivery, session modes, LLM config, custom commands, git worktrees
+- **[Architecture](docs/architecture.md)** — delivery queue, transcript watermark, and provider/multiplexer design
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -241,6 +241,14 @@ sequenceDiagram
     end
 ```
 
+## Delivery Queue, Progress, and Watermarks
+
+Transcript `NewMessage` events route into a per-user ordered queue. Consecutive text tasks can share one Telegram send only when they are non-empty, one-part text from the same chat, thread, window, role, and source session; the queue stops at every other boundary. Each part is converted to Telegram entities before assembly, then separated with a blank line and sent as one formatted payload. This preserves each source item's rendering and prevents Markdown/entity state from crossing items. Tool batching, status tasks, media/TTS, and skip notices retain their separate delivery boundaries.
+
+Queue telemetry is window/topic scoped: pending transcript content tasks include queued and in-flight tasks, oldest age is measured from enqueue time, and delivery lag is measured when a content attempt reaches the Telegram boundary. The status bubble renders these values and opens the inline Jump-to-live confirmation only at `pending >= 100 OR oldest_age >= 300s`. The metrics are deliberately in-memory telemetry, not durable state.
+
+Transcript state keeps a persisted delivered watermark and an in-memory parsed offset. The monitor advances the watermark only after every receipt through the relevant checkpoint is delivered or intentionally dropped; a failed/unconfirmed attempt remains replayable, making the contract at-least-once rather than exactly-once. A confirmed Jump to live snapshots source EOF, persists a `BacklogSkipIntent` before source-scoped queue retirement, and waits for the visible skipped-range notice receipt before atomically advancing the watermark. The raw transcript is not changed. Pending barriers survive restart and block rereading the frozen range until their notice is delivered.
+
 ## Hook Event Flow
 
 ```mermaid
@@ -299,6 +307,8 @@ graph TB
 
 ## Key Design Decisions
 
+<!-- markdownlint-disable MD060 -->
+
 | Decision                                          | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Window ID-centric routing (`@0`, `@12`)           | Unique within a tmux server; window names are display-only                                                                                                                                                                                                                                                                                                                                                                                            |
@@ -327,3 +337,5 @@ graph TB
 | Recovery split                                    | `recovery_callbacks.py` is a thin dispatcher; `recovery_banner.py` owns dead-window banner UX; `resume_picker.py` owns the resume picker + transcript scan. `recovery/__init__.py` re-exports the public surface                                                                                                                                                                                                                                      |
 | Commands subpackage                               | `handlers/commands/` mirrors the `shell/` pattern: `forward.py`, `menu_sync.py`, `failure_probe.py`, `status_snapshot.py`. `commands/__init__.py` hosts `commands_command` + `toolbar_command`                                                                                                                                                                                                                                                        |
 | Lazy-import contract                              | In-function `Import`/`ImportFrom` must carry `# Lazy: <reason>` (or live inside `if TYPE_CHECKING:` / `_reset_*_for_testing`). `scripts/lint_lazy_imports.py` runs in `make lint`; cycle regressions caught by `tests/integration/test_import_no_cycles.py`                                                                                                                                                                                           |
+
+<!-- markdownlint-enable MD060 -->

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -10,7 +10,7 @@ brew upgrade ccgram                   # Homebrew
 
 ## CLI Reference
 
-```
+```text
 ccgram                        # Start the bot
 ccgram status                 # Show running state (no token needed)
 ccgram doctor                 # Validate setup and diagnose issues
@@ -175,6 +175,8 @@ The tests create an isolated `ccgram-e2e` tmux session that does not interfere w
 
 All settings accept both CLI flags and environment variables. CLI flags take precedence. `TELEGRAM_BOT_TOKEN` is env-only for security (flags are visible in `ps`).
 
+<!-- markdownlint-disable MD060 -->
+
 | Variable / Flag                                      | Default                        | Description                                                                                          |
 | ---------------------------------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
 | `TELEGRAM_BOT_TOKEN`                                 | _(required)_                   | Bot token from @BotFather (env only)                                                                 |
@@ -224,6 +226,8 @@ All settings accept both CLI flags and environment variables. CLI flags take pre
 | `CCGRAM_TTS_MODEL`                                   | `gpt-4o-mini-tts`              | OpenAI TTS model (only used when `CCGRAM_TTS_PROVIDER=openai`)                                       |
 | `CCGRAM_TTS_API_KEY`                                 | _(empty)_                      | API key for OpenAI TTS; falls back to `OPENAI_API_KEY`                                               |
 
+<!-- markdownlint-enable MD060 -->
+
 ## Topic Emoji Color Scheme
 
 Topic emojis change color to reflect agent status. The mapping between color and meaning is configurable:
@@ -249,6 +253,32 @@ By default, `tool_use` and `tool_result` events from Claude/Codex/Gemini are for
 - **Per-window**: `/toolcalls` in a topic cycles `default → shown → hidden`. The per-window setting always wins over the global default.
 
 Hook events (Stop, StopFailure, SubagentStart/Stop, TaskCompleted, TeammateIdle) are **never** suppressed — they bypass the gate so you still see what matters.
+
+## Delivery, Backlog, and Jump to Live
+
+### Lossless text batching
+
+The outbound queue can combine consecutive eligible transcript text tasks into one Telegram message to reduce API calls. This is not the `/verbose` tool-call batching mode: `/verbose` controls the separate live tool-use display.
+
+A text batch is eligible only when every item is a non-empty, one-part text task with the same **chat, topic/thread, window, role, and transcript source session**. CCGram stops at the first different or ineligible queued item, so it never crosses chats, topics, windows, roles, sessions, tool updates, status updates, media/TTS deliveries, or other queue boundaries. Batches are capped below Telegram's message limit and use a blank line between original items.
+
+Each item is rendered to Telegram entities before the items are combined. Formatting opened in one item cannot alter the next item's formatting, and each item retains the formatting it would have had if sent on its own. This makes the batching lossless for eligible text while preserving the delivery boundaries of everything else.
+
+### Queue progress and severe backlogs
+
+The editable topic status bubble reports:
+
+- **pending** — queued and in-flight transcript content items for that topic/window;
+- **age** — how long the oldest of those items has waited; and
+- **delivery lag** — the elapsed time for the latest completed content delivery (`—` until one completes).
+
+These are in-memory progress metrics, so they reset when CCGram restarts. The status line is refreshed with status updates and its displayed text is throttled for up to 15 seconds. A backlog is severe when it has **100 or more pending items** **or** its oldest item is **5 minutes (300 seconds) or older**. Only then does the status keyboard include **⏭ Jump to live**.
+
+### Confirmed jump semantics
+
+**Jump to live** is an inline, two-step action: tap it, then tap **Confirm jump to live**. Cancel leaves the queue and all watermarks unchanged. On confirmation, CCGram snapshots the selected transcript source at its current EOF, persists a skip barrier before retiring only that source's queued range, and queues a visible notice such as `⏭ Skipped N queued transcript item(s) for live view (bytes A–B). Raw transcript retained.` New transcript bytes written after the snapshot are not part of the jump; an already in-flight send is also left alone rather than cancelled.
+
+The raw provider transcript is retained; Jump to live does not delete or rewrite it. CCGram advances the durable delivered watermark past the skipped range only after Telegram acknowledges the skipped-range notice. If CCGram restarts or notice delivery fails first, it restores the barrier and retries the notice rather than silently advancing. Normal transcript relay is **at-least-once**, not exactly-once: a Telegram outcome that is not confirmed before a retry or restart can produce a duplicate message. This watermark policy favors retaining/replaying output over losing it.
 
 ## Thinking Visibility
 
@@ -350,6 +380,8 @@ ccgram accepts herdr socket protocols 14–20 without warnings. On the first cal
 
 herdr advertises its own capabilities through the seam; the behavioral consequences a user sees:
 
+<!-- markdownlint-disable MD060 -->
+
 | Aspect                    | tmux                            | herdr                                                                      |
 | ------------------------- | ------------------------------- | -------------------------------------------------------------------------- |
 | Topic = agent session     | every window is eligible        | each reported agent session surfaces as one topic; a bare shell does not   |
@@ -359,11 +391,23 @@ herdr advertises its own capabilities through the seam; the behavioral consequen
 | Window IDs across restart | stable                          | guarded session target is revalidated from fresh `agent.list`; ccgram never re-resolves a tab/pane ID |
 | Topic labels              | window name                     | `<workspace> ▸ <tab> ▸ <pane>` for every reported agent session             |
 
+<!-- markdownlint-enable MD060 -->
+
 Creating sessions from the terminal on herdr is covered in [Creating Sessions from the Terminal](#creating-sessions-from-the-terminal).
 
 > **Workspace picker:** On herdr, `/new` shows an extra step after directory selection. Choose a workspace to pin the new tab there, or skip it: ccgram then explicitly creates a workspace from the requested directory and uses only its returned ID. It never infers the active or a matching workspace.
 >
 > **Self-hosting escape hatch:** Workspaces or tabs whose label matches `__*__` (e.g. `__main__`) are invisible to ccgram. Use this naming convention to run ccgram itself inside herdr without it auto-adopting its own terminal as a topic.
+
+## Sync and Retired Topic Cleanup
+
+`/sync` audits CCGram's local bindings and offers **Fix** for repairable items. Its retired-topic cleanup is intentionally narrow: it considers only a bounded local registry (up to 100 entries) of exact chat/topic bindings that CCGram previously owned and marked eligible for cleanup. It does **not** discover, list, or act on arbitrary forum topics. The Bot API does not let bots enumerate unknown topics, so a topic that was never recorded by CCGram cannot become a `/sync` cleanup candidate.
+
+When you choose **Fix**, CCGram rechecks each known retired topic immediately before the Bot API call. A topic that is active or was rebound in the meantime is reported as **Protected active or rebound** and receives no delete or close request. A new binding for the same chat/topic also removes the old retired record.
+
+For an eligible, still-retired topic, `/sync` tries `deleteForumTopic` first. Deletion is irreversible and removes the topic history. If deletion is unavailable or fails, `/sync` tries `closeForumTopic`; closing hides/closes the topic but retains its history. A successful delete, successful close, or an already-gone topic is removed from the local registry. Failed delete-and-close attempts stay in the registry for a later `/sync` attempt, and the report distinguishes Deleted, Closed, Already gone, Could not remove, and Protected active or rebound outcomes.
+
+The bot must be a group administrator with Telegram's **Manage Topics** (`can_manage_topics`) permission for topic cleanup. Configure forum topics and the admin permissions in [BotFather Setup](#botfather-setup); if Telegram denies either operation, `/sync` leaves the local record in place and reports the failure. Review candidates before pressing Fix because a successful delete cannot be undone.
 
 ## Auto-Close Behavior
 
@@ -464,7 +508,7 @@ The buttons shown adapt to each provider's capabilities. Claude and Antigravity 
 
 Forms:
 
-```
+```text
 /agent              # show picker (current marked ✓, with (manual override) badge if set)
 /agent shell        # switch to shell
 /agent claude       # switch to Claude (also: codex, gemini, pi)
@@ -599,14 +643,14 @@ CCGram supports Claude Code, Codex CLI, Gemini CLI, Pi, and Shell. Each topic ca
 
 All state files live in `$CCGRAM_DIR` (`~/.ccgram/` by default):
 
-| File                 | Description                                                 |
-| -------------------- | ----------------------------------------------------------- |
-| `state.json`         | Thread bindings, window states, display names, read offsets |
-| `session_map.json`   | Hook-generated window → session mappings                    |
-| `events.jsonl`       | Append-only hook event log (read incrementally by monitor)  |
-| `monitor_state.json` | Byte offsets per session (prevents duplicate notifications) |
+| File                 | Description                                                         |
+| -------------------- | ------------------------------------------------------------------- |
+| `state.json`         | Thread bindings, window states, display names, read offsets         |
+| `session_map.json`   | Hook-generated window → session mappings                            |
+| `events.jsonl`       | Append-only hook event log (read incrementally by monitor)          |
+| `monitor_state.json` | Delivered transcript watermarks and pending Jump-to-live barriers   |
 
-Session transcripts are read from provider-specific locations (read-only): `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), `~/.gemini/tmp/` (Gemini), `~/.pi/agent/sessions/` (Pi). Shell has no transcript — output is captured directly from the tmux pane. The bot never writes to agent data directories.
+Session transcripts are read from provider-specific locations (read-only): `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), `~/.gemini/tmp/` (Gemini), `~/.pi/agent/sessions/` (Pi). Shell has no transcript — output is captured directly from the tmux pane. The bot never writes to agent data directories; the delivered watermark records relay progress, not a mutation of the raw transcript.
 
 ## Running as a Service
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -15,6 +15,12 @@ CCGram supports multiple agent CLI backends. Each Telegram topic can use a diffe
 
 `Resume` in this table means the CLI accepts a known session ID. CCGram's Telegram Resume picker can enumerate sessions for Claude and Antigravity. Codex, Gemini, and Pi currently expose Fresh and Continue recovery actions only.
 
+## Transcript Delivery Guarantees
+
+For transcript-backed providers, CCGram delivers parsed output through an ordered queue. Consecutive eligible text items may be losslessly combined into one Telegram message only within the same chat, topic/thread, window, role, and transcript source session. Tool-use batching (`/verbose`), attachments/TTS, status updates, and any other queue boundary remain separate. Each original text item is rendered before batching, so its Telegram formatting is preserved and cannot leak into the next item.
+
+Delivery is at-least-once. CCGram persists a transcript's delivered watermark only after its queued delivery receipts succeed (or are intentionally dropped by a confirmed Jump to live). After a process restart or an unconfirmed Telegram result, it can replay output and therefore show a duplicate rather than risk losing output. Provider transcript files stay read-only; a confirmed Jump to live records a durable barrier and a visible skipped-range notice before advancing past that range. See [Delivery, Backlog, and Jump to Live](guides.md#delivery-backlog-and-jump-to-live) for queue metrics, severe thresholds, and the action's exact boundaries.
+
 ## Choosing a Provider
 
 **From Telegram**: When you create a new topic and select a directory, then — if the directory is an eligible git repo — choose whether to use the current branch or create a new worktree on a new branch (non-git directories skip this step), a provider picker appears with Claude (default), Codex, Gemini, Pi, Antigravity, and Shell options. After provider selection, CCGram asks for session mode:

--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -239,13 +239,14 @@ async def start_session_monitor(application: Application) -> SessionMonitor:
     # Lazy: message routing imports monitor NewMessage for transcript dispatch.
     from .handlers.messaging_pipeline.message_routing import enqueue_backlog_skip_notice
 
-    async def purge_backlog(intent) -> int:
+    async def purge_backlog(intent) -> int | None:
         return await purge_source_tasks(
             intent.user_id,
             intent.window_id,
             intent.thread_id,
             intent.session_id,
             intent.snapshot_offset,
+            intent.chat_id,
         )
 
     async def send_skip_notice(intent) -> None:

--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -252,7 +252,19 @@ async def start_session_monitor(application: Application) -> SessionMonitor:
     async def send_skip_notice(intent) -> None:
         await enqueue_backlog_skip_notice(client, intent)
 
-    monitor.set_skip_callbacks(purge=purge_backlog, notice=send_skip_notice)
+    def validate_skip(intent) -> bool:
+        return (
+            thread_router.resolve_window_for_thread(
+                intent.user_id, intent.thread_id, intent.chat_id
+            )
+            == intent.window_id
+        )
+
+    monitor.set_skip_callbacks(
+        purge=purge_backlog,
+        notice=send_skip_notice,
+        validate=validate_skip,
+    )
 
     async def new_window_callback(event: NewWindowEvent) -> None:
         await _handle_new_window(event, client)

--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -231,6 +231,28 @@ async def start_session_monitor(application: Application) -> SessionMonitor:
 
     monitor.set_message_callback(message_callback)
 
+    # Keep queue ownership at the bootstrap boundary: the monitor owns durable
+    # watermarks while the queue owns source-scoped task retirement and notice I/O.
+    # Lazy: messaging pipeline imports status handlers during queue dispatch.
+    from .handlers.messaging_pipeline.message_queue import purge_source_tasks
+
+    # Lazy: message routing imports monitor NewMessage for transcript dispatch.
+    from .handlers.messaging_pipeline.message_routing import enqueue_backlog_skip_notice
+
+    async def purge_backlog(intent) -> int:
+        return await purge_source_tasks(
+            intent.user_id,
+            intent.window_id,
+            intent.thread_id,
+            intent.session_id,
+            intent.snapshot_offset,
+        )
+
+    async def send_skip_notice(intent) -> None:
+        await enqueue_backlog_skip_notice(client, intent)
+
+    monitor.set_skip_callbacks(purge=purge_backlog, notice=send_skip_notice)
+
     async def new_window_callback(event: NewWindowEvent) -> None:
         await _handle_new_window(event, client)
 

--- a/src/ccgram/handlers/callback_data.py
+++ b/src/ccgram/handlers/callback_data.py
@@ -65,6 +65,9 @@ CB_STATUS_SCREENSHOT = "st:ss:"  # st:ss:<window_id>
 CB_STATUS_RECALL = "st:rc:"  # st:rc:<window_id>:<history_index>
 CB_STATUS_LAST_REPLY = "st:lr:"  # st:lr:<window_id>
 CB_STATUS_GET_FILE = "st:gf:"  # st:gf:<window_id>
+CB_STATUS_BACKLOG_JUMP = "st:bl:"  # st:bl:<window_id> (opens confirmation)
+CB_STATUS_BACKLOG_CONFIRM = "st:blok:"  # st:blok:<window_id>
+CB_STATUS_BACKLOG_CANCEL = "st:blx:"  # st:blx:<window_id>
 
 # Recovery UI (dead window)
 CB_RECOVERY_FRESH = "rec:f:"  # rec:f:<window_id>

--- a/src/ccgram/handlers/messaging_pipeline/backlog.py
+++ b/src/ccgram/handlers/messaging_pipeline/backlog.py
@@ -1,0 +1,35 @@
+"""Queue-backlog telemetry boundary for status presentation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BacklogSnapshot:
+    """Pending source work and its most recently observed delivery lag."""
+
+    pending_count: int
+    oldest_age_seconds: float
+    delivery_lag_seconds: float | None
+
+
+_snapshot_provider: Callable[[int, str, int | None], BacklogSnapshot] | None = None
+
+
+def register_snapshot_provider(
+    provider: Callable[[int, str, int | None], BacklogSnapshot],
+) -> None:
+    """Install the queue-owned telemetry provider without a status back-edge."""
+    global _snapshot_provider
+    _snapshot_provider = provider
+
+
+def get_backlog_snapshot(
+    user_id: int, window_id: str, thread_id: int | None
+) -> BacklogSnapshot:
+    """Return queue telemetry, or an empty snapshot before queue initialization."""
+    if _snapshot_provider is None:
+        return BacklogSnapshot(0, 0.0, None)
+    return _snapshot_provider(user_id, window_id, thread_id)

--- a/src/ccgram/handlers/messaging_pipeline/message_queue.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_queue.py
@@ -389,7 +389,7 @@ async def _merge_content_tasks(
     """
     merged_parts = list(first.parts)
     merged_receipts = list(first.delivery_receipts)
-    current_length = sum(len(p) for p in merged_parts)
+    current_length = sum(utf16_len(part) for part in merged_parts)
     oldest_enqueued_monotonic = first.enqueued_monotonic
     latest_source_checkpoint = first.source_checkpoint
     merge_count = 0
@@ -404,9 +404,9 @@ async def _merge_content_tasks(
                 break
 
             assert isinstance(task, ContentTask)
-            task_length = sum(len(p) for p in task.parts)
+            task_length = sum(utf16_len(part) for part in task.parts)
             if (
-                current_length + len(_TEXT_BATCH_SEPARATOR) + task_length
+                current_length + utf16_len(_TEXT_BATCH_SEPARATOR) + task_length
                 > MERGE_MAX_LENGTH
             ):
                 remaining = items[i:]
@@ -414,7 +414,7 @@ async def _merge_content_tasks(
 
             merged_parts.extend(task.parts)
             merged_receipts.extend(task.delivery_receipts)
-            current_length += len(_TEXT_BATCH_SEPARATOR) + task_length
+            current_length += utf16_len(_TEXT_BATCH_SEPARATOR) + task_length
             oldest_enqueued_monotonic = min(
                 oldest_enqueued_monotonic, task.enqueued_monotonic
             )

--- a/src/ccgram/handlers/messaging_pipeline/message_queue.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_queue.py
@@ -14,9 +14,12 @@ from io import BytesIO
 from typing import assert_never
 
 import structlog
+from telegram import MessageEntity
 from telegram.error import RetryAfter, TelegramError
+from telegramify_markdown import utf16_len
 
 from ...config import config
+from ...entity_formatting import convert_to_entities
 from ...delivery_contract import (
     DeliveryOutcome,
     DeliveryReceipt,
@@ -42,6 +45,7 @@ from ..status.status_bubble import (
 from .message_sender import (
     edit_with_fallback,
     rate_limit_send,
+    rate_limit_send_formatted_message,
     rate_limit_send_message,
     send_kwargs,
 )
@@ -79,6 +83,7 @@ __all__ = [
 ]
 
 MERGE_MAX_LENGTH = 3800  # Leave room within Telegram's 4096 char message limit
+_TEXT_BATCH_SEPARATOR = "\n\n"
 _QUEUE_RETRY_BACKOFF_BASE_SECONDS = 2.0
 _QUEUE_RETRY_BACKOFF_MAX_SECONDS = 60.0
 _QUEUE_RETRY_JITTER_MAX_SECONDS = 1.0
@@ -236,18 +241,43 @@ def _drain_queue(queue: asyncio.Queue[MessageTask]) -> list[MessageTask]:
 
 
 def _can_merge_tasks(base: ContentTask, candidate: MessageTask) -> bool:
-    """Check if two content tasks can be merged."""
+    """Return whether two tasks can safely share one Telegram text message.
+
+    Batching is deliberately narrower than generic content merging.  Only
+    one-part, non-empty ``text`` tasks qualify, so tool edits, status updates,
+    paginated messages, and TTS voice attachments retain their message
+    boundaries.
+    """
     if not isinstance(candidate, ContentTask):
         return False
-    if base.window_id != candidate.window_id:
+    if (
+        base.window_id != candidate.window_id
+        or base.thread_id != candidate.thread_id
+        or base.chat_id != candidate.chat_id
+        or base.role != candidate.role
+        # A missing chat ID follows the legacy status-conversion path, which
+        # may edit an existing bubble instead of sending a message.
+        or base.chat_id is None
+    ):
         return False
-    # Never merge across topics or chats: identical thread IDs can exist in
-    # different chats, and merged text is delivered to a single destination.
-    if base.thread_id != candidate.thread_id or base.chat_id != candidate.chat_id:
+    if (
+        base.content_type != "text"
+        or candidate.content_type != "text"
+        or base.tool_use_id is not None
+        or candidate.tool_use_id is not None
+        or base.tool_name is not None
+        or candidate.tool_name is not None
+        or base.is_text_batch
+        or candidate.is_text_batch
+        or len(base.parts) != 1
+        or len(candidate.parts) != 1
+        or not base.parts[0].strip()
+        or not candidate.parts[0].strip()
+    ):
         return False
-    if base.content_type in ("tool_use", "tool_result"):
-        return False
-    return candidate.content_type not in ("tool_use", "tool_result")
+    # A text task can produce a voice message when TTS is configured.  Keep
+    # those media deliveries one-for-one with their source task.
+    return not _should_send_tts(base)
 
 
 async def _merge_content_tasks(
@@ -281,13 +311,16 @@ async def _merge_content_tasks(
 
             assert isinstance(task, ContentTask)
             task_length = sum(len(p) for p in task.parts)
-            if current_length + task_length > MERGE_MAX_LENGTH:
+            if (
+                current_length + len(_TEXT_BATCH_SEPARATOR) + task_length
+                > MERGE_MAX_LENGTH
+            ):
                 remaining = items[i:]
                 break
 
             merged_parts.extend(task.parts)
             merged_receipts.extend(task.delivery_receipts)
-            current_length += task_length
+            current_length += len(_TEXT_BATCH_SEPARATOR) + task_length
             merge_count += 1
 
         for item in remaining:
@@ -307,6 +340,7 @@ async def _merge_content_tasks(
             thread_id=first.thread_id,
             chat_id=first.chat_id,
             delivery_receipts=tuple(merged_receipts),
+            is_text_batch=True,
         ),
         merge_count,
     )
@@ -551,6 +585,78 @@ async def _message_queue_worker(client: TelegramClient, user_id: int) -> None:
             )
 
 
+def _render_text_batch(parts: tuple[str, ...]) -> tuple[str, list[MessageEntity]]:
+    """Render text tasks independently, then combine their Telegram payloads.
+
+    Rendering raw markdown only after concatenation lets syntax opened in one
+    task affect another task.  Converting each source task first preserves the
+    exact entities it would have received alone, while shifted UTF-16 offsets
+    make the combined API call valid.
+    """
+    plain_parts: list[str] = []
+    entities: list[MessageEntity] = []
+    offset = 0
+    for raw_part in parts:
+        plain, part_entities = convert_to_entities(raw_part)
+        if plain_parts:
+            plain_parts.append(_TEXT_BATCH_SEPARATOR)
+            offset += utf16_len(_TEXT_BATCH_SEPARATOR)
+        plain_parts.append(plain)
+        for entity in part_entities:
+            entities.append(
+                MessageEntity(
+                    type=entity.type,
+                    offset=entity.offset + offset,
+                    length=entity.length,
+                    url=entity.url,
+                    language=entity.language,
+                    custom_emoji_id=entity.custom_emoji_id,
+                )
+            )
+        offset += utf16_len(plain)
+    return "".join(plain_parts), entities
+
+
+async def _process_text_batch(
+    client: TelegramClient, chat_id: int, task: ContentTask
+) -> DeliveryOutcome:
+    """Deliver a rendered text batch as one Telegram message."""
+    plain_text, entities = _render_text_batch(task.parts)
+    sent = await rate_limit_send_formatted_message(
+        client,
+        chat_id,
+        plain_text,
+        entities,
+        **send_kwargs(task.thread_id),
+    )
+    return DeliveryOutcome.DELIVERED if sent else DeliveryOutcome.FAILED
+
+
+async def _try_edit_tool_result(
+    client: TelegramClient,
+    user_id: int,
+    chat_id: int,
+    tkey: int,
+    task: ContentTask,
+) -> bool:
+    """Edit a prior tool-use message when this task supplies its result."""
+    if task.content_type != "tool_result" or not task.tool_use_id:
+        return False
+    edit_msg_id = _tool_msg_ids.pop((task.tool_use_id, user_id, tkey), None)
+    if edit_msg_id is None:
+        return False
+    await clear_status_message(client, user_id, tkey)
+    success = await edit_with_fallback(
+        client,
+        chat_id,
+        edit_msg_id,
+        "\n\n".join(task.parts),
+    )
+    if not success:
+        logger.debug("Failed to edit tool msg %s, sending new", edit_msg_id)
+    return success
+
+
 async def _process_content_task(
     client: TelegramClient, user_id: int, task: ContentTask
 ) -> DeliveryOutcome:
@@ -558,21 +664,11 @@ async def _process_content_task(
     tkey = thread_key(task.thread_id)
     chat_id = task.chat_id or thread_router.resolve_chat_id(user_id, task.thread_id)
 
-    if task.content_type == "tool_result" and task.tool_use_id:
-        _tkey = (task.tool_use_id, user_id, tkey)
-        edit_msg_id = _tool_msg_ids.pop(_tkey, None)
-        if edit_msg_id is not None:
-            await clear_status_message(client, user_id, tkey)
-            full_text = "\n\n".join(task.parts)
-            success = await edit_with_fallback(
-                client,
-                chat_id,
-                edit_msg_id,
-                full_text,
-            )
-            if success:
-                return DeliveryOutcome.DELIVERED
-            logger.debug("Failed to edit tool msg %s, sending new", edit_msg_id)
+    if task.is_text_batch:
+        return await _process_text_batch(client, chat_id, task)
+
+    if await _try_edit_tool_result(client, user_id, chat_id, tkey, task):
+        return DeliveryOutcome.DELIVERED
 
     first_part = True
     last_msg_id: int | None = None

--- a/src/ccgram/handlers/messaging_pipeline/message_queue.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_queue.py
@@ -9,6 +9,7 @@ tool-use batching lives in ``tool_batch``.
 import asyncio
 import contextlib
 import random
+import time
 from dataclasses import dataclass
 from io import BytesIO
 from typing import assert_never
@@ -42,6 +43,7 @@ from ..status.status_bubble import (
     process_status_clear,
     process_status_update,
 )
+from .backlog import BacklogSnapshot, register_snapshot_provider
 from .message_sender import (
     edit_with_fallback,
     rate_limit_send,
@@ -96,6 +98,90 @@ _queue_locks: dict[int, asyncio.Lock] = {}  # Protect drain/refill operations
 # In-flight sends: incremented around each task a worker is actively
 # processing. "Queue empty" alone does not mean delivered.
 _inflight_count = 0
+_inflight_tasks: dict[int, ContentTask] = {}
+
+# Per source/topic delivery lag, updated only when a content task reaches the
+# Telegram boundary.  It is deliberately in-memory telemetry, not state.
+_delivery_lags: dict[tuple[int, str, int], float] = {}
+
+
+def _get_backlog_snapshot(
+    user_id: int, window_id: str, thread_id: int | None
+) -> BacklogSnapshot:
+    """Return pending count, oldest age, and last delivery lag for one topic."""
+    tkey = thread_key(thread_id)
+    now = time.monotonic()
+    tasks: list[ContentTask] = []
+    queue = _message_queues.get(user_id)
+    if queue is not None:
+        tasks.extend(
+            task
+            for task in getattr(queue, "_queue", ())
+            if isinstance(task, ContentTask)
+            and task.window_id == window_id
+            and thread_key(task.thread_id) == tkey
+            and task.source_session_id is not None
+        )
+    inflight = _inflight_tasks.get(user_id)
+    if (
+        inflight is not None
+        and inflight.window_id == window_id
+        and thread_key(inflight.thread_id) == tkey
+        and inflight.source_session_id is not None
+    ):
+        tasks.append(inflight)
+    oldest = min((task.enqueued_monotonic for task in tasks), default=now)
+    return BacklogSnapshot(
+        pending_count=len(tasks),
+        oldest_age_seconds=max(0.0, now - oldest) if tasks else 0.0,
+        delivery_lag_seconds=_delivery_lags.get((user_id, window_id, tkey)),
+    )
+
+
+register_snapshot_provider(_get_backlog_snapshot)
+
+
+async def purge_source_tasks(
+    user_id: int,
+    window_id: str,
+    thread_id: int | None,
+    source_session_id: str,
+    snapshot_offset: int,
+) -> int:
+    """Retire queued (never in-flight) source tasks through a frozen offset.
+
+    Callers persist their skip barrier before this operation.  Each removed
+    receipt is intentionally dropped so it cannot block the later notice
+    receipt, while an in-flight send is left alone rather than cancelled.
+    """
+    queue = _message_queues.get(user_id)
+    lock = _queue_locks.get(user_id)
+    if queue is None or lock is None:
+        return 0
+    tkey = thread_key(thread_id)
+    removed: list[ContentTask] = []
+    async with lock:
+        retained: list[MessageTask] = []
+        for task in _drain_queue(queue):
+            if (
+                isinstance(task, ContentTask)
+                and task.window_id == window_id
+                and thread_key(task.thread_id) == tkey
+                and task.source_session_id == source_session_id
+                and task.source_checkpoint is not None
+                and task.source_checkpoint <= snapshot_offset
+            ):
+                removed.append(task)
+                queue.task_done()
+            else:
+                retained.append(task)
+        for task in retained:
+            queue.put_nowait(task)
+            queue.task_done()
+    for task in removed:
+        for receipt in task.delivery_receipts:
+            receipt.settle(DeliveryOutcome.INTENTIONALLY_DROPPED)
+    return len(removed)
 
 
 class DispatchResult(int):
@@ -260,8 +346,14 @@ def _can_merge_tasks(base: ContentTask, candidate: MessageTask) -> bool:
         or base.chat_id is None
     ):
         return False
+    # A skip notice retains its own delivery boundary. Transcript tasks may
+    # have different checkpoints, but only tasks from the same source can be
+    # acknowledged together.
     if (
-        base.content_type != "text"
+        base.is_backlog_notice
+        or candidate.is_backlog_notice
+        or base.source_session_id != candidate.source_session_id
+        or base.content_type != "text"
         or candidate.content_type != "text"
         or base.tool_use_id is not None
         or candidate.tool_use_id is not None
@@ -298,6 +390,8 @@ async def _merge_content_tasks(
     merged_parts = list(first.parts)
     merged_receipts = list(first.delivery_receipts)
     current_length = sum(len(p) for p in merged_parts)
+    oldest_enqueued_monotonic = first.enqueued_monotonic
+    latest_source_checkpoint = first.source_checkpoint
     merge_count = 0
 
     async with lock:
@@ -321,6 +415,14 @@ async def _merge_content_tasks(
             merged_parts.extend(task.parts)
             merged_receipts.extend(task.delivery_receipts)
             current_length += len(_TEXT_BATCH_SEPARATOR) + task_length
+            oldest_enqueued_monotonic = min(
+                oldest_enqueued_monotonic, task.enqueued_monotonic
+            )
+            if task.source_checkpoint is not None:
+                latest_source_checkpoint = max(
+                    latest_source_checkpoint or task.source_checkpoint,
+                    task.source_checkpoint,
+                )
             merge_count += 1
 
         for item in remaining:
@@ -341,6 +443,9 @@ async def _merge_content_tasks(
             chat_id=first.chat_id,
             delivery_receipts=tuple(merged_receipts),
             is_text_batch=True,
+            source_session_id=first.source_session_id,
+            source_checkpoint=latest_source_checkpoint,
+            enqueued_monotonic=oldest_enqueued_monotonic,
         ),
         merge_count,
     )
@@ -505,6 +610,21 @@ def _delivery_receipts_for_settlement(
     return list(unique.values())
 
 
+def _mark_task_inflight(user_id: int, task: MessageTask) -> None:
+    """Expose a content task to source-scoped backlog telemetry."""
+    if isinstance(task, ContentTask):
+        _inflight_tasks[user_id] = task
+
+
+def _record_content_delivery(user_id: int, task: MessageTask) -> None:
+    """Settle in-memory delivery-lag telemetry after a worker attempt."""
+    if isinstance(task, ContentTask):
+        _inflight_tasks.pop(user_id, None)
+        _delivery_lags[(user_id, task.window_id, thread_key(task.thread_id))] = max(
+            0.0, time.monotonic() - task.enqueued_monotonic
+        )
+
+
 async def _message_queue_worker(client: TelegramClient, user_id: int) -> None:
     global _inflight_count
     """Process message tasks for a user sequentially."""
@@ -516,6 +636,7 @@ async def _message_queue_worker(client: TelegramClient, user_id: int) -> None:
         try:
             task = await queue.get()
             _inflight_count += 1
+            _mark_task_inflight(user_id, task)
             outcome = DeliveryOutcome.DELIVERED
             merged_receipts: tuple[DeliveryReceipt, ...] = ()
             try:
@@ -573,6 +694,7 @@ async def _message_queue_worker(client: TelegramClient, user_id: int) -> None:
             finally:
                 for receipt in _delivery_receipts_for_settlement(task, merged_receipts):
                     receipt.settle(outcome)
+                _record_content_delivery(user_id, task)
                 _inflight_count -= 1
                 queue.task_done()
         except asyncio.CancelledError:
@@ -726,10 +848,13 @@ async def enqueue_content_message(
     role: MessageRole = "assistant",
     thread_id: int | None = None,
     chat_id: int | None = None,
-) -> None:
-    """Enqueue a content message task."""
+    source_session_id: str | None = None,
+    source_checkpoint: int | None = None,
+    is_backlog_notice: bool = False,
+) -> bool:
+    """Enqueue a content message task and report whether it entered the queue."""
     if _is_ghost_window_task_at_enqueue(window_id):
-        return
+        return False
     queue = get_or_create_queue(client, user_id)
 
     receipt = get_active_delivery_receipt()
@@ -745,8 +870,16 @@ async def enqueue_content_message(
         thread_id=thread_id,
         chat_id=chat_id,
         delivery_receipts=(receipt,) if receipt is not None else (),
+        source_session_id=source_session_id,
+        source_checkpoint=(
+            source_checkpoint
+            if source_checkpoint is not None
+            else (receipt.checkpoint if receipt is not None else None)
+        ),
+        is_backlog_notice=is_backlog_notice,
     )
     queue.put_nowait(task)
+    return True
 
 
 async def enqueue_status_update(
@@ -814,5 +947,7 @@ async def shutdown_workers(drain_timeout: float = 10.0) -> None:
     _queue_workers.clear()
     _message_queues.clear()
     _queue_locks.clear()
+    _inflight_tasks.clear()
+    _delivery_lags.clear()
     clear_all_batches()
     logger.info("Message queue workers stopped")

--- a/src/ccgram/handlers/messaging_pipeline/message_queue.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_queue.py
@@ -796,6 +796,21 @@ async def _process_content_task(
     client: TelegramClient, user_id: int, task: ContentTask
 ) -> DeliveryOutcome:
     """Process a content message task and report whether it reached Telegram."""
+    if task.is_backlog_notice and (
+        task.chat_id is None
+        or thread_router.resolve_window_for_thread(
+            user_id, task.thread_id, task.chat_id
+        )
+        != task.window_id
+    ):
+        logger.warning(
+            "Dropping stale backlog skip notice",
+            user_id=user_id,
+            window_id=task.window_id,
+            thread_id=task.thread_id,
+        )
+        return DeliveryOutcome.FAILED
+
     tkey = thread_key(task.thread_id)
     chat_id = task.chat_id or thread_router.resolve_chat_id(user_id, task.thread_id)
 

--- a/src/ccgram/handlers/messaging_pipeline/message_queue.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_queue.py
@@ -147,7 +147,8 @@ async def purge_source_tasks(
     thread_id: int | None,
     source_session_id: str,
     snapshot_offset: int,
-) -> int:
+    chat_id: int | None = None,
+) -> int | None:
     """Retire queued (never in-flight) source tasks through a frozen offset.
 
     Callers persist their skip barrier before this operation.  Each removed
@@ -161,6 +162,18 @@ async def purge_source_tasks(
     tkey = thread_key(thread_id)
     removed: list[ContentTask] = []
     async with lock:
+        if (
+            chat_id is not None
+            and thread_router.resolve_window_for_thread(user_id, thread_id, chat_id)
+            != window_id
+        ):
+            logger.warning(
+                "Skipping stale backlog purge for rebound topic",
+                user_id=user_id,
+                window_id=window_id,
+                thread_id=thread_id,
+            )
+            return None
         retained: list[MessageTask] = []
         for task in _drain_queue(queue):
             if (

--- a/src/ccgram/handlers/messaging_pipeline/message_routing.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_routing.py
@@ -125,6 +125,27 @@ async def _handle_assistant_stream(
     return True
 
 
+async def enqueue_backlog_skip_notice(client: TelegramClient, intent: object) -> None:
+    """Queue a visible, receipt-tracked notice for a confirmed skipped range."""
+    snapshot = int(getattr(intent, "snapshot_offset"))
+    start = int(getattr(intent, "range_start"))
+    count = int(getattr(intent, "skipped_count"))
+    enqueued = await enqueue_content_message(
+        client=client,
+        user_id=int(getattr(intent, "user_id")),
+        window_id=str(getattr(intent, "window_id")),
+        parts=[
+            f"⏭ Skipped {count} queued transcript item(s) for live view "
+            f"(bytes {start}–{snapshot}). Raw transcript retained."
+        ],
+        thread_id=getattr(intent, "thread_id"),
+        chat_id=int(getattr(intent, "chat_id")),
+        is_backlog_notice=True,
+    )
+    if not enqueued:
+        raise RuntimeError("backlog skip notice could not enter the delivery queue")
+
+
 async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  # noqa: C901, PLR0912
     """Handle a new assistant message — enqueue for sequential processing.
 
@@ -210,6 +231,7 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
                 role=msg.role,  # type: ignore[arg-type]  # NewMessage.role is str, narrows at runtime
                 thread_id=thread_id,
                 chat_id=chat_id,
+                source_session_id=msg.session_id,
             )
 
             await _update_window_offset(user_id, window_id)

--- a/src/ccgram/handlers/messaging_pipeline/message_sender.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_sender.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from telegram import CallbackQuery, LinkPreviewOptions, Message, ReactionTypeEmoji
 from telegram.error import BadRequest, RetryAfter, TelegramError
+from telegramify_markdown import utf16_len
 
 from ...config import config
 from ...entity_formatting import convert_to_entities
@@ -115,13 +116,24 @@ async def rate_limit_send(chat_id: int) -> None:
 def _cap_to_telegram_limit(
     plain_text: str, entities: list[Any]
 ) -> tuple[str, list[Any]]:
-    """Truncate plain_text + drop overflow entities so a single send fits Telegram's limit."""
-    if len(plain_text) <= TELEGRAM_MAX_MESSAGE_LENGTH:
+    """Truncate text and entities to Telegram's UTF-16 message limit."""
+    if utf16_len(plain_text) <= TELEGRAM_MAX_MESSAGE_LENGTH:
         return plain_text, entities
+
     ellipsis = "…"
-    cap = TELEGRAM_MAX_MESSAGE_LENGTH - len(ellipsis)
-    truncated = plain_text[:cap] + ellipsis
-    kept = [e for e in entities if e.offset + e.length <= cap]
+    budget = TELEGRAM_MAX_MESSAGE_LENGTH - utf16_len(ellipsis)
+    used = 0
+    end = 0
+    for end, char in enumerate(plain_text):
+        char_units = utf16_len(char)
+        if used + char_units > budget:
+            break
+        used += char_units
+    else:
+        end = len(plain_text)
+
+    truncated = plain_text[:end] + ellipsis
+    kept = [entity for entity in entities if entity.offset + entity.length <= used]
     return truncated, kept
 
 

--- a/src/ccgram/handlers/messaging_pipeline/message_sender.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_sender.py
@@ -51,6 +51,7 @@ __all__ = [
     "edit_with_fallback",
     "is_thread_gone",
     "rate_limit_send",
+    "rate_limit_send_formatted_message",
     "rate_limit_send_message",
     "react",
     "retry_after_seconds",
@@ -183,14 +184,49 @@ async def _send_with_fallback(
 
     Returns the sent Message on success, None on failure.
     """
+    plain_text, entities = convert_to_entities(text)
+    return await _send_formatted_with_fallback(
+        client, chat_id, plain_text, entities, **kwargs
+    )
+
+
+async def _send_formatted_with_fallback(
+    client: TelegramClient,
+    chat_id: int,
+    plain_text: str,
+    entities: list[Any],
+    **kwargs: Any,
+) -> Message | None:
+    """Send already-rendered text and entities with the normal plain fallback."""
     kwargs.setdefault("link_preview_options", NO_LINK_PREVIEW)
+    if not plain_text.strip():
+        return None
+
+    plain_text, entities = _cap_to_telegram_limit(plain_text, entities)
 
     async def _send(text: str, **kw: Any) -> Message:
         return await client.send_message(chat_id=chat_id, text=text, **kw)
 
-    return await _with_entity_fallback(
-        _send, text, f"send message to {chat_id}", **kwargs
-    )
+    # Keep the two-phase contract used for single-message sends, but do not
+    # reparse a batch: each constituent was rendered independently to prevent
+    # markdown opened in one task from changing a later task's formatting.
+    last_error: TelegramError | None = None
+    for phase_entities in (entities, None):
+        send_kwargs = {**kwargs}
+        if phase_entities is not None:
+            send_kwargs["entities"] = phase_entities
+        try:
+            return await _send(plain_text, **send_kwargs)
+        except RetryAfter:
+            raise
+        except TelegramError as exc:
+            if is_thread_gone(exc):
+                return None
+            last_error = exc
+
+    if last_error is not None:
+        logger.warning("Failed to send message to %s: %s", chat_id, last_error)
+    return None
 
 
 async def rate_limit_send_message(
@@ -206,6 +242,20 @@ async def rate_limit_send_message(
     """
     await rate_limit_send(chat_id)
     return await _send_with_fallback(client, chat_id, text, **kwargs)
+
+
+async def rate_limit_send_formatted_message(
+    client: TelegramClient,
+    chat_id: int,
+    plain_text: str,
+    entities: list[Any],
+    **kwargs: Any,
+) -> Message | None:
+    """Rate-limit and send independently rendered text without reparsing it."""
+    await rate_limit_send(chat_id)
+    return await _send_formatted_with_fallback(
+        client, chat_id, plain_text, entities, **kwargs
+    )
 
 
 async def safe_reply(message: Message, text: str, **kwargs: Any) -> Message | None:

--- a/src/ccgram/handlers/messaging_pipeline/message_task.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_task.py
@@ -5,6 +5,7 @@ Three frozen dataclasses replace the monolithic ``MessageTask`` that lived in
 keeping the dependency graph acyclic.
 """
 
+import time
 from dataclasses import dataclass, field
 from typing import Literal, TypeAlias
 
@@ -34,6 +35,11 @@ class ContentTask:
     # Queue-internal marker: each part is an independently rendered text task
     # which may be delivered together in one Telegram message.
     is_text_batch: bool = field(compare=False, hash=False, default=False)
+    # Source identity makes a confirmed backlog skip narrowly purgeable.
+    source_session_id: str | None = None
+    source_checkpoint: int | None = None
+    enqueued_monotonic: float = field(default_factory=time.monotonic, compare=False)
+    is_backlog_notice: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ccgram/handlers/messaging_pipeline/message_task.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_task.py
@@ -31,6 +31,9 @@ class ContentTask:
     delivery_receipts: tuple[DeliveryReceipt, ...] = field(
         compare=False, hash=False, default=()
     )
+    # Queue-internal marker: each part is an independently rendered text task
+    # which may be delivered together in one Telegram message.
+    is_text_batch: bool = field(compare=False, hash=False, default=False)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/ccgram/handlers/polling/window_tick/apply.py
+++ b/src/ccgram/handlers/polling/window_tick/apply.py
@@ -398,7 +398,11 @@ async def _handle_dead_window_notification(
                     window_id=wid,
                     window_dead=True,
                 )
-                thread_router.unbind_thread(user_id, thread_id)
+                thread_router.unbind_thread(
+                    user_id,
+                    thread_id,
+                    retirement_reason="remote_deleted",
+                )
                 logger.info(
                     "Topic deleted: unbound window %s for thread %d, user %d",
                     wid,

--- a/src/ccgram/handlers/recovery/recovery_banner.py
+++ b/src/ccgram/handlers/recovery/recovery_banner.py
@@ -251,7 +251,12 @@ async def _create_and_bind_window(
 
     Returns True on success, False on failure.
     """
-    thread_router.unbind_thread(user_id, thread_id)
+    thread_router.unbind_thread(
+        user_id,
+        thread_id,
+        retirement_reason="system_replacement",
+        cleanup_eligible=True,
+    )
     # Lazy: polling_state → recovery_banner via callback_registry
     # side effects.
     # Lazy: polling.polling_state pulls heavy strategy stack; defer per-call

--- a/src/ccgram/handlers/recovery/resume_command.py
+++ b/src/ccgram/handlers/recovery/resume_command.py
@@ -378,7 +378,12 @@ async def _create_resume_window(
     )
 
     if old_window_id:
-        thread_router.unbind_thread(user_id, thread_id)
+        thread_router.unbind_thread(
+            user_id,
+            thread_id,
+            retirement_reason="system_replacement",
+            cleanup_eligible=True,
+        )
         # Lazy: polling_state cycle — same path as recovery_callbacks.
         from ..polling.polling_state import lifecycle_strategy
 

--- a/src/ccgram/handlers/sessions_dashboard.py
+++ b/src/ccgram/handlers/sessions_dashboard.py
@@ -175,7 +175,12 @@ async def handle_sessions_kill_confirm(
     for uid, tid, bound_wid in list(thread_router.iter_thread_bindings()):
         if bound_wid == window_id:
             await clear_topic_state(uid, tid, client, window_id=window_id)
-            thread_router.unbind_thread(uid, tid)
+            thread_router.unbind_thread(
+                uid,
+                tid,
+                retirement_reason="stale_owned_binding",
+                cleanup_eligible=True,
+            )
 
     logger.info(
         "sessions_kill_confirm: killed window %s (%s), user=%d",

--- a/src/ccgram/handlers/status/status_bar_actions.py
+++ b/src/ccgram/handlers/status/status_bar_actions.py
@@ -21,6 +21,7 @@ import structlog
 from telegram import (
     CallbackQuery,
     InlineKeyboardButton,
+    InlineKeyboardMarkup,
     InputMediaDocument,
     Update,
     WebAppInfo,
@@ -38,13 +39,16 @@ from ..telegram_origin import send_telegram_to_window
 from ...topic_state_registry import topic_state
 from ..callback_data import (
     CB_KEYS_PREFIX,
+    CB_STATUS_BACKLOG_CANCEL,
+    CB_STATUS_BACKLOG_CONFIRM,
+    CB_STATUS_BACKLOG_JUMP,
     CB_STATUS_ESC,
     CB_STATUS_GET_FILE,
     CB_STATUS_LAST_REPLY,
     CB_STATUS_RECALL,
 )
 from ..callback_helpers import get_thread_id, parse_target, user_owns_window
-from ..callback_tokens import resolve_callback_data
+from ..callback_tokens import compact_callback_data, resolve_callback_data
 from ..callback_registry import register
 from ..live.screenshot_callbacks import (
     KEY_LABELS,
@@ -359,6 +363,101 @@ async def _handle_get_file(
     await query.answer()
 
 
+async def _handle_backlog_jump(
+    query: CallbackQuery, user_id: int, data: str, update: Update
+) -> None:
+    """Ask for explicit confirmation before skipping one severe source backlog."""
+    window_id = data[len(CB_STATUS_BACKLOG_JUMP) :]
+    chat_id = query.message.chat.id if query.message else None
+    if not user_owns_window(user_id, window_id, chat_id):
+        await query.answer("Not your session", show_alert=True)
+        return
+    thread_id = get_thread_id(update)
+    if thread_id is None or chat_id is None:
+        await query.answer("Use in a topic", show_alert=True)
+        return
+    # Lazy: status_bubble loads this module to build its optional dashboard row.
+    from .status_bubble import (
+        SEVERE_BACKLOG_AGE_SECONDS,
+        SEVERE_BACKLOG_COUNT,
+    )
+
+    # Lazy: messaging pipeline is loaded only when a severe action is tapped.
+    from ..messaging_pipeline.backlog import get_backlog_snapshot
+
+    snapshot = get_backlog_snapshot(user_id, window_id, thread_id)
+    if (
+        snapshot.pending_count < SEVERE_BACKLOG_COUNT
+        and snapshot.oldest_age_seconds < SEVERE_BACKLOG_AGE_SECONDS
+    ):
+        await query.answer("Backlog is no longer severe", show_alert=True)
+        return
+    keyboard = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    "⏭ Confirm jump to live",
+                    callback_data=compact_callback_data(
+                        CB_STATUS_BACKLOG_CONFIRM,
+                        f"{CB_STATUS_BACKLOG_CONFIRM}{window_id}",
+                        window_id,
+                    ),
+                ),
+                InlineKeyboardButton(
+                    "Cancel",
+                    callback_data=compact_callback_data(
+                        CB_STATUS_BACKLOG_CANCEL,
+                        f"{CB_STATUS_BACKLOG_CANCEL}{window_id}",
+                        window_id,
+                    ),
+                ),
+            ]
+        ]
+    )
+    await PTBTelegramClient(query.get_bot()).send_message(
+        chat_id=chat_id,
+        text=(
+            f"Queue has {snapshot.pending_count} pending item(s). Jump to live and "
+            "skip this source's queued range? The raw transcript is retained."
+        ),
+        message_thread_id=thread_id,
+        reply_markup=keyboard,
+    )
+    await query.answer("Confirm jump to live")
+
+
+async def _handle_backlog_confirm(
+    query: CallbackQuery, user_id: int, data: str, update: Update
+) -> None:
+    """Persist the source barrier and queue its visible skipped-range notice."""
+    window_id = data[len(CB_STATUS_BACKLOG_CONFIRM) :]
+    chat_id = query.message.chat.id if query.message else None
+    if not user_owns_window(user_id, window_id, chat_id):
+        await query.answer("Not your session", show_alert=True)
+        return
+    thread_id = get_thread_id(update)
+    if thread_id is None or chat_id is None:
+        await query.answer("Use in a topic", show_alert=True)
+        return
+    # Lazy: session_monitor reaches handler routing through bootstrap callbacks.
+    from ...session_monitor import get_active_monitor
+
+    monitor = get_active_monitor()
+    if monitor is None:
+        await query.answer("Monitor unavailable", show_alert=True)
+        return
+    intent = await monitor.request_backlog_skip(user_id, window_id, thread_id, chat_id)
+    if intent is None:
+        await query.answer("Backlog changed; try again", show_alert=True)
+        return
+    await query.answer(f"Jumping to live ({intent.skipped_count} queued item(s))")
+
+
+async def _handle_backlog_cancel(query: CallbackQuery) -> None:
+    """Leave all source watermarks and queued work unchanged."""
+    await query.answer("Jump to live cancelled")
+
+
 async def _handle_status_bar_action(
     query: CallbackQuery,
     user_id: int,
@@ -371,6 +470,8 @@ async def _handle_status_bar_action(
         CB_STATUS_RECALL: _handle_status_recall,
         CB_KEYS_PREFIX: _handle_keys,
         CB_STATUS_LAST_REPLY: _handle_last_reply,
+        CB_STATUS_BACKLOG_JUMP: _handle_backlog_jump,
+        CB_STATUS_BACKLOG_CONFIRM: _handle_backlog_confirm,
     }
     for prefix, handler in with_update.items():
         if data.startswith(prefix):
@@ -379,6 +480,10 @@ async def _handle_status_bar_action(
 
     if data.startswith(CB_STATUS_ESC):
         await _handle_status_esc(query, user_id, data)
+        return
+
+    if data.startswith(CB_STATUS_BACKLOG_CANCEL):
+        await _handle_backlog_cancel(query)
         return
 
     if data.startswith(CB_STATUS_GET_FILE):
@@ -392,6 +497,9 @@ async def _handle_status_bar_action(
     CB_KEYS_PREFIX,
     CB_STATUS_LAST_REPLY,
     CB_STATUS_GET_FILE,
+    CB_STATUS_BACKLOG_JUMP,
+    CB_STATUS_BACKLOG_CONFIRM,
+    CB_STATUS_BACKLOG_CANCEL,
 )
 async def _dispatch(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query

--- a/src/ccgram/handlers/status/status_bar_actions.py
+++ b/src/ccgram/handlers/status/status_bar_actions.py
@@ -376,6 +376,12 @@ async def _handle_backlog_jump(
     if thread_id is None or chat_id is None:
         await query.answer("Use in a topic", show_alert=True)
         return
+    if (
+        thread_router.resolve_window_for_thread(user_id, thread_id, chat_id)
+        != window_id
+    ):
+        await query.answer("Stale status button", show_alert=True)
+        return
     # Lazy: status_bubble loads this module to build its optional dashboard row.
     from .status_bubble import (
         SEVERE_BACKLOG_AGE_SECONDS,
@@ -438,6 +444,30 @@ async def _handle_backlog_confirm(
     thread_id = get_thread_id(update)
     if thread_id is None or chat_id is None:
         await query.answer("Use in a topic", show_alert=True)
+        return
+    if (
+        thread_router.resolve_window_for_thread(user_id, thread_id, chat_id)
+        != window_id
+    ):
+        await query.answer("Stale status button", show_alert=True)
+        return
+    # Confirmation may sit in Telegram while the queue drains. Recheck the
+    # destructive action's threshold instead of applying a stale decision.
+    # Lazy: status_bubble imports this module to build optional action rows.
+    from .status_bubble import (
+        SEVERE_BACKLOG_AGE_SECONDS,
+        SEVERE_BACKLOG_COUNT,
+    )
+
+    # Lazy: messaging pipeline is loaded only for a confirmed severe action.
+    from ..messaging_pipeline.backlog import get_backlog_snapshot
+
+    snapshot = get_backlog_snapshot(user_id, window_id, thread_id)
+    if (
+        snapshot.pending_count < SEVERE_BACKLOG_COUNT
+        and snapshot.oldest_age_seconds < SEVERE_BACKLOG_AGE_SECONDS
+    ):
+        await query.answer("Backlog is no longer severe", show_alert=True)
         return
     # Lazy: session_monitor reaches handler routing through bootstrap callbacks.
     from ...session_monitor import get_active_monitor

--- a/src/ccgram/handlers/status/status_bubble.py
+++ b/src/ccgram/handlers/status/status_bubble.py
@@ -27,6 +27,7 @@ from ...window_state_ports.pane_state import PaneProjection, list_pane_projectio
 
 from ..callback_tokens import compact_callback_data
 from ..callback_data import (
+    CB_STATUS_BACKLOG_JUMP,
     CB_STATUS_ESC,
     CB_STATUS_GET_FILE,
     CB_STATUS_LAST_REPLY,
@@ -50,6 +51,10 @@ logger = structlog.get_logger()
 
 # Status message tracking: (user_id, thread_key) -> (message_id, window_id, last_text, chat_id)
 _status_msg_info: dict[tuple[int, int], tuple[int, str, str, int]] = {}
+_backlog_status_cache: dict[tuple[int, int, str], tuple[float, str]] = {}
+_BACKLOG_STATUS_THROTTLE_SECONDS = 15.0
+SEVERE_BACKLOG_COUNT = 100
+SEVERE_BACKLOG_AGE_SECONDS = 300.0
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +68,7 @@ def build_status_keyboard(
     *,
     user_id: int | None = None,
     is_group: bool = False,
+    backlog_severe: bool = False,
 ) -> InlineKeyboardMarkup:
     """Build inline keyboard for status messages.
 
@@ -134,6 +140,19 @@ def build_status_keyboard(
             ),
         ]
     )
+    if backlog_severe:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    "⏭ Jump to live",
+                    callback_data=compact_callback_data(
+                        CB_STATUS_BACKLOG_JUMP,
+                        f"{CB_STATUS_BACKLOG_JUMP}{window_id}",
+                        window_id,
+                    ),
+                )
+            ]
+        )
     if user_id is not None and not is_group:
         dashboard = build_dashboard_button(window_id, user_id)
         if dashboard is not None:
@@ -144,6 +163,37 @@ def build_status_keyboard(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def format_backlog_status(
+    user_id: int, thread_id_or_0: int, window_id: str
+) -> tuple[str, bool]:
+    """Render throttled queue telemetry and report whether its skip gate is open."""
+    # Lazy: queue imports this status module for dispatch, so keep the reverse
+    # dependency at call time.
+    from ..messaging_pipeline.backlog import get_backlog_snapshot
+
+    snapshot = get_backlog_snapshot(user_id, window_id, thread_id_or_0 or None)
+    severe = (
+        snapshot.pending_count >= SEVERE_BACKLOG_COUNT
+        or snapshot.oldest_age_seconds >= SEVERE_BACKLOG_AGE_SECONDS
+    )
+    key = (user_id, thread_id_or_0, window_id)
+    now = time.monotonic()
+    cached = _backlog_status_cache.get(key)
+    if cached is not None and now - cached[0] < _BACKLOG_STATUS_THROTTLE_SECONDS:
+        return cached[1], severe
+    lag = (
+        f" · delivery lag {snapshot.delivery_lag_seconds:.1f}s"
+        if snapshot.delivery_lag_seconds is not None
+        else " · delivery lag —"
+    )
+    line = (
+        f"Queue: {snapshot.pending_count} pending · age {snapshot.oldest_age_seconds:.0f}s"
+        f"{lag}"
+    )
+    _backlog_status_cache[key] = (now, line)
+    return line, severe
 
 
 def _get_idle_history(
@@ -302,6 +352,8 @@ async def send_status_text(
     thread_id_or_0: int,
     window_id: str,
     text: str,
+    *,
+    backlog_severe: bool = False,
 ) -> None:
     """Send a new status message with action buttons and track it.
 
@@ -323,6 +375,7 @@ async def send_status_text(
         history=history,
         user_id=user_id,
         is_group=(thread_id_or_0 != 0),
+        backlog_severe=backlog_severe,
     )
 
     existing = _status_msg_info.get(skey)
@@ -424,7 +477,15 @@ async def process_status_update(
         await clear_status_message(client, user_id, tkey)
         return
 
-    await send_status_text(client, user_id, tkey, task.window_id, status_text)
+    backlog_line, severe = format_backlog_status(user_id, tkey, task.window_id)
+    await send_status_text(
+        client,
+        user_id,
+        tkey,
+        task.window_id,
+        f"{status_text}\n{backlog_line}",
+        backlog_severe=severe,
+    )
 
 
 async def process_status_clear(
@@ -437,7 +498,15 @@ async def process_status_clear(
     tkey = thread_key(task.thread_id)
     status_text = format_claude_task_status(window_id, None)
     if status_text and window_id:
-        await send_status_text(client, user_id, tkey, window_id, status_text)
+        backlog_line, severe = format_backlog_status(user_id, tkey, window_id)
+        await send_status_text(
+            client,
+            user_id,
+            tkey,
+            window_id,
+            f"{status_text}\n{backlog_line}",
+            backlog_severe=severe,
+        )
         return
     await clear_status_message(client, user_id, tkey)
 

--- a/src/ccgram/handlers/sync_command.py
+++ b/src/ccgram/handlers/sync_command.py
@@ -271,9 +271,7 @@ async def _remove_topic(client: TelegramClient, chat_id: int, thread_id: int) ->
         return False
 
 
-async def _delete_retired_topic(
-    client: TelegramClient, topic: RetiredTopic
-) -> str:
+async def _delete_retired_topic(client: TelegramClient, topic: RetiredTopic) -> str:
     """Delete a known topic, returning a terminal result or close fallback."""
     chat_id = topic.chat_id
     thread_id = topic.thread_id

--- a/src/ccgram/handlers/sync_command.py
+++ b/src/ccgram/handlers/sync_command.py
@@ -12,6 +12,7 @@ Key functions:
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import TYPE_CHECKING
 import asyncio
 import re
@@ -29,7 +30,7 @@ from ..config import config
 from ..session import AuditIssue, AuditResult, session_manager
 from ..session_map import session_map_sync
 from ..telegram_client import PTBTelegramClient, TelegramClient
-from ..thread_router import thread_router
+from ..thread_router import RetiredTopic, thread_router
 from ..multiplexer import multiplexer as tmux_manager
 from ..multiplexer.reconciliation import list_windows_for_reconciliation
 from ..user_preferences import user_preferences
@@ -63,6 +64,14 @@ _CATEGORY_LABELS: dict[str, str] = {
     "legacy_herdr": "legacy Herdr binding (blocked; archive or explicitly rebind)",
 }
 
+_RETIRED_OUTCOME_LABELS = {
+    "deleted": "Deleted",
+    "closed": "Closed",
+    "already_gone": "Already gone",
+    "failed": "Could not remove",
+    "protected_active": "Protected active or rebound",
+}
+
 
 async def _run_audit() -> AuditResult:
     """Fetch live multiplexer state and run audit."""
@@ -80,11 +89,23 @@ def _issue_summary_lines(audit: AuditResult) -> list[str]:
             continue  # shown in dedicated report lines
         category_counts[issue.category] = category_counts.get(issue.category, 0) + 1
 
-    if category_counts:
-        return [
-            f"⚠ {count} {_CATEGORY_LABELS.get(cat, cat)}"
-            for cat, count in category_counts.items()
-        ]
+    retired_reasons = Counter(
+        issue.detail.removeprefix("reason:")
+        for issue in audit.issues
+        if issue.category == "retired_topic"
+    )
+    if retired_reasons:
+        category_counts.pop("retired_topic", None)
+    lines = [
+        f"⚠ {count} {_CATEGORY_LABELS.get(cat, cat)}"
+        for cat, count in category_counts.items()
+    ]
+    lines.extend(
+        f"⚠ {count} known retired topic cleanup candidate(s) ({reason})"
+        for reason, count in retired_reasons.items()
+    )
+    if lines:
+        return lines
     if audit.total_bindings > 0:
         return ["✓ No orphaned entries", "✓ Tmux display cache in sync"]
     return []
@@ -128,6 +149,16 @@ async def _sync_live_topic_names(
             logger.error("Unexpected error syncing topic name", exc_info=result)
 
 
+def _retired_outcome_lines(retired_outcomes: dict[str, int] | None) -> list[str]:
+    """Format explicit outcomes for locally known retired-topic cleanup."""
+    return [
+        f"{'⚠' if outcome == 'failed' else 'ℹ'} "
+        f"{_RETIRED_OUTCOME_LABELS[outcome]} {count} known retired topic(s)"
+        for outcome, count in (retired_outcomes or {}).items()
+        if count
+    ]
+
+
 def _format_report(
     audit: AuditResult,
     *,
@@ -135,6 +166,7 @@ def _format_report(
     closed_topic_count: int = 0,
     recreated_topic_count: int = 0,
     manual_close_count: int = 0,
+    retired_outcomes: dict[str, int] | None = None,
 ) -> tuple[str, InlineKeyboardMarkup | None]:
     """Build report text and optional keyboard."""
     lines: list[str] = []
@@ -159,6 +191,8 @@ def _format_report(
             f"⚠ {manual_close_count} {topic_word} could not be closed automatically; "
             "safe to close manually"
         )
+
+    lines.extend(_retired_outcome_lines(retired_outcomes))
 
     # Binding summary
     if audit.total_bindings == 0:
@@ -203,6 +237,19 @@ def _format_report(
     return text, keyboard
 
 
+def _retired_topic_issues() -> list[AuditIssue]:
+    """Return Fix candidates known from local retired-binding state only."""
+    return [
+        AuditIssue(
+            category="retired_topic",
+            detail=f"reason:{topic.reason}",
+            fixable=True,
+        )
+        for topic in thread_router.iter_retired_topics()
+        if topic.cleanup_eligible
+    ]
+
+
 async def _remove_topic(client: TelegramClient, chat_id: int, thread_id: int) -> bool:
     """Try to delete a topic, fall back to close. Returns True on success.
 
@@ -222,6 +269,53 @@ async def _remove_topic(client: TelegramClient, chat_id: int, thread_id: int) ->
         return True
     except TelegramError:
         return False
+
+
+async def _delete_retired_topic(
+    client: TelegramClient, topic: RetiredTopic
+) -> str:
+    """Delete a known topic, returning a terminal result or close fallback."""
+    chat_id = topic.chat_id
+    thread_id = topic.thread_id
+    try:
+        deleted = await client.delete_forum_topic(chat_id, thread_id)
+    except BadRequest as exc:
+        return "already_gone" if is_thread_gone(exc) else "failed"
+    except TelegramError:
+        return "failed"
+    return "deleted" if deleted is not False else "failed"
+
+
+async def _close_retired_topic(client: TelegramClient, topic: RetiredTopic) -> str:
+    """Close a known topic when deletion is unavailable."""
+    try:
+        closed = await client.close_forum_topic(topic.chat_id, topic.thread_id)
+    except TelegramError as exc:
+        return "already_gone" if is_thread_gone(exc) else "failed"
+    return "closed" if closed is not False else "failed"
+
+
+async def _cleanup_retired_topics(client: TelegramClient) -> dict[str, int]:
+    """Remove only locally known, eligible retired topics.
+
+    A binding is rechecked immediately before the Telegram request. This does
+    not discover remote topics: it operates solely on the bounded registry.
+    """
+    outcomes: Counter[str] = Counter()
+    terminal_outcomes = {"deleted", "closed", "already_gone"}
+    for topic in tuple(thread_router.iter_retired_topics()):
+        if not topic.cleanup_eligible:
+            continue
+        if thread_router.get_window_for_chat_thread(topic.chat_id, topic.thread_id):
+            outcomes["protected_active"] += 1
+            continue
+        outcome = await _delete_retired_topic(client, topic)
+        if outcome == "failed":
+            outcome = await _close_retired_topic(client, topic)
+        outcomes[outcome] += 1
+        if outcome in terminal_outcomes:
+            thread_router.discard_retired_topic(topic)
+    return dict(outcomes)
 
 
 async def _close_ghost_topics(
@@ -270,7 +364,11 @@ async def _close_ghost_topics(
                 await clear_topic_state(
                     user_id, thread_id, client=client, window_id=window_id
                 )
-                thread_router.unbind_thread(user_id, thread_id)
+                thread_router.unbind_thread(
+                    user_id,
+                    thread_id,
+                    retirement_reason="remote_removed",
+                )
                 if topic_removed:
                     closed_count += 1
             except OSError, TelegramError:
@@ -406,7 +504,11 @@ async def _recreate_dead_topics(
         # directly so another user's binding cannot short-circuit recreation.
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
 
-        thread_router.unbind_thread(user_id, thread_id)
+        thread_router.unbind_thread(
+            user_id,
+            thread_id,
+            retirement_reason="remote_deleted",
+        )
 
         created = False
         try:
@@ -477,6 +579,7 @@ async def sync_command(update: Update, _context: ContextTypes.DEFAULT_TYPE) -> N
             "Telegram topic probe completed",
             dead_topic_count=len(dead_issues),
         )
+    audit.issues.extend(_retired_topic_issues())
     text, keyboard = _format_report(audit)
     if status_msg is not None:
         await safe_edit(status_msg, text, reply_markup=keyboard)
@@ -510,6 +613,7 @@ async def handle_sync_fix(query: CallbackQuery) -> None:
     pre_audit = session_manager.audit_state(live_ids, live_pairs)
     dead_issues = await _probe_dead_topics(client)
     pre_audit.issues.extend(dead_issues)
+    pre_audit.issues.extend(_retired_topic_issues())
 
     # Run state cleanup operations
     try:
@@ -533,6 +637,7 @@ async def handle_sync_fix(query: CallbackQuery) -> None:
         client, pre_audit.issues
     )
     recreated_count = await _recreate_dead_topics(client, pre_audit.issues)
+    retired_outcomes = await _cleanup_retired_topics(client)
 
     # Re-audit and compute actual fixed count (handles partial failures).
     # No skip_threads here: successful recreations use a new thread_id (old
@@ -541,6 +646,7 @@ async def handle_sync_fix(query: CallbackQuery) -> None:
     post_audit = await _run_audit()
     post_dead = await _probe_dead_topics(client)
     post_audit.issues.extend(post_dead)
+    post_audit.issues.extend(_retired_topic_issues())
     actual_fixed = pre_audit.fixable_count - post_audit.fixable_count
     text, keyboard = _format_report(
         post_audit,
@@ -548,6 +654,7 @@ async def handle_sync_fix(query: CallbackQuery) -> None:
         closed_topic_count=closed_count,
         recreated_topic_count=recreated_count,
         manual_close_count=manual_close_count,
+        retired_outcomes=retired_outcomes,
     )
     await safe_edit(query, text, reply_markup=keyboard)
 

--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -364,7 +364,12 @@ async def _handle_dead_window(
             user_id,
             thread_id,
         )
-        thread_router.unbind_thread(user_id, thread_id)
+        thread_router.unbind_thread(
+            user_id,
+            thread_id,
+            retirement_reason="system_replacement",
+            cleanup_eligible=True,
+        )
         lifecycle_strategy.clear_dead_notification(user_id, thread_id)
         start_path = str(Path.cwd())
         msg_text, keyboard, subdirs = build_directory_browser(

--- a/src/ccgram/handlers/topics/topic_lifecycle.py
+++ b/src/ccgram/handlers/topics/topic_lifecycle.py
@@ -131,7 +131,11 @@ async def _close_expired_topic(
         if scoped_chat_id is not None:
             cleanup_kwargs["chat_id"] = scoped_chat_id
         await clear_topic_state(user_id, thread_id, client=client, **cleanup_kwargs)
-        thread_router.unbind_thread(user_id, thread_id)
+        thread_router.unbind_thread(
+            user_id,
+            thread_id,
+            retirement_reason="remote_closed",
+        )
 
 
 # ── Unbound window TTL ────────────────────────────────────────────────────
@@ -317,7 +321,12 @@ async def _unbind_deleted_topic(
         killed = True
     terminal_poll_state.reset_probe_failures(wid)
     await clear_topic_state(user_id, thread_id, client, window_id=wid, chat_id=chat_id)
-    thread_router.unbind_thread(user_id, thread_id, chat_id=chat_id)
+    thread_router.unbind_thread(
+        user_id,
+        thread_id,
+        chat_id=chat_id,
+        retirement_reason="remote_deleted",
+    )
     logger.info(
         "Topic deleted: %s window_id '%s' and unbound thread %d for user %d",
         "killed" if killed else "unbound",
@@ -433,9 +442,18 @@ async def topic_closed_handler(
             **cleanup_kwargs,
         )
         if isinstance(chat_id, int):
-            thread_router.unbind_thread(user.id, thread_id, chat_id=chat_id)
+            thread_router.unbind_thread(
+                user.id,
+                thread_id,
+                chat_id=chat_id,
+                retirement_reason="remote_closed",
+            )
         else:
-            thread_router.unbind_thread(user.id, thread_id)
+            thread_router.unbind_thread(
+                user.id,
+                thread_id,
+                retirement_reason="remote_closed",
+            )
         logger.info(
             "Topic closed: window %s unbound (kept alive for rebinding, user=%d, thread=%d)",
             display,

--- a/src/ccgram/handlers/topics/window_launch_service.py
+++ b/src/ccgram/handlers/topics/window_launch_service.py
@@ -332,7 +332,12 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         if await tmux_manager.kill_window(created_wid):
             topic_orchestration.clear_pending_creation(created_wid)
             if pending_thread_id is not None:
-                thread_router.unbind_thread(user_id, pending_thread_id)
+                thread_router.unbind_thread(
+                    user_id,
+                    pending_thread_id,
+                    retirement_reason="system_replacement",
+                    cleanup_eligible=True,
+                )
         raise
 
     query_message = query.message
@@ -349,7 +354,12 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
             if await tmux_manager.kill_window(created_wid):
                 topic_orchestration.clear_pending_creation(created_wid)
                 if pending_thread_id is not None:
-                    thread_router.unbind_thread(user_id, pending_thread_id)
+                    thread_router.unbind_thread(
+                        user_id,
+                        pending_thread_id,
+                        retirement_reason="system_replacement",
+                        cleanup_eligible=True,
+                    )
             raise
 
     if pending_thread_id is not None:
@@ -380,7 +390,12 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         if await tmux_manager.kill_window(created_wid):
             topic_orchestration.clear_pending_creation(created_wid)
             if pending_thread_id is not None:
-                thread_router.unbind_thread(user_id, pending_thread_id)
+                thread_router.unbind_thread(
+                    user_id,
+                    pending_thread_id,
+                    retirement_reason="system_replacement",
+                    cleanup_eligible=True,
+                )
         raise
 
     created_wid = _follow_supersession(created_wid)
@@ -393,7 +408,12 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         if await tmux_manager.kill_window(created_wid):
             topic_orchestration.clear_pending_creation(created_wid)
             if pending_thread_id is not None:
-                thread_router.unbind_thread(user_id, pending_thread_id)
+                thread_router.unbind_thread(
+                    user_id,
+                    pending_thread_id,
+                    retirement_reason="system_replacement",
+                    cleanup_eligible=True,
+                )
             message = "Session did not register with ccgram in time"
         else:
             message = (

--- a/src/ccgram/monitor_state.py
+++ b/src/ccgram/monitor_state.py
@@ -127,8 +127,8 @@ class MonitorState:
             logger.warning("Failed to load state file: %s", e)
             self.tracked_sessions = {}
 
-    def save(self) -> None:
-        """Save state to file atomically."""
+    def save(self) -> bool:
+        """Save state to file atomically and report whether it succeeded."""
         data = {
             "tracked_sessions": {
                 k: v.to_dict() for k, v in self.tracked_sessions.items()
@@ -143,8 +143,10 @@ class MonitorState:
         try:
             atomic_write_json(self.state_file, data)
             self._dirty = False
+            return True
         except OSError:
             logger.exception("Failed to save state file")
+            return False
 
     def get_session(self, session_id: str) -> TrackedSession | None:
         """Get tracked session by ID."""
@@ -205,6 +207,11 @@ class MonitorState:
             intent.purge_complete = True
             self._dirty = True
 
+    def cancel_skip(self, session_id: str) -> None:
+        """Remove a skip barrier without changing the delivered watermark."""
+        if self.pending_skips.pop(session_id, None) is not None:
+            self._dirty = True
+
     def complete_skip(self, session_id: str) -> bool:
         """Atomically retire a delivered skip barrier and advance its watermark."""
         intent = self.pending_skips.get(session_id)
@@ -218,7 +225,6 @@ class MonitorState:
         self._dirty = True
         return True
 
-    def save_if_dirty(self) -> None:
-        """Save state only if it has been modified."""
-        if self._dirty:
-            self.save()
+    def save_if_dirty(self) -> bool:
+        """Save state only if it has been modified and report success."""
+        return not self._dirty or self.save()

--- a/src/ccgram/monitor_state.py
+++ b/src/ccgram/monitor_state.py
@@ -203,7 +203,9 @@ class MonitorState:
         """Record the exact queued items retired for a pending skip."""
         intent = self.pending_skips.get(session_id)
         if intent is not None:
-            intent.skipped_count = skipped_count
+            # Purge can be retried after state persistence fails. Retried
+            # purges may return zero after the queue was already drained.
+            intent.skipped_count += skipped_count
             intent.purge_complete = True
             self._dirty = True
 

--- a/src/ccgram/monitor_state.py
+++ b/src/ccgram/monitor_state.py
@@ -67,6 +67,7 @@ class BacklogSkipIntent:
     snapshot_offset: int
     range_start: int
     skipped_count: int = 0
+    purge_complete: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -82,6 +83,7 @@ class BacklogSkipIntent:
             snapshot_offset=int(data.get("snapshot_offset", 0)),
             range_start=int(data.get("range_start", 0)),
             skipped_count=int(data.get("skipped_count", 0)),
+            purge_complete=bool(data.get("purge_complete", False)),
         )
 
 
@@ -200,6 +202,7 @@ class MonitorState:
         intent = self.pending_skips.get(session_id)
         if intent is not None:
             intent.skipped_count = skipped_count
+            intent.purge_complete = True
             self._dirty = True
 
     def complete_skip(self, session_id: str) -> bool:
@@ -208,8 +211,9 @@ class MonitorState:
         session = self.tracked_sessions.get(session_id)
         if intent is None or session is None:
             return False
-        session.last_byte_offset = intent.snapshot_offset
-        session.parsed_offset = intent.snapshot_offset
+        target_offset = max(session.last_byte_offset, intent.snapshot_offset)
+        session.last_byte_offset = target_offset
+        session.parsed_offset = target_offset
         self.pending_skips.pop(session_id, None)
         self._dirty = True
         return True

--- a/src/ccgram/monitor_state.py
+++ b/src/ccgram/monitor_state.py
@@ -52,6 +52,40 @@ class TrackedSession:
 
 
 @dataclass
+class BacklogSkipIntent:
+    """Durable barrier for a confirmed transcript backlog skip.
+
+    The transcript remains untouched. Until the notice is acknowledged this
+    record prevents replay of the frozen range across a restart.
+    """
+
+    session_id: str
+    window_id: str
+    user_id: int
+    thread_id: int | None
+    chat_id: int
+    snapshot_offset: int
+    range_start: int
+    skipped_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BacklogSkipIntent":
+        return cls(
+            session_id=str(data.get("session_id", "")),
+            window_id=str(data.get("window_id", "")),
+            user_id=int(data.get("user_id", 0)),
+            thread_id=data.get("thread_id"),
+            chat_id=int(data.get("chat_id", 0)),
+            snapshot_offset=int(data.get("snapshot_offset", 0)),
+            range_start=int(data.get("range_start", 0)),
+            skipped_count=int(data.get("skipped_count", 0)),
+        )
+
+
+@dataclass
 class MonitorState:
     """Persistent state for the session monitor.
 
@@ -63,6 +97,7 @@ class MonitorState:
     state_file: Path
     tracked_sessions: dict[str, TrackedSession] = field(default_factory=dict)
     events_offset: int = 0
+    pending_skips: dict[str, BacklogSkipIntent] = field(default_factory=dict)
     _dirty: bool = field(default=False, repr=False)
 
     def load(self) -> None:
@@ -78,6 +113,11 @@ class MonitorState:
                 k: TrackedSession.from_dict(v) for k, v in sessions.items()
             }
             self.events_offset = data.get("events_offset", 0)
+            self.pending_skips = {
+                session_id: BacklogSkipIntent.from_dict(intent)
+                for session_id, intent in data.get("pending_skips", {}).items()
+                if isinstance(intent, dict)
+            }
             logger.info(
                 "Loaded %d tracked sessions from state", len(self.tracked_sessions)
             )
@@ -92,6 +132,10 @@ class MonitorState:
                 k: v.to_dict() for k, v in self.tracked_sessions.items()
             },
             "events_offset": self.events_offset,
+            "pending_skips": {
+                session_id: intent.to_dict()
+                for session_id, intent in self.pending_skips.items()
+            },
         }
 
         try:
@@ -145,6 +189,30 @@ class MonitorState:
                 advanced = True
                 self._dirty = True
         return advanced
+
+    def begin_skip(self, intent: BacklogSkipIntent) -> None:
+        """Persist a skip barrier before any queued source work is retired."""
+        self.pending_skips[intent.session_id] = intent
+        self._dirty = True
+
+    def update_skip_count(self, session_id: str, skipped_count: int) -> None:
+        """Record the exact queued items retired for a pending skip."""
+        intent = self.pending_skips.get(session_id)
+        if intent is not None:
+            intent.skipped_count = skipped_count
+            self._dirty = True
+
+    def complete_skip(self, session_id: str) -> bool:
+        """Atomically retire a delivered skip barrier and advance its watermark."""
+        intent = self.pending_skips.get(session_id)
+        session = self.tracked_sessions.get(session_id)
+        if intent is None or session is None:
+            return False
+        session.last_byte_offset = intent.snapshot_offset
+        session.parsed_offset = intent.snapshot_offset
+        self.pending_skips.pop(session_id, None)
+        self._dirty = True
+        return True
 
     def save_if_dirty(self) -> None:
         """Save state only if it has been modified."""

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -223,8 +223,6 @@ class SessionMonitor:
             snapshot_offset=snapshot_offset,
             range_start=session.last_byte_offset,
         )
-        if not self._skip_is_current(intent):
-            return None
         # The durable barrier is written before destructive queue retirement.
         self.state.begin_skip(intent)
         if not self.state.save_if_dirty():
@@ -233,7 +231,8 @@ class SessionMonitor:
         prepared = await self._prepare_pending_skip(intent)
         if prepared is not True:
             return None
-        await self._enqueue_pending_skip_notice(intent)
+        if not await self._enqueue_pending_skip_notice(intent):
+            return None
         return intent
 
     def _skip_is_current(self, intent: BacklogSkipIntent) -> bool:
@@ -303,20 +302,20 @@ class SessionMonitor:
         self._clear_skip_retry(intent.session_id)
         return True
 
-    async def _enqueue_pending_skip_notice(self, intent: BacklogSkipIntent) -> None:
+    async def _enqueue_pending_skip_notice(self, intent: BacklogSkipIntent) -> bool:
         """Create one receipt-tracked visible notice for a persisted barrier."""
         if not self._skip_is_current(intent):
             self.state.cancel_skip(intent.session_id)
             self.state.save_if_dirty()
             self._clear_skip_retry(intent.session_id)
-            return
+            return False
         if intent.session_id in self._skip_notice_receipts or not self._skip_retry_due(
             intent.session_id
         ):
-            return
+            return False
         callback = self._skip_notice_callback
         if callback is None:
-            return
+            return False
         receipt = new_delivery_receipt(checkpoint=intent.snapshot_offset)
         token = activate_delivery_receipt(receipt)
         try:
@@ -333,9 +332,11 @@ class SessionMonitor:
         finally:
             deactivate_delivery_receipt(token)
             receipt.close()
-        if not receipt.failed:
-            self._clear_skip_retry(intent.session_id)
-            self._skip_notice_receipts[intent.session_id] = receipt
+        if receipt.failed:
+            return False
+        self._clear_skip_retry(intent.session_id)
+        self._skip_notice_receipts[intent.session_id] = receipt
+        return True
 
     async def _resume_pending_skip_notices(self) -> None:
         """Resume persisted skip barriers before reading any skipped bytes."""

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -242,7 +242,9 @@ class SessionMonitor:
         try:
             return callback(intent)
         except Exception:
-            logger.exception("Failed to validate backlog skip for %s", intent.session_id)
+            logger.exception(
+                "Failed to validate backlog skip for %s", intent.session_id
+            )
             return False
 
     def _skip_retry_due(self, session_id: str) -> bool:

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -109,7 +109,11 @@ class SessionMonitor:
         self._hook_event_callback: Callable[[HookEvent], Awaitable[None]] | None = None
 
         self._idle_tracker = IdleTracker()
-        self._transcript_reader = TranscriptReader(self.state, self._idle_tracker)
+        self._transcript_reader = TranscriptReader(
+            self.state,
+            self._idle_tracker,
+            on_session_retired=self._discard_session_delivery_state,
+        )
         # Receipts are grouped by transcript session so one failed send only
         # freezes its own watermark.
         self._delivery_receipts: dict[str, list[DeliveryReceipt]] = {}
@@ -150,6 +154,12 @@ class SessionMonitor:
     def get_last_activity(self, session_id: str) -> float | None:
         """Get monotonic timestamp of last transcript activity for a session."""
         return self._idle_tracker.get_last_activity(session_id)
+
+    def _discard_session_delivery_state(self, session_id: str) -> None:
+        """Drop receipts tied to a session identity that no longer exists."""
+        self._delivery_receipts.pop(session_id, None)
+        self._skip_notice_receipts.pop(session_id, None)
+        self._clear_skip_retry(session_id)
 
     def set_message_callback(
         self, callback: Callable[[NewMessage], Awaitable[None]]
@@ -295,6 +305,11 @@ class SessionMonitor:
 
     async def _enqueue_pending_skip_notice(self, intent: BacklogSkipIntent) -> None:
         """Create one receipt-tracked visible notice for a persisted barrier."""
+        if not self._skip_is_current(intent):
+            self.state.cancel_skip(intent.session_id)
+            self.state.save_if_dirty()
+            self._clear_skip_retry(intent.session_id)
+            return
         if intent.session_id in self._skip_notice_receipts or not self._skip_retry_due(
             intent.session_id
         ):
@@ -342,6 +357,16 @@ class SessionMonitor:
                 self._schedule_skip_retry(session_id)
                 continue
             if not receipt.commit_ready:
+                continue
+            intent = self.state.pending_skips.get(session_id)
+            if intent is None or not self._skip_is_current(intent):
+                # A topic may rebind after the notice was queued or delivered.
+                # Never advance the old source watermark across that boundary.
+                self.state.cancel_skip(session_id)
+                self.state.save_if_dirty()
+                self._delivery_receipts.pop(session_id, None)
+                self._skip_notice_receipts.pop(session_id, None)
+                self._clear_skip_retry(session_id)
                 continue
             if self.state.complete_skip(session_id):
                 self.state.save_if_dirty()

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -35,7 +35,7 @@ from .delivery_contract import (
 )
 from .event_reader import read_new_events
 from .idle_tracker import IdleTracker
-from .monitor_state import MonitorState
+from .monitor_state import BacklogSkipIntent, MonitorState
 from .providers import get_provider_for_window, registry  # noqa: F401 (used by test patches)
 from .session_map import parse_session_map, read_session_map_raw, session_map_prefix
 from .session_lifecycle import session_lifecycle
@@ -110,6 +110,15 @@ class SessionMonitor:
         # Receipts are grouped by transcript session so one failed send only
         # freezes its own watermark.
         self._delivery_receipts: dict[str, list[DeliveryReceipt]] = {}
+        # Backlog skips cross the monitor/queue boundary through injected
+        # adapters, preserving this module's handler independence.
+        self._skip_purge_callback: (
+            Callable[[BacklogSkipIntent], Awaitable[int]] | None
+        ) = None
+        self._skip_notice_callback: (
+            Callable[[BacklogSkipIntent], Awaitable[None]] | None
+        ) = None
+        self._skip_notice_receipts: dict[str, DeliveryReceipt] = {}
 
     # Delegation properties for backward-compatible test access
     @property
@@ -149,6 +158,97 @@ class SessionMonitor:
     def set_hook_event_callback(self, callback: Callable[..., Awaitable[None]]) -> None:
         self._hook_event_callback = callback
 
+    def set_skip_callbacks(
+        self,
+        *,
+        purge: Callable[[BacklogSkipIntent], Awaitable[int]],
+        notice: Callable[[BacklogSkipIntent], Awaitable[None]],
+    ) -> None:
+        """Install the queue adapters used by confirmed backlog skips."""
+        self._skip_purge_callback = purge
+        self._skip_notice_callback = notice
+
+    async def request_backlog_skip(
+        self, user_id: int, window_id: str, thread_id: int | None, chat_id: int
+    ) -> BacklogSkipIntent | None:
+        """Freeze one source at EOF, persist its barrier, then retire its queue work."""
+        if self._skip_purge_callback is None or self._skip_notice_callback is None:
+            raise RuntimeError("backlog skip callbacks are not wired")
+        session_id = session_lifecycle.resolve_session_id(window_id)
+        if not session_id:
+            return None
+        session = self.state.get_session(session_id)
+        if session is None or session_id in self.state.pending_skips:
+            return None
+        try:
+            snapshot_offset = Path(session.file_path).stat().st_size
+        except OSError:
+            logger.warning(
+                "Cannot snapshot transcript for backlog skip: %s", session.file_path
+            )
+            return None
+        if snapshot_offset < session.last_byte_offset:
+            logger.warning(
+                "Refusing backlog skip with regressed transcript EOF: %s", session_id
+            )
+            return None
+        intent = BacklogSkipIntent(
+            session_id=session_id,
+            window_id=window_id,
+            user_id=user_id,
+            thread_id=thread_id,
+            chat_id=chat_id,
+            snapshot_offset=snapshot_offset,
+            range_start=session.last_byte_offset,
+        )
+        # The durable barrier is written before destructive queue retirement.
+        self.state.begin_skip(intent)
+        self.state.save_if_dirty()
+        skipped = await self._skip_purge_callback(intent)
+        self.state.update_skip_count(session_id, skipped)
+        self.state.save_if_dirty()
+        await self._enqueue_pending_skip_notice(intent)
+        return intent
+
+    async def _enqueue_pending_skip_notice(self, intent: BacklogSkipIntent) -> None:
+        """Create one receipt-tracked visible notice for a persisted barrier."""
+        if intent.session_id in self._skip_notice_receipts:
+            return
+        callback = self._skip_notice_callback
+        if callback is None:
+            return
+        receipt = new_delivery_receipt(checkpoint=intent.snapshot_offset)
+        token = activate_delivery_receipt(receipt)
+        try:
+            await callback(intent)
+        except asyncio.CancelledError:
+            receipt.fail()
+            raise
+        except Exception:
+            receipt.fail()
+            logger.exception(
+                "Failed to enqueue backlog skip notice for %s", intent.session_id
+            )
+        finally:
+            deactivate_delivery_receipt(token)
+            receipt.close()
+        self._skip_notice_receipts[intent.session_id] = receipt
+
+    async def _resume_pending_skip_notices(self) -> None:
+        """Resume persisted skip barriers before reading any skipped bytes."""
+        for intent in tuple(self.state.pending_skips.values()):
+            await self._enqueue_pending_skip_notice(intent)
+
+    def _commit_pending_skips(self) -> None:
+        """Advance only barriers whose visible notices reached Telegram."""
+        for session_id, receipt in tuple(self._skip_notice_receipts.items()):
+            if not receipt.commit_ready:
+                continue
+            if self.state.complete_skip(session_id):
+                self.state.save_if_dirty()
+                self._delivery_receipts.pop(session_id, None)
+            self._skip_notice_receipts.pop(session_id, None)
+
     def record_hook_activity(self, window_id: str) -> None:
         """Record hook-based activity for a window (resets idle timers)."""
         session_id = session_lifecycle.resolve_session_id(window_id)
@@ -173,9 +273,11 @@ class SessionMonitor:
         from the previous persisted watermark rather than loss.
         """
         delivered_offsets: dict[str, int] = {}
+        self._commit_pending_skips()
         for session_id, receipts in self._delivery_receipts.items():
             if (
-                session_id in self._transcript_reader._pending_tools
+                session_id in self.state.pending_skips
+                or session_id in self._transcript_reader._pending_tools
                 or not delivery_receipts_ready(receipts)
                 or any(receipt.checkpoint is None for receipt in receipts)
             ):
@@ -221,6 +323,8 @@ class SessionMonitor:
             fallback_session_ids.add(session_id)
 
         for session_id, file_path in direct_sessions:
+            if session_id in self.state.pending_skips:
+                continue
             try:
                 await self._process_session_file(
                     session_id,
@@ -235,7 +339,10 @@ class SessionMonitor:
             active_cwds = await self._get_active_cwds()
             sessions = self._scan_projects_sync(active_cwds) if active_cwds else []
             for session_info in sessions:
-                if session_info.session_id not in fallback_session_ids:
+                if (
+                    session_info.session_id not in fallback_session_ids
+                    or session_info.session_id in self.state.pending_skips
+                ):
                     continue
                 try:
                     await self._process_session_file(
@@ -584,6 +691,10 @@ class SessionMonitor:
                         if window_id in live_window_ids
                     }
 
+                # A persisted barrier must be noticed before its source is read
+                # again; this preserves the exact EOF snapshot across restarts.
+                await self._resume_pending_skip_notices()
+                self._commit_pending_skips()
                 new_messages = await self.check_for_updates(monitored_map)
                 # Register every parsed message before the next await. A
                 # shutdown cancellation between parse and dispatch must leave

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -116,7 +116,7 @@ class SessionMonitor:
         # Backlog skips cross the monitor/queue boundary through injected
         # adapters, preserving this module's handler independence.
         self._skip_purge_callback: (
-            Callable[[BacklogSkipIntent], Awaitable[int]] | None
+            Callable[[BacklogSkipIntent], Awaitable[int | None]] | None
         ) = None
         self._skip_notice_callback: (
             Callable[[BacklogSkipIntent], Awaitable[None]] | None
@@ -166,7 +166,7 @@ class SessionMonitor:
     def set_skip_callbacks(
         self,
         *,
-        purge: Callable[[BacklogSkipIntent], Awaitable[int]],
+        purge: Callable[[BacklogSkipIntent], Awaitable[int | None]],
         notice: Callable[[BacklogSkipIntent], Awaitable[None]],
     ) -> None:
         """Install the queue adapters used by confirmed backlog skips."""
@@ -208,8 +208,13 @@ class SessionMonitor:
         )
         # The durable barrier is written before destructive queue retirement.
         self.state.begin_skip(intent)
-        self.state.save_if_dirty()
-        if await self._prepare_pending_skip(intent):
+        if not self.state.save_if_dirty():
+            self.state.cancel_skip(session_id)
+            return None
+        prepared = await self._prepare_pending_skip(intent)
+        if prepared is None:
+            return None
+        if prepared:
             await self._enqueue_pending_skip_notice(intent)
         return intent
 
@@ -235,7 +240,7 @@ class SessionMonitor:
         self._skip_retry_attempts.pop(session_id, None)
         self._skip_retry_at.pop(session_id, None)
 
-    async def _prepare_pending_skip(self, intent: BacklogSkipIntent) -> bool:
+    async def _prepare_pending_skip(self, intent: BacklogSkipIntent) -> bool | None:
         """Retire frozen source work before a skip notice may be sent."""
         if intent.purge_complete:
             return True
@@ -250,8 +255,17 @@ class SessionMonitor:
             logger.exception("Failed to purge backlog for %s", intent.session_id)
             self._schedule_skip_retry(intent.session_id)
             return False
+        if skipped is None:
+            logger.warning("Cancelling stale backlog skip for %s", intent.session_id)
+            self.state.cancel_skip(intent.session_id)
+            self.state.save_if_dirty()
+            self._clear_skip_retry(intent.session_id)
+            return None
         self.state.update_skip_count(intent.session_id, skipped)
-        self.state.save_if_dirty()
+        if not self.state.save_if_dirty():
+            intent.purge_complete = False
+            self._schedule_skip_retry(intent.session_id)
+            return False
         self._clear_skip_retry(intent.session_id)
         return True
 
@@ -289,7 +303,8 @@ class SessionMonitor:
         for intent in tuple(self.state.pending_skips.values()):
             if not self._skip_retry_due(intent.session_id):
                 continue
-            if await self._prepare_pending_skip(intent):
+            prepared = await self._prepare_pending_skip(intent)
+            if prepared:
                 await self._enqueue_pending_skip_notice(intent)
 
     def _commit_pending_skips(self) -> None:

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -118,6 +118,7 @@ class SessionMonitor:
         self._skip_purge_callback: (
             Callable[[BacklogSkipIntent], Awaitable[int | None]] | None
         ) = None
+        self._skip_validate_callback: Callable[[BacklogSkipIntent], bool] | None = None
         self._skip_notice_callback: (
             Callable[[BacklogSkipIntent], Awaitable[None]] | None
         ) = None
@@ -168,16 +169,22 @@ class SessionMonitor:
         *,
         purge: Callable[[BacklogSkipIntent], Awaitable[int | None]],
         notice: Callable[[BacklogSkipIntent], Awaitable[None]],
+        validate: Callable[[BacklogSkipIntent], bool],
     ) -> None:
         """Install the queue adapters used by confirmed backlog skips."""
         self._skip_purge_callback = purge
+        self._skip_validate_callback = validate
         self._skip_notice_callback = notice
 
     async def request_backlog_skip(
         self, user_id: int, window_id: str, thread_id: int | None, chat_id: int
     ) -> BacklogSkipIntent | None:
         """Freeze one source at EOF, persist its barrier, then retire its queue work."""
-        if self._skip_purge_callback is None or self._skip_notice_callback is None:
+        if (
+            self._skip_purge_callback is None
+            or self._skip_notice_callback is None
+            or self._skip_validate_callback is None
+        ):
             raise RuntimeError("backlog skip callbacks are not wired")
         session_id = session_lifecycle.resolve_session_id(window_id)
         if not session_id:
@@ -206,17 +213,28 @@ class SessionMonitor:
             snapshot_offset=snapshot_offset,
             range_start=session.last_byte_offset,
         )
+        if not self._skip_is_current(intent):
+            return None
         # The durable barrier is written before destructive queue retirement.
         self.state.begin_skip(intent)
         if not self.state.save_if_dirty():
             self.state.cancel_skip(session_id)
             return None
         prepared = await self._prepare_pending_skip(intent)
-        if prepared is None:
+        if prepared is not True:
             return None
-        if prepared:
-            await self._enqueue_pending_skip_notice(intent)
+        await self._enqueue_pending_skip_notice(intent)
         return intent
+
+    def _skip_is_current(self, intent: BacklogSkipIntent) -> bool:
+        callback = self._skip_validate_callback
+        if callback is None:
+            return False
+        try:
+            return callback(intent)
+        except Exception:
+            logger.exception("Failed to validate backlog skip for %s", intent.session_id)
+            return False
 
     def _skip_retry_due(self, session_id: str) -> bool:
         return time.monotonic() >= self._skip_retry_at.get(session_id, 0.0)
@@ -242,6 +260,12 @@ class SessionMonitor:
 
     async def _prepare_pending_skip(self, intent: BacklogSkipIntent) -> bool | None:
         """Retire frozen source work before a skip notice may be sent."""
+        if not self._skip_is_current(intent):
+            logger.warning("Cancelling stale backlog skip for %s", intent.session_id)
+            self.state.cancel_skip(intent.session_id)
+            self.state.save_if_dirty()
+            self._clear_skip_retry(intent.session_id)
+            return None
         if intent.purge_complete:
             return True
         callback = self._skip_purge_callback
@@ -320,6 +344,12 @@ class SessionMonitor:
             if not receipt.commit_ready:
                 continue
             if self.state.complete_skip(session_id):
+                self.state.save_if_dirty()
+                self._delivery_receipts.pop(session_id, None)
+            else:
+                # The tracked session was removed or re-keyed. Do not retain a
+                # barrier that can no longer be committed or replay safely.
+                self.state.cancel_skip(session_id)
                 self.state.save_if_dirty()
                 self._delivery_receipts.pop(session_id, None)
             self._skip_notice_receipts.pop(session_id, None)

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -19,6 +19,7 @@ Re-exported from transcript_reader for backward-compatible imports.
 import asyncio
 import contextlib
 import structlog
+import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
@@ -63,6 +64,8 @@ _LoopError = (OSError, RuntimeError, json.JSONDecodeError, ValueError, TelegramE
 
 _BACKOFF_MIN = 2.0
 _BACKOFF_MAX = 30.0
+_SKIP_RETRY_BASE_SECONDS = 2.0
+_SKIP_RETRY_MAX_SECONDS = 60.0
 _MSG_PREVIEW_LENGTH = 80
 
 logger = structlog.get_logger()
@@ -119,6 +122,8 @@ class SessionMonitor:
             Callable[[BacklogSkipIntent], Awaitable[None]] | None
         ) = None
         self._skip_notice_receipts: dict[str, DeliveryReceipt] = {}
+        self._skip_retry_attempts: dict[str, int] = {}
+        self._skip_retry_at: dict[str, float] = {}
 
     # Delegation properties for backward-compatible test access
     @property
@@ -204,15 +209,57 @@ class SessionMonitor:
         # The durable barrier is written before destructive queue retirement.
         self.state.begin_skip(intent)
         self.state.save_if_dirty()
-        skipped = await self._skip_purge_callback(intent)
-        self.state.update_skip_count(session_id, skipped)
-        self.state.save_if_dirty()
-        await self._enqueue_pending_skip_notice(intent)
+        if await self._prepare_pending_skip(intent):
+            await self._enqueue_pending_skip_notice(intent)
         return intent
+
+    def _skip_retry_due(self, session_id: str) -> bool:
+        return time.monotonic() >= self._skip_retry_at.get(session_id, 0.0)
+
+    def _schedule_skip_retry(self, session_id: str) -> None:
+        attempt = self._skip_retry_attempts.get(session_id, 0) + 1
+        delay = min(
+            _SKIP_RETRY_MAX_SECONDS,
+            _SKIP_RETRY_BASE_SECONDS * (2 ** min(attempt - 1, 5)),
+        )
+        self._skip_retry_attempts[session_id] = attempt
+        self._skip_retry_at[session_id] = time.monotonic() + delay
+        logger.warning(
+            "Backlog skip step failed; retrying later",
+            session_id=session_id,
+            retry=attempt,
+            retry_in_seconds=delay,
+        )
+
+    def _clear_skip_retry(self, session_id: str) -> None:
+        self._skip_retry_attempts.pop(session_id, None)
+        self._skip_retry_at.pop(session_id, None)
+
+    async def _prepare_pending_skip(self, intent: BacklogSkipIntent) -> bool:
+        """Retire frozen source work before a skip notice may be sent."""
+        if intent.purge_complete:
+            return True
+        callback = self._skip_purge_callback
+        if callback is None or not self._skip_retry_due(intent.session_id):
+            return False
+        try:
+            skipped = await callback(intent)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Failed to purge backlog for %s", intent.session_id)
+            self._schedule_skip_retry(intent.session_id)
+            return False
+        self.state.update_skip_count(intent.session_id, skipped)
+        self.state.save_if_dirty()
+        self._clear_skip_retry(intent.session_id)
+        return True
 
     async def _enqueue_pending_skip_notice(self, intent: BacklogSkipIntent) -> None:
         """Create one receipt-tracked visible notice for a persisted barrier."""
-        if intent.session_id in self._skip_notice_receipts:
+        if intent.session_id in self._skip_notice_receipts or not self._skip_retry_due(
+            intent.session_id
+        ):
             return
         callback = self._skip_notice_callback
         if callback is None:
@@ -229,25 +276,39 @@ class SessionMonitor:
             logger.exception(
                 "Failed to enqueue backlog skip notice for %s", intent.session_id
             )
+            self._schedule_skip_retry(intent.session_id)
         finally:
             deactivate_delivery_receipt(token)
             receipt.close()
-        self._skip_notice_receipts[intent.session_id] = receipt
+        if not receipt.failed:
+            self._clear_skip_retry(intent.session_id)
+            self._skip_notice_receipts[intent.session_id] = receipt
 
     async def _resume_pending_skip_notices(self) -> None:
         """Resume persisted skip barriers before reading any skipped bytes."""
         for intent in tuple(self.state.pending_skips.values()):
-            await self._enqueue_pending_skip_notice(intent)
+            if not self._skip_retry_due(intent.session_id):
+                continue
+            if await self._prepare_pending_skip(intent):
+                await self._enqueue_pending_skip_notice(intent)
 
     def _commit_pending_skips(self) -> None:
         """Advance only barriers whose visible notices reached Telegram."""
         for session_id, receipt in tuple(self._skip_notice_receipts.items()):
+            if receipt.failed:
+                # A failed notice has no acknowledgement boundary. Remove the
+                # failed receipt so the persisted barrier can retry in-process;
+                # the source remains paused until a notice is delivered.
+                self._skip_notice_receipts.pop(session_id, None)
+                self._schedule_skip_retry(session_id)
+                continue
             if not receipt.commit_ready:
                 continue
             if self.state.complete_skip(session_id):
                 self.state.save_if_dirty()
                 self._delivery_receipts.pop(session_id, None)
             self._skip_notice_receipts.pop(session_id, None)
+            self._clear_skip_retry(session_id)
 
     def record_hook_activity(self, window_id: str) -> None:
         """Record hook-based activity for a window (resets idle timers)."""

--- a/src/ccgram/thread_router.py
+++ b/src/ccgram/thread_router.py
@@ -25,11 +25,32 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+from dataclasses import dataclass
 import structlog
 from collections.abc import Callable, Iterator
 from typing import Any, cast
 
 logger = structlog.get_logger()
+
+_RETIRED_TOPIC_LIMIT = 100
+
+
+@dataclass(frozen=True)
+class RetiredTopic:
+    """A known former forum-topic binding retained for Sync cleanup.
+
+    This is deliberately local evidence only: a record means ccgram previously
+    owned this exact chat/thread binding. It is not evidence that arbitrary
+    Telegram topics can be enumerated or safely removed.
+    """
+
+    user_id: int
+    chat_id: int
+    thread_id: int
+    reason: str
+    cleanup_eligible: bool
+    sequence: int
+
 
 _active_chat_id: contextvars.ContextVar[int | None] = contextvars.ContextVar(
     "active_thread_chat_id", default=None
@@ -78,6 +99,8 @@ class ThreadRouter:
         # Reverse index: (user_id, window_id) -> thread_id for O(1) lookups
         self._window_to_thread: dict[tuple[int, str], int] = {}
         self._chat_window_to_thread: dict[tuple[int, int, str], int] = {}
+        self._retired_topics: list[RetiredTopic] = []
+        self._next_retired_sequence = 1
         self._schedule_save: Callable[[], None] = schedule_save
         self._has_window_state: Callable[[str], bool] = has_window_state
 
@@ -89,6 +112,8 @@ class ThreadRouter:
         self.window_display_names.clear()
         self._window_to_thread.clear()
         self._chat_window_to_thread.clear()
+        self._retired_topics.clear()
+        self._next_retired_sequence = 1
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -141,6 +166,17 @@ class ThreadRouter:
                 for (uid, chat_id, tid), wid in self.chat_thread_bindings.items()
             },
             "window_display_names": self.window_display_names,
+            "retired_topics": [
+                {
+                    "user_id": topic.user_id,
+                    "chat_id": topic.chat_id,
+                    "thread_id": topic.thread_id,
+                    "reason": topic.reason,
+                    "cleanup_eligible": topic.cleanup_eligible,
+                    "sequence": topic.sequence,
+                }
+                for topic in self._retired_topics
+            ],
         }
 
     def from_dict(self, data: dict[str, Any]) -> None:
@@ -159,8 +195,111 @@ class ThreadRouter:
             uid, chat_id, tid = (int(part) for part in key.split(":", 2))
             self.chat_thread_bindings[(uid, chat_id, tid)] = wid
         self.window_display_names = data.get("window_display_names", {})
+        self._retired_topics = self._load_retired_topics(data.get("retired_topics", []))
+        self._next_retired_sequence = (
+            max((topic.sequence for topic in self._retired_topics), default=0) + 1
+        )
         self._dedup_thread_bindings()
         self._rebuild_reverse_index()
+        for _user_id, chat_id, thread_id, _window_id in self.iter_thread_bindings_with_chat():
+            self._restore_active_topic(chat_id, thread_id)
+
+    @staticmethod
+    def _load_retired_topics(raw_topics: Any) -> list[RetiredTopic]:
+        """Load a bounded, validated retired-topic registry from persisted state."""
+        if not isinstance(raw_topics, list):
+            return []
+        loaded: list[RetiredTopic] = []
+        for raw in raw_topics[-_RETIRED_TOPIC_LIMIT:]:
+            if not isinstance(raw, dict):
+                continue
+            try:
+                reason = raw["reason"]
+                cleanup_eligible = raw["cleanup_eligible"]
+                topic = RetiredTopic(
+                    user_id=int(raw["user_id"]),
+                    chat_id=int(raw["chat_id"]),
+                    thread_id=int(raw["thread_id"]),
+                    reason=reason,
+                    cleanup_eligible=cleanup_eligible,
+                    sequence=int(raw["sequence"]),
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+            if (
+                not isinstance(reason, str)
+                or not reason
+                or not isinstance(cleanup_eligible, bool)
+                or topic.chat_id == topic.user_id
+                or topic.thread_id <= 0
+                or topic.sequence <= 0
+            ):
+                continue
+            loaded = [
+                existing
+                for existing in loaded
+                if (existing.chat_id, existing.thread_id)
+                != (topic.chat_id, topic.thread_id)
+            ]
+            loaded.append(topic)
+        return loaded
+
+    # ------------------------------------------------------------------
+    # Retired topic registry
+    # ------------------------------------------------------------------
+
+    def iter_retired_topics(self) -> Iterator[RetiredTopic]:
+        """Yield locally known retired topics in oldest-first retention order."""
+        return iter(tuple(self._retired_topics))
+
+    def discard_retired_topic(self, topic: RetiredTopic) -> bool:
+        """Remove exactly *topic* after a terminal Telegram API outcome."""
+        try:
+            self._retired_topics.remove(topic)
+        except ValueError:
+            return False
+        self._schedule_save()
+        return True
+
+    def _retire_topic(
+        self,
+        user_id: int,
+        chat_id: int | None,
+        thread_id: int,
+        *,
+        reason: str,
+        cleanup_eligible: bool,
+    ) -> None:
+        """Remember a known local forum topic, never an inferred Telegram topic."""
+        if chat_id is None or chat_id == user_id:
+            return
+        self._retired_topics = [
+            topic
+            for topic in self._retired_topics
+            if (topic.chat_id, topic.thread_id) != (chat_id, thread_id)
+        ]
+        self._retired_topics.append(
+            RetiredTopic(
+                user_id=user_id,
+                chat_id=chat_id,
+                thread_id=thread_id,
+                reason=reason,
+                cleanup_eligible=cleanup_eligible,
+                sequence=self._next_retired_sequence,
+            )
+        )
+        self._next_retired_sequence += 1
+        self._retired_topics = self._retired_topics[-_RETIRED_TOPIC_LIMIT:]
+
+    def _restore_active_topic(self, chat_id: int | None, thread_id: int) -> None:
+        """Forget a retired record when the same chat/topic is bound again."""
+        if chat_id is None:
+            return
+        self._retired_topics = [
+            topic
+            for topic in self._retired_topics
+            if (topic.chat_id, topic.thread_id) != (chat_id, thread_id)
+        ]
 
     # ------------------------------------------------------------------
     # Thread binding operations
@@ -214,10 +353,17 @@ class ThreadRouter:
             self._window_to_thread[(user_id, window_id)] = thread_id
         if window_name:
             self.window_display_names[window_id] = window_name
+        self._restore_active_topic(chat_id, thread_id)
         self._schedule_save()
 
     def unbind_thread(
-        self, user_id: int, thread_id: int, chat_id: int | None = None
+        self,
+        user_id: int,
+        thread_id: int,
+        chat_id: int | None = None,
+        *,
+        retirement_reason: str = "keep_remote",
+        cleanup_eligible: bool = False,
     ) -> str | None:
         """Remove a thread binding.  Returns the previously bound window_id.
 
@@ -225,6 +371,7 @@ class ThreadRouter:
         display names — the caller (SessionManager) handles display-name
         lifecycle because it requires window_states knowledge.
         """
+        known_chat_id: int | None = chat_id
         if chat_id is not None:
             key = (user_id, chat_id, thread_id)
             window_id = self.chat_thread_bindings.pop(key, None)
@@ -243,11 +390,13 @@ class ThreadRouter:
                 if len(candidates) != 1:
                     return None
                 key, window_id = candidates[0]
+                known_chat_id = key[1]
                 self.chat_thread_bindings.pop(key, None)
                 self._chat_window_to_thread.pop((user_id, key[1], window_id), None)
                 self.group_chat_ids.pop(f"{user_id}:{thread_id}:{key[1]}", None)
             else:
                 window_id = bindings.pop(thread_id)
+                known_chat_id = self.group_chat_ids.get(f"{user_id}:{thread_id}")
                 self._window_to_thread.pop((user_id, window_id), None)
                 if not bindings:
                     del self.thread_bindings[user_id]
@@ -263,6 +412,14 @@ class ThreadRouter:
             thread_id,
             window_id,
             user_id,
+        )
+
+        self._retire_topic(
+            user_id,
+            known_chat_id,
+            thread_id,
+            reason=retirement_reason,
+            cleanup_eligible=cleanup_eligible,
         )
 
         # Clean up group_chat_id for the unbound thread
@@ -402,6 +559,7 @@ class ThreadRouter:
             self._window_to_thread.pop((user_id, window_id), None)
             self.chat_thread_bindings[(user_id, chat_id, thread_id)] = window_id
             self._chat_window_to_thread[(user_id, chat_id, window_id)] = thread_id
+            self._restore_active_topic(chat_id, thread_id)
         key = f"{user_id}:{thread_id}"
         if self.group_chat_ids.get(key) != chat_id:
             self.group_chat_ids[key] = chat_id

--- a/src/ccgram/thread_router.py
+++ b/src/ccgram/thread_router.py
@@ -201,7 +201,12 @@ class ThreadRouter:
         )
         self._dedup_thread_bindings()
         self._rebuild_reverse_index()
-        for _user_id, chat_id, thread_id, _window_id in self.iter_thread_bindings_with_chat():
+        for (
+            _user_id,
+            chat_id,
+            thread_id,
+            _window_id,
+        ) in self.iter_thread_bindings_with_chat():
             self._restore_active_topic(chat_id, thread_id)
 
     @staticmethod
@@ -224,7 +229,7 @@ class ThreadRouter:
                     cleanup_eligible=cleanup_eligible,
                     sequence=int(raw["sequence"]),
                 )
-            except (KeyError, TypeError, ValueError):
+            except KeyError, TypeError, ValueError:
                 continue
             if (
                 not isinstance(reason, str)

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -421,6 +421,9 @@ class TranscriptReader:
 
     def clear_session(self, session_id: str) -> None:
         """Remove all per-session state for a cleaned-up session."""
+        # A skip barrier belongs to the tracked session lifetime. Once that
+        # session disappears, cancel it so it cannot block a future replay.
+        self._state.cancel_skip(session_id)
         self._state.remove_session(session_id)
         self._file_mtimes.pop(session_id, None)
         self._pending_tools.pop(session_id, None)
@@ -456,6 +459,9 @@ class TranscriptReader:
                 file_path=str(file_path),
                 last_byte_offset=old_session.last_byte_offset,
             )
+            # Session IDs can be refreshed for the same transcript. A pending
+            # skip is tied to the old identity and must not follow it silently.
+            self._state.cancel_skip(old_session_id)
             self._state.remove_session(old_session_id)
             self._state.update_session(tracked)
             if old_session_id in self._file_mtimes:

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -17,7 +17,7 @@ import asyncio
 import hashlib
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple
 
 import aiofiles
 import structlog
@@ -132,9 +132,15 @@ class TranscriptReader:
     Delegates activity recording to IdleTracker (via session_id).
     """
 
-    def __init__(self, state: MonitorState, idle_tracker: IdleTracker) -> None:
+    def __init__(
+        self,
+        state: MonitorState,
+        idle_tracker: IdleTracker,
+        on_session_retired: Callable[[str], None] | None = None,
+    ) -> None:
         self._state = state
         self._idle_tracker = idle_tracker
+        self._on_session_retired = on_session_retired
         self._pending_tools: dict[str, dict[str, Any]] = {}
         self._file_mtimes: dict[str, float] = {}
         self._file_ctimes: dict[str, int] = self._snapshot_file_ctimes()
@@ -424,6 +430,8 @@ class TranscriptReader:
         # A skip barrier belongs to the tracked session lifetime. Once that
         # session disappears, cancel it so it cannot block a future replay.
         self._state.cancel_skip(session_id)
+        if self._on_session_retired is not None:
+            self._on_session_retired(session_id)
         self._state.remove_session(session_id)
         self._file_mtimes.pop(session_id, None)
         self._pending_tools.pop(session_id, None)
@@ -462,6 +470,8 @@ class TranscriptReader:
             # Session IDs can be refreshed for the same transcript. A pending
             # skip is tied to the old identity and must not follow it silently.
             self._state.cancel_skip(old_session_id)
+            if self._on_session_retired is not None:
+                self._on_session_retired(old_session_id)
             self._state.remove_session(old_session_id)
             self._state.update_session(tracked)
             if old_session_id in self._file_mtimes:

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_queue.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_queue.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from telegram.error import RetryAfter, TelegramError
+from telegramify_markdown import utf16_len
 
 from ccgram.handlers.messaging_pipeline.message_queue import (
     MERGE_MAX_LENGTH,
@@ -229,6 +230,17 @@ class TestMergeContentTasks:
 
         merged, count = await _merge_content_tasks(queue, first, lock)
 
+        assert merged is first
+        assert count == 0
+        assert queue.qsize() == 1
+
+    async def test_utf16_units_count_toward_length_limit(self, queue, lock):
+        first = _content_task("😀" * (MERGE_MAX_LENGTH // 2))
+        queue.put_nowait(_content_task("x"))
+
+        merged, count = await _merge_content_tasks(queue, first, lock)
+
+        assert utf16_len(first.parts[0]) == MERGE_MAX_LENGTH
         assert merged is first
         assert count == 0
         assert queue.qsize() == 1

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_queue.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_queue.py
@@ -9,6 +9,7 @@ import pytest
 from telegram.error import RetryAfter, TelegramError
 from telegramify_markdown import utf16_len
 
+from ccgram.delivery_contract import DeliveryOutcome
 from ccgram.handlers.messaging_pipeline.message_queue import (
     MERGE_MAX_LENGTH,
     _can_merge_tasks,
@@ -467,6 +468,31 @@ class TestDispatch:
 
 
 class TestChatScopedContentDelivery:
+    async def test_stale_backlog_notice_is_not_sent(self) -> None:
+        client = FakeTelegramClient()
+        task = ContentTask(
+            window_id="@0",
+            parts=("skipped",),
+            thread_id=42,
+            chat_id=-1002,
+            is_backlog_notice=True,
+        )
+
+        with (
+            patch(
+                "ccgram.handlers.messaging_pipeline.message_queue.thread_router.resolve_window_for_thread",
+                return_value="@other",
+            ),
+            patch(
+                "ccgram.handlers.messaging_pipeline.message_queue.rate_limit_send_message",
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
+            outcome = await _process_content_task(client, 100, task)
+
+        assert outcome is DeliveryOutcome.FAILED
+        mock_send.assert_not_awaited()
+
     async def test_content_task_uses_explicit_chat_id(self) -> None:
         client = FakeTelegramClient()
         task = ContentTask(

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_queue.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_queue.py
@@ -49,6 +49,7 @@ def _content_task(
     content_type: ContentType = "text",
     thread_id: int | None = 42,
     tool_use_id: str | None = None,
+    chat_id: int | None = -1001,
 ) -> ContentTask:
     return ContentTask(
         window_id=window_id,
@@ -56,6 +57,7 @@ def _content_task(
         content_type=content_type,
         thread_id=thread_id,
         tool_use_id=tool_use_id,
+        chat_id=chat_id,
     )
 
 
@@ -140,6 +142,36 @@ class TestCanMergeTasks:
         b = _content_task("world", window_id="@1")
         assert not _can_merge_tasks(a, b)
 
+    @pytest.mark.parametrize("content_type", ["thinking", "tool_use", "tool_result"])
+    def test_non_plain_text_blocks_merge(self, content_type: ContentType):
+        candidate = _content_task("world", content_type=content_type)
+        assert not _can_merge_tasks(_content_task("hello"), candidate)
+
+    def test_chat_and_thread_boundaries_block_merge(self):
+        base = ContentTask(
+            window_id="@0", parts=("hello",), thread_id=42, chat_id=-1001
+        )
+        assert not _can_merge_tasks(
+            base,
+            ContentTask(window_id="@0", parts=("world",), thread_id=43, chat_id=-1001),
+        )
+        assert not _can_merge_tasks(
+            base,
+            ContentTask(window_id="@0", parts=("world",), thread_id=42, chat_id=-1002),
+        )
+        assert not _can_merge_tasks(
+            ContentTask(window_id="@0", parts=("hello",), thread_id=42),
+            ContentTask(window_id="@0", parts=("world",), thread_id=42),
+        )
+
+    def test_tool_metadata_and_paginated_parts_block_merge(self):
+        base = _content_task("hello")
+        assert not _can_merge_tasks(base, _content_task("world", tool_use_id="tool-1"))
+        assert not _can_merge_tasks(
+            base,
+            ContentTask(window_id="@0", parts=("page one", "page two"), thread_id=42),
+        )
+
     def test_non_content_candidate_blocks_merge(self):
         assert not _can_merge_tasks(_content_task("hello"), _status_task())
 
@@ -179,7 +211,7 @@ class TestMergeContentTasks:
         assert queue.qsize() == 1
 
     async def test_merges_up_to_the_exact_length_limit(self, queue, lock):
-        half = "x" * (MERGE_MAX_LENGTH // 2)
+        half = "x" * ((MERGE_MAX_LENGTH - 2) // 2)
         queue.put_nowait(_content_task(half))
         queue.put_nowait(_content_task("overflow"))
         first = _content_task(half)
@@ -187,7 +219,18 @@ class TestMergeContentTasks:
         merged, count = await _merge_content_tasks(queue, first, lock)
 
         assert count == 1
-        assert sum(len(p) for p in merged.parts) <= MERGE_MAX_LENGTH
+        assert sum(len(p) for p in merged.parts) + 2 <= MERGE_MAX_LENGTH
+        assert merged.is_text_batch is True
+        assert queue.qsize() == 1
+
+    async def test_separator_counts_toward_length_limit(self, queue, lock):
+        first = _content_task("x" * (MERGE_MAX_LENGTH - 1))
+        queue.put_nowait(_content_task("x"))
+
+        merged, count = await _merge_content_tasks(queue, first, lock)
+
+        assert merged is first
+        assert count == 0
         assert queue.qsize() == 1
 
     async def test_no_merge_returns_zero(self, queue, lock):
@@ -197,6 +240,40 @@ class TestMergeContentTasks:
 
         assert count == 0
         assert merged is first
+
+
+class TestActualTextBatching:
+    async def test_consecutive_text_tasks_use_one_formatted_api_call(
+        self, bot, queue, lock
+    ):
+        first = ContentTask(
+            window_id="@0", parts=("**first**",), thread_id=42, chat_id=-1001
+        )
+        queue.put_nowait(
+            ContentTask(
+                window_id="@0", parts=("_second_",), thread_id=42, chat_id=-1001
+            )
+        )
+
+        result = await _handle_content_task(bot, 1, first, queue, lock)
+
+        assert result == 1
+        assert bot.call_count("send_message") == 1
+        call = bot.last_call("send_message")
+        assert call is not None
+        assert call.kwargs["text"] == "first\n\nsecond"
+        assert {entity.type for entity in call.kwargs["entities"]} == {"bold", "italic"}
+        assert [entity.offset for entity in call.kwargs["entities"]] == [0, 7]
+
+    async def test_tts_media_tasks_do_not_merge(self, monkeypatch):
+        first = _content_task("first")
+        candidate = _content_task("second")
+        monkeypatch.setattr(
+            "ccgram.handlers.messaging_pipeline.message_queue.config.tts_provider",
+            "edge",
+        )
+
+        assert not _can_merge_tasks(first, candidate)
 
 
 class TestCoalesceStatusUpdates:
@@ -685,6 +762,97 @@ class TestMessageQueueWorker:
             ):
                 await asyncio.wait_for(mq._message_queues[user_id].join(), timeout=1)
 
+            assert all(receipt.failed for receipt in receipts)
+            assert all(not receipt.commit_ready for receipt in receipts)
+        finally:
+            worker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await worker
+            mq._message_queues.pop(user_id, None)
+            mq._queue_locks.pop(user_id, None)
+
+    async def test_batched_retry_after_retries_one_combined_payload_and_receipts(
+        self, bot
+    ):
+        from ccgram.handlers.messaging_pipeline import message_queue as mq
+
+        user_id = 88004
+        mq._message_queues[user_id] = asyncio.Queue()
+        mq._queue_locks[user_id] = asyncio.Lock()
+        receipts = [mq.DeliveryReceipt(), mq.DeliveryReceipt()]
+        for receipt in receipts:
+            receipt.track()
+            receipt.close()
+        mq._message_queues[user_id].put_nowait(
+            ContentTask(
+                window_id="@0",
+                parts=("first",),
+                thread_id=42,
+                chat_id=-1001,
+                delivery_receipts=(receipts[0],),
+            )
+        )
+        mq._message_queues[user_id].put_nowait(
+            ContentTask(
+                window_id="@0",
+                parts=("second",),
+                thread_id=42,
+                chat_id=-1001,
+                delivery_receipts=(receipts[1],),
+            )
+        )
+        bot.set_side_effect("send_message", [RetryAfter(timedelta(seconds=0)), True])
+        worker = asyncio.create_task(mq._message_queue_worker(bot, user_id))
+        try:
+            with (
+                patch.object(mq.asyncio, "sleep", new_callable=AsyncMock),
+                patch("random.uniform", return_value=0),
+            ):
+                await asyncio.wait_for(mq._message_queues[user_id].join(), timeout=1)
+
+            assert bot.call_count("send_message") == 2
+            assert [call.kwargs["text"] for call in bot.calls] == [
+                "first\n\nsecond",
+                "first\n\nsecond",
+            ]
+            assert all(receipt.commit_ready for receipt in receipts)
+        finally:
+            worker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await worker
+            mq._message_queues.pop(user_id, None)
+            mq._queue_locks.pop(user_id, None)
+
+    async def test_batched_terminal_failure_fails_every_receipt(self, bot):
+        from ccgram.handlers.messaging_pipeline import message_queue as mq
+
+        user_id = 88005
+        mq._message_queues[user_id] = asyncio.Queue()
+        mq._queue_locks[user_id] = asyncio.Lock()
+        receipts = [mq.DeliveryReceipt(), mq.DeliveryReceipt()]
+        for receipt in receipts:
+            receipt.track()
+            receipt.close()
+        for text, receipt in zip(("first", "second"), receipts, strict=True):
+            mq._message_queues[user_id].put_nowait(
+                ContentTask(
+                    window_id="@0",
+                    parts=(text,),
+                    thread_id=42,
+                    chat_id=-1001,
+                    delivery_receipts=(receipt,),
+                )
+            )
+        # Entity and plain fallback both fail, so the batch reports a terminal
+        # delivery failure rather than advancing either transcript receipt.
+        bot.set_side_effect(
+            "send_message", [TelegramError("entity"), TelegramError("plain")]
+        )
+        worker = asyncio.create_task(mq._message_queue_worker(bot, user_id))
+        try:
+            await asyncio.wait_for(mq._message_queues[user_id].join(), timeout=1)
+
+            assert bot.call_count("send_message") == 2
             assert all(receipt.failed for receipt in receipts)
             assert all(not receipt.commit_ready for receipt in receipts)
         finally:

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_queue_properties.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_queue_properties.py
@@ -34,6 +34,7 @@ def _content_task(
         window_id=window_id,
         parts=parts or ("hello",),
         content_type=content_type,
+        chat_id=-1001,
     )
 
 
@@ -57,7 +58,7 @@ async def test_merged_length_never_exceeds_limit(parts_list: list[str]) -> None:
         await queue.put(_content_task(parts=(p,)))
 
     merged, _count = await _merge_content_tasks(queue, first, lock)
-    total = sum(len(p) for p in merged.parts)
+    total = sum(len(p) for p in merged.parts) + 2 * (len(merged.parts) - 1)
     assert total <= MERGE_MAX_LENGTH
 
 

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_sender.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_sender.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 from telegram import Message
 from telegram.error import BadRequest, RetryAfter, TelegramError
+from telegramify_markdown import utf16_len
 
 from ccgram.expandable_quote import EXPANDABLE_QUOTE_END as EXP_END
 from ccgram.expandable_quote import EXPANDABLE_QUOTE_START as EXP_START
@@ -276,6 +277,20 @@ class TestEmptyAndOverlongGuards:
         assert last is not None
         sent_text = last.kwargs["text"]
         assert len(sent_text) <= TELEGRAM_MAX_MESSAGE_LENGTH
+        assert sent_text.endswith("…")
+
+    async def test_overlong_emoji_text_truncates_by_utf16_units(
+        self, client: FakeTelegramClient
+    ) -> None:
+        from ccgram.telegram_sender import TELEGRAM_MAX_MESSAGE_LENGTH
+
+        client.returns["send_message"] = _fake_message()
+        await _send_with_fallback(client, 123, "😀" * 3000)
+
+        last = client.last_call("send_message")
+        assert last is not None
+        sent_text = last.kwargs["text"]
+        assert utf16_len(sent_text) <= TELEGRAM_MAX_MESSAGE_LENGTH
         assert sent_text.endswith("…")
 
 

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -113,7 +113,9 @@ class TestAutocloseTimers:
             chat_id=-100, message_thread_id=42
         )
         bot.delete_forum_topic.assert_not_called()
-        mock_tr.unbind_thread.assert_called_once_with(1, 42)
+        mock_tr.unbind_thread.assert_called_once_with(
+            1, 42, retirement_reason="remote_closed"
+        )
         assert not _has_autoclose(1, 42)
 
     async def test_check_not_expired_yet(self) -> None:
@@ -187,7 +189,9 @@ class TestAutocloseTimers:
             chat_id=-100, message_thread_id=42
         )
         bot.delete_forum_topic.assert_not_called()
-        mock_tr.unbind_thread.assert_called_once_with(1, 42)
+        mock_tr.unbind_thread.assert_called_once_with(
+            1, 42, retirement_reason="remote_closed"
+        )
         mock_clear.assert_awaited_once()
         assert not _has_autoclose(1, 42)
 
@@ -781,7 +785,9 @@ class TestProbeFailures:
             await probe_topic_existence(bot)
         mock_tm.kill_window.assert_not_called()
         mock_cleanup.assert_called_once_with(1, 42, bot, window_id="@5", chat_id=-100)
-        mock_tr.unbind_thread.assert_called_once_with(1, 42, chat_id=-100)
+        mock_tr.unbind_thread.assert_called_once_with(
+            1, 42, chat_id=-100, retirement_reason="remote_deleted"
+        )
         assert (
             _window_poll_state.get("@5") is None
             or _window_poll_state["@5"].probe_failures == 0
@@ -2284,7 +2290,9 @@ class TestDeadWindowNotification:
 
         mock_tm.kill_window.assert_not_called()
         mock_cleanup.assert_called_once_with(1, 42, bot, window_id="@5", chat_id=-100)
-        mock_tr.unbind_thread.assert_called_once_with(1, 42, chat_id=-100)
+        mock_tr.unbind_thread.assert_called_once_with(
+            1, 42, chat_id=-100, retirement_reason="remote_deleted"
+        )
 
 
 def _make_pane(pane_id: str = "%1", *, active: bool = True, index: int = 0) -> PaneInfo:

--- a/tests/ccgram/handlers/polling/test_window_tick.py
+++ b/tests/ccgram/handlers/polling/test_window_tick.py
@@ -537,7 +537,9 @@ class TestDeadWindowTopicDeleted:
             mock_clear.assert_awaited_once()
             _, kwargs = mock_clear.call_args
             assert kwargs.get("window_dead") is True
-            mock_tr.unbind_thread.assert_called_once_with(1, 100)
+            mock_tr.unbind_thread.assert_called_once_with(
+                1, 100, retirement_reason="remote_deleted"
+            )
 
 
 class TestPaneLifecycleNotify:

--- a/tests/ccgram/handlers/recovery/test_recovery_ui.py
+++ b/tests/ccgram/handlers/recovery/test_recovery_ui.py
@@ -449,7 +449,12 @@ class TestRecoveryFreshCallback:
 
         await _tap(f"{CB_RECOVERY_FRESH}@0", _make_context(_recovery_user_data()))
 
-        recovery_env.router.unbind_thread.assert_called_once_with(100, 42)
+        recovery_env.router.unbind_thread.assert_called_once_with(
+            100,
+            42,
+            retirement_reason="system_replacement",
+            cleanup_eligible=True,
+        )
         recovery_env.tmux.create_window.assert_called_once_with(
             "/tmp/project", agent_args="", launch_command="claude"
         )

--- a/tests/ccgram/handlers/recovery/test_resume_command.py
+++ b/tests/ccgram/handlers/recovery/test_resume_command.py
@@ -860,7 +860,12 @@ class TestResumePickCallback:
 
         await _pick(0, [_session()], _make_context())
 
-        pick_env.router.unbind_thread.assert_called_once_with(100, 42)
+        pick_env.router.unbind_thread.assert_called_once_with(
+            100,
+            42,
+            retirement_reason="system_replacement",
+            cleanup_eligible=True,
+        )
 
     async def test_pick_sets_group_chat_id(self, pick_env) -> None:
         await _pick(0, [_session()], _make_context())

--- a/tests/ccgram/handlers/test_backlog.py
+++ b/tests/ccgram/handlers/test_backlog.py
@@ -257,7 +257,7 @@ async def test_notice_enqueue_failure_retries_in_process(tmp_path: Path) -> None
         purge=purge, notice=notice, validate=lambda _intent: True
     )
     intent = await monitor.request_backlog_skip(1, "@0", 4, 99)
-    assert intent is not None
+    assert intent is None
     assert attempts == 1
     assert "s1" not in monitor._skip_notice_receipts
     assert "s1" in monitor.state.pending_skips

--- a/tests/ccgram/handlers/test_backlog.py
+++ b/tests/ccgram/handlers/test_backlog.py
@@ -23,7 +23,7 @@ from ccgram.handlers.status.status_bubble import (
     build_status_keyboard,
     format_backlog_status,
 )
-from ccgram.monitor_state import TrackedSession
+from ccgram.monitor_state import BacklogSkipIntent, TrackedSession
 from ccgram.session_monitor import SessionMonitor
 
 
@@ -194,7 +194,9 @@ async def test_failed_notice_retries_in_process_before_watermark_advances(
         assert receipt is not None
         receipt.track()
 
-    monitor.set_skip_callbacks(purge=purge, notice=notice)
+    monitor.set_skip_callbacks(
+        purge=purge, notice=notice, validate=lambda _intent: True
+    )
     intent = await monitor.request_backlog_skip(1, "@0", 4, 99)
     assert intent is not None
     assert intent.snapshot_offset == 50
@@ -251,7 +253,9 @@ async def test_notice_enqueue_failure_retries_in_process(tmp_path: Path) -> None
         assert receipt is not None
         receipt.track()
 
-    monitor.set_skip_callbacks(purge=purge, notice=notice)
+    monitor.set_skip_callbacks(
+        purge=purge, notice=notice, validate=lambda _intent: True
+    )
     intent = await monitor.request_backlog_skip(1, "@0", 4, 99)
     assert intent is not None
     assert attempts == 1
@@ -281,10 +285,12 @@ async def test_failed_purge_resumes_after_restart_before_notice(tmp_path: Path) 
         raise RuntimeError("queue unavailable")
 
     notice = AsyncMock()
-    monitor.set_skip_callbacks(purge=failed_purge, notice=notice)
+    monitor.set_skip_callbacks(
+        purge=failed_purge, notice=notice, validate=lambda _intent: True
+    )
     intent = await monitor.request_backlog_skip(1, "@0", 4, 99)
-    assert intent is not None
-    assert intent.purge_complete is False
+    assert intent is None
+    assert monitor.state.pending_skips["s1"].purge_complete is False
     notice.assert_not_awaited()
     assert "s1" in monitor.state.pending_skips
 
@@ -298,13 +304,92 @@ async def test_failed_purge_resumes_after_restart_before_notice(tmp_path: Path) 
         assert receipt is not None
         receipt.track()
 
-    restarted.set_skip_callbacks(purge=purge, notice=resumed_notice)
+    restarted.set_skip_callbacks(
+        purge=purge, notice=resumed_notice, validate=lambda _intent: True
+    )
     await restarted._resume_pending_skip_notices()
     assert restarted.state.pending_skips["s1"].purge_complete is True
     assert restarted.state.pending_skips["s1"].skipped_count == 3
     restarted._skip_notice_receipts["s1"].settle(DeliveryOutcome.DELIVERED)
     restarted.commit_delivered_watermarks()
     assert restarted.state.get_session("s1").last_byte_offset == 50  # type: ignore[union-attr]
+    assert "s1" not in restarted.state.pending_skips
+
+
+async def test_purge_retry_preserves_retired_count_after_state_save_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_bytes(b"x" * 50)
+    monitor = SessionMonitor(
+        projects_path=tmp_path, state_file=tmp_path / "monitor.json"
+    )
+    monitor.state.update_session(
+        TrackedSession("s1", str(transcript), last_byte_offset=10, parsed_offset=50)
+    )
+    monitor._last_session_map = {"@0": {"session_id": "s1"}}
+    purge_calls = 0
+
+    async def purge(_intent) -> int:
+        nonlocal purge_calls
+        purge_calls += 1
+        return 3 if purge_calls == 1 else 0
+
+    async def notice(_intent) -> None:
+        receipt = get_active_delivery_receipt()
+        assert receipt is not None
+        receipt.track()
+
+    real_save = monitor.state.save_if_dirty
+    save_calls = 0
+
+    def save_once_as_failed() -> bool:
+        nonlocal save_calls
+        save_calls += 1
+        if save_calls == 2:
+            return False
+        return real_save()
+
+    monkeypatch.setattr(monitor.state, "save_if_dirty", save_once_as_failed)
+    monitor.set_skip_callbacks(
+        purge=purge, notice=notice, validate=lambda _intent: True
+    )
+    assert await monitor.request_backlog_skip(1, "@0", 4, 99) is None
+    assert monitor.state.pending_skips["s1"].skipped_count == 3
+
+    monitor._skip_retry_at["s1"] = 0.0
+    await monitor._resume_pending_skip_notices()
+
+    assert monitor.state.pending_skips["s1"].skipped_count == 3
+    assert monitor.state.pending_skips["s1"].purge_complete is True
+
+
+async def test_purge_complete_skip_is_cancelled_after_topic_rebound(
+    tmp_path: Path,
+) -> None:
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_bytes(b"x" * 50)
+    state_file = tmp_path / "monitor.json"
+    monitor = SessionMonitor(projects_path=tmp_path, state_file=state_file)
+    monitor.state.update_session(
+        TrackedSession("s1", str(transcript), last_byte_offset=10, parsed_offset=50)
+    )
+    monitor._last_session_map = {"@0": {"session_id": "s1"}}
+    intent = BacklogSkipIntent("s1", "@0", 1, 4, 99, 50, 10)
+    monitor.state.begin_skip(intent)
+    monitor.state.update_skip_count("s1", 3)
+    assert monitor.state.save_if_dirty()
+
+    restarted = SessionMonitor(projects_path=tmp_path, state_file=state_file)
+    notice = AsyncMock()
+    restarted.set_skip_callbacks(
+        purge=AsyncMock(return_value=0),
+        notice=notice,
+        validate=lambda _intent: False,
+    )
+    await restarted._resume_pending_skip_notices()
+
+    notice.assert_not_awaited()
     assert "s1" not in restarted.state.pending_skips
 
 

--- a/tests/ccgram/handlers/test_backlog.py
+++ b/tests/ccgram/handlers/test_backlog.py
@@ -94,6 +94,32 @@ def test_backlog_status_reports_count_age_lag_and_throttles() -> None:
     assert get_snapshot.call_count == 2
 
 
+async def test_purge_refuses_rebound_topic_before_draining() -> None:
+    user_id = 702
+    queue: asyncio.Queue = asyncio.Queue()
+    mq._message_queues[user_id] = queue
+    mq._queue_locks[user_id] = asyncio.Lock()
+    queue.put_nowait(
+        ContentTask(
+            window_id="@0",
+            parts=("old",),
+            thread_id=4,
+            chat_id=99,
+            source_session_id="s1",
+            source_checkpoint=50,
+        )
+    )
+    try:
+        with patch.object(
+            mq.thread_router, "resolve_window_for_thread", return_value="@1"
+        ):
+            assert await mq.purge_source_tasks(user_id, "@0", 4, "s1", 50, 99) is None
+        assert queue.qsize() == 1
+    finally:
+        mq._message_queues.clear()
+        mq._queue_locks.clear()
+
+
 async def test_purge_is_source_scoped_and_settles_only_retired_receipts() -> None:
     user_id = 701
     queue: asyncio.Queue = asyncio.Queue()

--- a/tests/ccgram/handlers/test_backlog.py
+++ b/tests/ccgram/handlers/test_backlog.py
@@ -1,0 +1,227 @@
+"""Safety coverage for source-scoped backlog progress and live jumps."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ccgram.delivery_contract import DeliveryOutcome, get_active_delivery_receipt
+from ccgram.handlers.callback_data import (
+    CB_STATUS_BACKLOG_CANCEL,
+    CB_STATUS_BACKLOG_CONFIRM,
+    CB_STATUS_BACKLOG_JUMP,
+)
+from ccgram.handlers.messaging_pipeline import message_queue as mq
+from ccgram.handlers.messaging_pipeline.backlog import BacklogSnapshot
+from ccgram.handlers.messaging_pipeline.message_task import (
+    ContentTask,
+    StatusUpdateTask,
+)
+from ccgram.handlers.status.status_bar_actions import _handle_status_bar_action
+from ccgram.handlers.status.status_bubble import (
+    build_status_keyboard,
+    format_backlog_status,
+)
+from ccgram.monitor_state import TrackedSession
+from ccgram.session_monitor import SessionMonitor
+
+
+def _callbacks(kb) -> list[str]:
+    return [
+        button.callback_data
+        for row in kb.inline_keyboard
+        for button in row
+        if isinstance(button.callback_data, str)
+    ]
+
+
+def test_jump_button_is_only_rendered_for_severe_backlog() -> None:
+    assert not any(
+        data.startswith(CB_STATUS_BACKLOG_JUMP)
+        for data in _callbacks(build_status_keyboard("@0", backlog_severe=False))
+    )
+    assert any(
+        data.startswith(CB_STATUS_BACKLOG_JUMP)
+        for data in _callbacks(build_status_keyboard("@0", backlog_severe=True))
+    )
+
+
+async def test_status_update_includes_backlog_progress() -> None:
+    with (
+        patch(
+            "ccgram.handlers.status.status_bubble.format_claude_task_status",
+            return_value="Working",
+        ),
+        patch(
+            "ccgram.handlers.status.status_bubble.format_backlog_status",
+            return_value=("Queue: 2 pending · age 4s · delivery lag 1.0s", False),
+        ),
+        patch(
+            "ccgram.handlers.status.status_bubble.send_status_text",
+            new_callable=AsyncMock,
+        ) as send,
+    ):
+        from ccgram.handlers.status.status_bubble import process_status_update
+
+        await process_status_update(
+            MagicMock(),
+            1,
+            StatusUpdateTask(window_id="@0", text="Working", thread_id=4),
+        )
+    call = send.await_args
+    assert call is not None
+    assert call.args[4] == "Working\nQueue: 2 pending · age 4s · delivery lag 1.0s"
+    assert call.kwargs["backlog_severe"] is False
+
+
+def test_backlog_status_reports_count_age_lag_and_throttles() -> None:
+    from ccgram.handlers.status import status_bubble
+
+    status_bubble._backlog_status_cache.clear()
+    snapshot = BacklogSnapshot(100, 301.0, 2.5)
+    with patch(
+        "ccgram.handlers.messaging_pipeline.backlog.get_backlog_snapshot",
+        return_value=snapshot,
+    ) as get_snapshot:
+        line, severe = format_backlog_status(1, 2, "@0")
+        second, second_severe = format_backlog_status(1, 2, "@0")
+    assert "100 pending" in line
+    assert "age 301s" in line
+    assert "delivery lag 2.5s" in line
+    assert severe is True and second_severe is True
+    assert second == line
+    assert get_snapshot.call_count == 2
+
+
+async def test_purge_is_source_scoped_and_settles_only_retired_receipts() -> None:
+    user_id = 701
+    queue: asyncio.Queue = asyncio.Queue()
+    mq._message_queues[user_id] = queue
+    mq._queue_locks[user_id] = asyncio.Lock()
+    retired = mq.DeliveryReceipt(checkpoint=50)
+    retained = mq.DeliveryReceipt(checkpoint=60)
+    for receipt in (retired, retained):
+        receipt.track()
+        receipt.close()
+    queue.put_nowait(
+        ContentTask(
+            window_id="@0",
+            parts=("old",),
+            thread_id=4,
+            source_session_id="s1",
+            source_checkpoint=50,
+            delivery_receipts=(retired,),
+        )
+    )
+    queue.put_nowait(
+        ContentTask(
+            window_id="@0",
+            parts=("new",),
+            thread_id=4,
+            source_session_id="s1",
+            source_checkpoint=60,
+            delivery_receipts=(retained,),
+        )
+    )
+    queue.put_nowait(
+        ContentTask(
+            window_id="@1",
+            parts=("other",),
+            thread_id=4,
+            source_session_id="s1",
+            source_checkpoint=50,
+        )
+    )
+    try:
+        assert await mq.purge_source_tasks(user_id, "@0", 4, "s1", 50) == 1
+        assert retired.commit_ready is True
+        assert retained.commit_ready is False
+        assert queue.qsize() == 2
+    finally:
+        mq._message_queues.clear()
+        mq._queue_locks.clear()
+
+
+async def test_notice_receipt_precedes_watermark_and_resumes_after_restart(
+    tmp_path: Path,
+) -> None:
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_bytes(b"x" * 50)
+    state_file = tmp_path / "monitor.json"
+    monitor = SessionMonitor(projects_path=tmp_path, state_file=state_file)
+    monitor.state.update_session(
+        TrackedSession("s1", str(transcript), last_byte_offset=10, parsed_offset=50)
+    )
+    monitor._last_session_map = {"@0": {"session_id": "s1"}}
+    purged: list[int] = []
+
+    async def purge(intent) -> int:
+        purged.append(intent.snapshot_offset)
+        return 3
+
+    async def notice(_intent) -> None:
+        receipt = get_active_delivery_receipt()
+        assert receipt is not None
+        receipt.track()
+
+    monitor.set_skip_callbacks(purge=purge, notice=notice)
+    intent = await monitor.request_backlog_skip(1, "@0", 4, 99)
+    assert intent is not None
+    assert intent.snapshot_offset == 50
+    assert intent.range_start == 10
+    assert intent.skipped_count == 3
+    assert purged == [50]
+    monitor.commit_delivered_watermarks()
+    assert monitor.state.get_session("s1").last_byte_offset == 10  # type: ignore[union-attr]
+
+    first_notice = monitor._skip_notice_receipts["s1"]
+    first_notice.settle(DeliveryOutcome.FAILED)
+    monitor.commit_delivered_watermarks()
+    assert monitor.state.get_session("s1").last_byte_offset == 10  # type: ignore[union-attr]
+    assert "s1" in monitor.state.pending_skips
+
+    restarted = SessionMonitor(projects_path=tmp_path, state_file=state_file)
+    resumed: list[str] = []
+
+    async def resumed_notice(intent) -> None:
+        resumed.append(intent.session_id)
+        receipt = get_active_delivery_receipt()
+        assert receipt is not None
+        receipt.track()
+
+    restarted.set_skip_callbacks(purge=purge, notice=resumed_notice)
+    await restarted._resume_pending_skip_notices()
+    assert resumed == ["s1"]
+    restarted._skip_notice_receipts["s1"].settle(DeliveryOutcome.DELIVERED)
+    restarted.commit_delivered_watermarks()
+    assert restarted.state.get_session("s1").last_byte_offset == 50  # type: ignore[union-attr]
+    assert "s1" not in restarted.state.pending_skips
+    assert transcript.read_bytes() == b"x" * 50
+
+
+async def test_confirmation_and_cancellation_do_not_skip_without_confirmation() -> None:
+    query = AsyncMock()
+    query.message.chat.id = 99
+    query.get_bot.return_value = AsyncMock()
+    update = MagicMock()
+    monitor = MagicMock()
+    monitor.request_backlog_skip = AsyncMock(return_value=MagicMock(skipped_count=2))
+    with (
+        patch(
+            "ccgram.handlers.status.status_bar_actions.user_owns_window",
+            return_value=True,
+        ),
+        patch(
+            "ccgram.handlers.status.status_bar_actions.get_thread_id", return_value=4
+        ),
+        patch("ccgram.session_monitor.get_active_monitor", return_value=monitor),
+    ):
+        await _handle_status_bar_action(
+            query, 1, f"{CB_STATUS_BACKLOG_CANCEL}@0", update, MagicMock()
+        )
+        monitor.request_backlog_skip.assert_not_awaited()
+        await _handle_status_bar_action(
+            query, 1, f"{CB_STATUS_BACKLOG_CONFIRM}@0", update, MagicMock()
+        )
+    monitor.request_backlog_skip.assert_awaited_once_with(1, "@0", 4, 99)

--- a/tests/ccgram/handlers/test_backlog.py
+++ b/tests/ccgram/handlers/test_backlog.py
@@ -316,6 +316,43 @@ async def test_failed_purge_resumes_after_restart_before_notice(tmp_path: Path) 
     assert "s1" not in restarted.state.pending_skips
 
 
+async def test_rebound_after_notice_delivery_does_not_commit_skip(
+    tmp_path: Path,
+) -> None:
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_bytes(b"x" * 50)
+    monitor = SessionMonitor(
+        projects_path=tmp_path, state_file=tmp_path / "monitor.json"
+    )
+    monitor.state.update_session(
+        TrackedSession("s1", str(transcript), last_byte_offset=10, parsed_offset=50)
+    )
+    monitor._last_session_map = {"@0": {"session_id": "s1"}}
+    binding_current = True
+
+    async def purge(_intent) -> int:
+        return 3
+
+    def validate(_intent) -> bool:
+        return binding_current
+
+    async def notice(_intent) -> None:
+        nonlocal binding_current
+        receipt = get_active_delivery_receipt()
+        assert receipt is not None
+        receipt.track()
+        binding_current = False
+
+    monitor.set_skip_callbacks(purge=purge, notice=notice, validate=validate)
+    intent = await monitor.request_backlog_skip(1, "@0", 4, 99)
+    assert intent is not None
+    monitor._skip_notice_receipts["s1"].settle(DeliveryOutcome.DELIVERED)
+    monitor.commit_delivered_watermarks()
+
+    assert monitor.state.get_session("s1").last_byte_offset == 10  # type: ignore[union-attr]
+    assert "s1" not in monitor.state.pending_skips
+
+
 async def test_purge_retry_preserves_retired_count_after_state_save_failure(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/ccgram/handlers/test_backlog.py
+++ b/tests/ccgram/handlers/test_backlog.py
@@ -143,7 +143,7 @@ async def test_purge_is_source_scoped_and_settles_only_retired_receipts() -> Non
         mq._queue_locks.clear()
 
 
-async def test_notice_receipt_precedes_watermark_and_resumes_after_restart(
+async def test_failed_notice_retries_in_process_before_watermark_advances(
     tmp_path: Path,
 ) -> None:
     transcript = tmp_path / "session.jsonl"
@@ -160,7 +160,10 @@ async def test_notice_receipt_precedes_watermark_and_resumes_after_restart(
         purged.append(intent.snapshot_offset)
         return 3
 
-    async def notice(_intent) -> None:
+    notice_attempts: list[str] = []
+
+    async def notice(intent) -> None:
+        notice_attempts.append(intent.session_id)
         receipt = get_active_delivery_receipt()
         assert receipt is not None
         receipt.track()
@@ -172,6 +175,7 @@ async def test_notice_receipt_precedes_watermark_and_resumes_after_restart(
     assert intent.range_start == 10
     assert intent.skipped_count == 3
     assert purged == [50]
+    assert notice_attempts == ["s1"]
     monitor.commit_delivered_watermarks()
     assert monitor.state.get_session("s1").last_byte_offset == 10  # type: ignore[union-attr]
 
@@ -180,24 +184,102 @@ async def test_notice_receipt_precedes_watermark_and_resumes_after_restart(
     monitor.commit_delivered_watermarks()
     assert monitor.state.get_session("s1").last_byte_offset == 10  # type: ignore[union-attr]
     assert "s1" in monitor.state.pending_skips
+    assert "s1" not in monitor._skip_notice_receipts
+
+    # Controlled backoff suppresses an immediate hot-loop retry.
+    await monitor._resume_pending_skip_notices()
+    assert notice_attempts == ["s1"]
+
+    monitor._skip_retry_at["s1"] = 0.0
+    await monitor._resume_pending_skip_notices()
+    assert notice_attempts == ["s1", "s1"]
+    monitor._skip_notice_receipts["s1"].settle(DeliveryOutcome.DELIVERED)
+    monitor.commit_delivered_watermarks()
+    assert monitor.state.get_session("s1").last_byte_offset == 50  # type: ignore[union-attr]
+    assert "s1" not in monitor.state.pending_skips
+    assert transcript.read_bytes() == b"x" * 50
+
+
+async def test_notice_enqueue_failure_retries_in_process(tmp_path: Path) -> None:
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_bytes(b"x" * 50)
+    monitor = SessionMonitor(
+        projects_path=tmp_path, state_file=tmp_path / "monitor.json"
+    )
+    monitor.state.update_session(
+        TrackedSession("s1", str(transcript), last_byte_offset=10, parsed_offset=50)
+    )
+    monitor._last_session_map = {"@0": {"session_id": "s1"}}
+
+    async def purge(_intent) -> int:
+        return 3
+
+    attempts = 0
+
+    async def notice(_intent) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("queue unavailable")
+        receipt = get_active_delivery_receipt()
+        assert receipt is not None
+        receipt.track()
+
+    monitor.set_skip_callbacks(purge=purge, notice=notice)
+    intent = await monitor.request_backlog_skip(1, "@0", 4, 99)
+    assert intent is not None
+    assert attempts == 1
+    assert "s1" not in monitor._skip_notice_receipts
+    assert "s1" in monitor.state.pending_skips
+
+    monitor._skip_retry_at["s1"] = 0.0
+    await monitor._resume_pending_skip_notices()
+    assert attempts == 2
+    monitor._skip_notice_receipts["s1"].settle(DeliveryOutcome.DELIVERED)
+    monitor.commit_delivered_watermarks()
+    assert monitor.state.get_session("s1").last_byte_offset == 50  # type: ignore[union-attr]
+    assert "s1" not in monitor.state.pending_skips
+
+
+async def test_failed_purge_resumes_after_restart_before_notice(tmp_path: Path) -> None:
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_bytes(b"x" * 50)
+    state_file = tmp_path / "monitor.json"
+    monitor = SessionMonitor(projects_path=tmp_path, state_file=state_file)
+    monitor.state.update_session(
+        TrackedSession("s1", str(transcript), last_byte_offset=10, parsed_offset=50)
+    )
+    monitor._last_session_map = {"@0": {"session_id": "s1"}}
+
+    async def failed_purge(_intent) -> int:
+        raise RuntimeError("queue unavailable")
+
+    notice = AsyncMock()
+    monitor.set_skip_callbacks(purge=failed_purge, notice=notice)
+    intent = await monitor.request_backlog_skip(1, "@0", 4, 99)
+    assert intent is not None
+    assert intent.purge_complete is False
+    notice.assert_not_awaited()
+    assert "s1" in monitor.state.pending_skips
 
     restarted = SessionMonitor(projects_path=tmp_path, state_file=state_file)
-    resumed: list[str] = []
 
-    async def resumed_notice(intent) -> None:
-        resumed.append(intent.session_id)
+    async def purge(_intent) -> int:
+        return 3
+
+    async def resumed_notice(_intent) -> None:
         receipt = get_active_delivery_receipt()
         assert receipt is not None
         receipt.track()
 
     restarted.set_skip_callbacks(purge=purge, notice=resumed_notice)
     await restarted._resume_pending_skip_notices()
-    assert resumed == ["s1"]
+    assert restarted.state.pending_skips["s1"].purge_complete is True
+    assert restarted.state.pending_skips["s1"].skipped_count == 3
     restarted._skip_notice_receipts["s1"].settle(DeliveryOutcome.DELIVERED)
     restarted.commit_delivered_watermarks()
     assert restarted.state.get_session("s1").last_byte_offset == 50  # type: ignore[union-attr]
     assert "s1" not in restarted.state.pending_skips
-    assert transcript.read_bytes() == b"x" * 50
 
 
 async def test_confirmation_and_cancellation_do_not_skip_without_confirmation() -> None:
@@ -216,7 +298,13 @@ async def test_confirmation_and_cancellation_do_not_skip_without_confirmation() 
             "ccgram.handlers.status.status_bar_actions.get_thread_id", return_value=4
         ),
         patch("ccgram.session_monitor.get_active_monitor", return_value=monitor),
+        patch(
+            "ccgram.handlers.messaging_pipeline.backlog.get_backlog_snapshot",
+            return_value=BacklogSnapshot(100, 0.0, None),
+        ),
+        patch("ccgram.handlers.status.status_bar_actions.thread_router") as mock_router,
     ):
+        mock_router.resolve_window_for_thread.return_value = "@0"
         await _handle_status_bar_action(
             query, 1, f"{CB_STATUS_BACKLOG_CANCEL}@0", update, MagicMock()
         )
@@ -225,3 +313,61 @@ async def test_confirmation_and_cancellation_do_not_skip_without_confirmation() 
             query, 1, f"{CB_STATUS_BACKLOG_CONFIRM}@0", update, MagicMock()
         )
     monitor.request_backlog_skip.assert_awaited_once_with(1, "@0", 4, 99)
+
+
+async def test_stale_topic_confirmation_cannot_skip_source() -> None:
+    query = AsyncMock()
+    query.message.chat.id = 99
+    update = MagicMock()
+    monitor = MagicMock()
+    monitor.request_backlog_skip = AsyncMock()
+    with (
+        patch(
+            "ccgram.handlers.status.status_bar_actions.user_owns_window",
+            return_value=True,
+        ),
+        patch(
+            "ccgram.handlers.status.status_bar_actions.get_thread_id", return_value=4
+        ),
+        patch("ccgram.handlers.status.status_bar_actions.thread_router") as mock_router,
+        patch("ccgram.session_monitor.get_active_monitor", return_value=monitor),
+    ):
+        mock_router.resolve_window_for_thread.return_value = "@other"
+        await _handle_status_bar_action(
+            query, 1, f"{CB_STATUS_BACKLOG_CONFIRM}@0", update, MagicMock()
+        )
+
+    monitor.request_backlog_skip.assert_not_awaited()
+    query.answer.assert_awaited_once_with("Stale status button", show_alert=True)
+
+
+async def test_confirmation_rechecks_severe_threshold() -> None:
+    query = AsyncMock()
+    query.message.chat.id = 99
+    update = MagicMock()
+    monitor = MagicMock()
+    monitor.request_backlog_skip = AsyncMock()
+    with (
+        patch(
+            "ccgram.handlers.status.status_bar_actions.user_owns_window",
+            return_value=True,
+        ),
+        patch(
+            "ccgram.handlers.status.status_bar_actions.get_thread_id", return_value=4
+        ),
+        patch("ccgram.handlers.status.status_bar_actions.thread_router") as mock_router,
+        patch(
+            "ccgram.handlers.messaging_pipeline.backlog.get_backlog_snapshot",
+            return_value=BacklogSnapshot(0, 0.0, None),
+        ),
+        patch("ccgram.session_monitor.get_active_monitor", return_value=monitor),
+    ):
+        mock_router.resolve_window_for_thread.return_value = "@0"
+        await _handle_status_bar_action(
+            query, 1, f"{CB_STATUS_BACKLOG_CONFIRM}@0", update, MagicMock()
+        )
+
+    monitor.request_backlog_skip.assert_not_awaited()
+    query.answer.assert_awaited_once_with(
+        "Backlog is no longer severe", show_alert=True
+    )

--- a/tests/ccgram/handlers/test_kill_command.py
+++ b/tests/ccgram/handlers/test_kill_command.py
@@ -67,8 +67,18 @@ class TestHandleSessionsKillConfirm:
 
         mock_tm.kill_window.assert_called_once_with("@5")
         assert mock_tr.unbind_thread.call_count == 2
-        mock_tr.unbind_thread.assert_any_call(100, 42)
-        mock_tr.unbind_thread.assert_any_call(200, 99)
+        mock_tr.unbind_thread.assert_any_call(
+            100,
+            42,
+            retirement_reason="stale_owned_binding",
+            cleanup_eligible=True,
+        )
+        mock_tr.unbind_thread.assert_any_call(
+            200,
+            99,
+            retirement_reason="stale_owned_binding",
+            cleanup_eligible=True,
+        )
         assert mock_clear.call_count == 2
 
     async def test_window_already_gone(self, _patch_deps) -> None:
@@ -84,7 +94,12 @@ class TestHandleSessionsKillConfirm:
             await handle_sessions_kill_confirm(query, 100, "@5", bot)
 
         mock_tm.kill_window.assert_not_called()
-        mock_tr.unbind_thread.assert_called_once_with(100, 42)
+        mock_tr.unbind_thread.assert_called_once_with(
+            100,
+            42,
+            retirement_reason="stale_owned_binding",
+            cleanup_eligible=True,
+        )
 
     async def test_refreshes_dashboard_after_kill(self, _patch_deps) -> None:
         _mock_sm, mock_tr, mock_tm, _ = _patch_deps

--- a/tests/ccgram/handlers/test_sync_command.py
+++ b/tests/ccgram/handlers/test_sync_command.py
@@ -233,7 +233,9 @@ class TestRetiredTopicCleanup:
             sequence=1,
         )
 
-    async def test_deleted_outcome_removes_known_retired_topic(self, _patch_deps) -> None:
+    async def test_deleted_outcome_removes_known_retired_topic(
+        self, _patch_deps
+    ) -> None:
         *_, mock_tr, _, _ = _patch_deps
         topic = self._topic()
         mock_tr.iter_retired_topics.return_value = [topic]
@@ -261,7 +263,9 @@ class TestRetiredTopicCleanup:
         client.close_forum_topic.assert_awaited_once_with(-999, 42)
         mock_tr.discard_retired_topic.assert_called_once_with(topic)
 
-    async def test_already_gone_is_terminal_not_a_failed_delete(self, _patch_deps) -> None:
+    async def test_already_gone_is_terminal_not_a_failed_delete(
+        self, _patch_deps
+    ) -> None:
         *_, mock_tr, _, _ = _patch_deps
         topic = self._topic()
         mock_tr.iter_retired_topics.return_value = [topic]
@@ -275,7 +279,9 @@ class TestRetiredTopicCleanup:
         client.close_forum_topic.assert_not_awaited()
         mock_tr.discard_retired_topic.assert_called_once_with(topic)
 
-    async def test_failed_calls_remain_in_registry_for_later_fix(self, _patch_deps) -> None:
+    async def test_failed_calls_remain_in_registry_for_later_fix(
+        self, _patch_deps
+    ) -> None:
         *_, mock_tr, _, _ = _patch_deps
         topic = self._topic()
         mock_tr.iter_retired_topics.return_value = [topic]

--- a/tests/ccgram/handlers/test_sync_command.py
+++ b/tests/ccgram/handlers/test_sync_command.py
@@ -6,6 +6,7 @@ from telegram.error import BadRequest, TelegramError
 
 from ccgram.handlers.callback_data import CB_SYNC_DISMISS, CB_SYNC_FIX
 from ccgram.handlers.sync_command import (
+    _cleanup_retired_topics,
     _close_ghost_topics,
     _format_report,
     _probe_dead_topics,
@@ -17,6 +18,7 @@ from ccgram.handlers.sync_command import (
     sync_command,
 )
 from ccgram.session import AuditIssue, AuditResult
+from ccgram.thread_router import RetiredTopic
 
 
 @pytest.fixture(autouse=True)
@@ -123,6 +125,40 @@ class TestFormatReport:
         assert CB_SYNC_FIX in buttons
         assert CB_SYNC_DISMISS in buttons
 
+    def test_known_retired_candidate_reports_reason_and_offers_fix(self) -> None:
+        text, keyboard = _format_report(
+            _audit(
+                AuditIssue(
+                    "retired_topic",
+                    "reason:system_replacement",
+                    fixable=True,
+                ),
+                total=0,
+                live=0,
+            )
+        )
+
+        assert "known retired topic cleanup candidate" in text
+        assert "system_replacement" in text
+        assert keyboard is not None
+        assert "Fix 1 issue" in keyboard.inline_keyboard[0][0].text
+
+    def test_retired_cleanup_outcomes_are_distinguished_in_report(self) -> None:
+        text, _keyboard = _format_report(
+            _audit(total=0, live=0),
+            retired_outcomes={
+                "deleted": 1,
+                "closed": 2,
+                "already_gone": 3,
+                "failed": 4,
+            },
+        )
+
+        assert "Deleted 1 known retired topic" in text
+        assert "Closed 2 known retired topic" in text
+        assert "Already gone 3 known retired topic" in text
+        assert "Could not remove 4 known retired topic" in text
+
     def test_fix_button_counts_every_issue(self) -> None:
         _text, keyboard = _format_report(
             _audit(
@@ -183,6 +219,92 @@ class TestFormatReport:
     def test_fixed_mode_summary(self, kwargs: dict, expected_text: str) -> None:
         text, _keyboard = _format_report(_audit(total=0, live=0), **kwargs)
         assert expected_text in text
+
+
+class TestRetiredTopicCleanup:
+    @staticmethod
+    def _topic() -> RetiredTopic:
+        return RetiredTopic(
+            user_id=100,
+            chat_id=-999,
+            thread_id=42,
+            reason="system_replacement",
+            cleanup_eligible=True,
+            sequence=1,
+        )
+
+    async def test_deleted_outcome_removes_known_retired_topic(self, _patch_deps) -> None:
+        *_, mock_tr, _, _ = _patch_deps
+        topic = self._topic()
+        mock_tr.iter_retired_topics.return_value = [topic]
+        mock_tr.get_window_for_chat_thread.return_value = None
+        client = AsyncMock()
+
+        outcomes = await _cleanup_retired_topics(client)
+
+        assert outcomes == {"deleted": 1}
+        client.delete_forum_topic.assert_awaited_once_with(-999, 42)
+        client.close_forum_topic.assert_not_awaited()
+        mock_tr.discard_retired_topic.assert_called_once_with(topic)
+
+    async def test_close_fallback_is_reported_separately(self, _patch_deps) -> None:
+        *_, mock_tr, _, _ = _patch_deps
+        topic = self._topic()
+        mock_tr.iter_retired_topics.return_value = [topic]
+        mock_tr.get_window_for_chat_thread.return_value = None
+        client = AsyncMock()
+        client.delete_forum_topic.side_effect = TelegramError("not permitted")
+
+        outcomes = await _cleanup_retired_topics(client)
+
+        assert outcomes == {"closed": 1}
+        client.close_forum_topic.assert_awaited_once_with(-999, 42)
+        mock_tr.discard_retired_topic.assert_called_once_with(topic)
+
+    async def test_already_gone_is_terminal_not_a_failed_delete(self, _patch_deps) -> None:
+        *_, mock_tr, _, _ = _patch_deps
+        topic = self._topic()
+        mock_tr.iter_retired_topics.return_value = [topic]
+        mock_tr.get_window_for_chat_thread.return_value = None
+        client = AsyncMock()
+        client.delete_forum_topic.side_effect = BadRequest("Message thread not found")
+
+        outcomes = await _cleanup_retired_topics(client)
+
+        assert outcomes == {"already_gone": 1}
+        client.close_forum_topic.assert_not_awaited()
+        mock_tr.discard_retired_topic.assert_called_once_with(topic)
+
+    async def test_failed_calls_remain_in_registry_for_later_fix(self, _patch_deps) -> None:
+        *_, mock_tr, _, _ = _patch_deps
+        topic = self._topic()
+        mock_tr.iter_retired_topics.return_value = [topic]
+        mock_tr.get_window_for_chat_thread.return_value = None
+        client = AsyncMock()
+        client.delete_forum_topic.side_effect = TelegramError("not permitted")
+        client.close_forum_topic.side_effect = TelegramError("not permitted")
+
+        outcomes = await _cleanup_retired_topics(client)
+
+        assert outcomes == {"failed": 1}
+        mock_tr.discard_retired_topic.assert_not_called()
+
+    async def test_active_or_rebound_topic_is_protected_before_api_call(
+        self, _patch_deps
+    ) -> None:
+        *_, mock_tr, _, _ = _patch_deps
+        topic = self._topic()
+        mock_tr.iter_retired_topics.return_value = [topic]
+        # Simulates a rebind after the Fix snapshot but before its API call.
+        mock_tr.get_window_for_chat_thread.return_value = "@rebound"
+        client = AsyncMock()
+
+        outcomes = await _cleanup_retired_topics(client)
+
+        assert outcomes == {"protected_active": 1}
+        client.delete_forum_topic.assert_not_awaited()
+        client.close_forum_topic.assert_not_awaited()
+        mock_tr.discard_retired_topic.assert_not_called()
 
 
 class TestSyncDismiss:
@@ -559,7 +681,9 @@ class TestSyncFix:
             assert cleanup_args.args[:2] == (100, 42)
             assert cleanup_args.kwargs["window_id"] == "w2:t1"
             assert cleanup_args.kwargs["client"].bot is mock_bot
-            mock_tr.unbind_thread.assert_called_once_with(100, 42)
+            mock_tr.unbind_thread.assert_called_once_with(
+                100, 42, retirement_reason="remote_removed"
+            )
             report_text = mock_edit.call_args[0][1]
             assert "Removed 1 stale topic" in report_text
 
@@ -644,7 +768,9 @@ class TestSyncFix:
             assert cleanup_args.args[:2] == (100, 42)
             assert cleanup_args.kwargs["window_id"] == "@7"
             assert cleanup_args.kwargs["client"].bot is mock_bot
-            mock_tr.unbind_thread.assert_called_once_with(100, 42)
+            mock_tr.unbind_thread.assert_called_once_with(
+                100, 42, retirement_reason="remote_removed"
+            )
 
     async def test_fix_adopts_orphaned_windows(self, _patch_deps) -> None:
         mock_sm, _, mock_wq, _, _, _ = _patch_deps
@@ -795,7 +921,9 @@ class TestDeadTopicRecreation:
         ) as mock_handle:
             count = await _recreate_dead_topics(mock_bot, issues)
             assert count == 1
-            mock_tr.unbind_thread.assert_called_once_with(100, 42)
+            mock_tr.unbind_thread.assert_called_once_with(
+                100, 42, retirement_reason="remote_deleted"
+            )
             mock_handle.assert_called_once()
             event = mock_handle.call_args[0][0]
             assert event.window_id == "w2:t2"
@@ -904,7 +1032,9 @@ class TestDeadTopicRecreation:
         ):
             count = await _recreate_dead_topics(mock_bot, issues)
             assert count == 0
-            mock_tr.unbind_thread.assert_called_once_with(100, 42)
+            mock_tr.unbind_thread.assert_called_once_with(
+                100, 42, retirement_reason="remote_deleted"
+            )
             mock_tr.bind_thread.assert_called_once_with(
                 100, 42, "@2", window_name="proj", chat_id=-999
             )
@@ -945,7 +1075,9 @@ class TestSyncFixDeadTopic:
             ) as mock_handle,
         ):
             await handle_sync_fix(query)
-            mock_tr.unbind_thread.assert_called_once_with(100, 42)
+            mock_tr.unbind_thread.assert_called_once_with(
+                100, 42, retirement_reason="remote_deleted"
+            )
             mock_handle.assert_called_once()
             report_text = mock_edit.call_args[0][1]
             assert "Recreated 1 topic" in report_text

--- a/tests/ccgram/handlers/text/test_text_handler.py
+++ b/tests/ccgram/handlers/text/test_text_handler.py
@@ -312,7 +312,12 @@ class TestHandleDeadWindow:
             )
 
         assert result is True
-        mock_tr.unbind_thread.assert_called_once_with(100, 42)
+        mock_tr.unbind_thread.assert_called_once_with(
+            100,
+            42,
+            retirement_reason="system_replacement",
+            cleanup_eligible=True,
+        )
         mock_browser.assert_called_once()
 
 

--- a/tests/ccgram/handlers/topics/test_topic_close.py
+++ b/tests/ccgram/handlers/topics/test_topic_close.py
@@ -50,7 +50,9 @@ class TestTopicClosedHandler:
         await topic_closed_handler(_make_update(), ctx)
 
         router.get_window_for_thread.assert_called_once_with(1, 42)
-        router.unbind_thread.assert_called_once_with(1, 42)
+        router.unbind_thread.assert_called_once_with(
+            1, 42, retirement_reason="remote_closed"
+        )
         clear_args = clear_state.call_args
         assert clear_args.args[0:2] == (1, 42)
         assert clear_args.args[2].bot is ctx.bot

--- a/tests/ccgram/handlers/topics/test_topic_lifecycle.py
+++ b/tests/ccgram/handlers/topics/test_topic_lifecycle.py
@@ -257,7 +257,9 @@ class TestProbeTopicExistence:
             mock_tmux.kill_window = AsyncMock()
             await probe_topic_existence(bot)
 
-        mock_router.unbind_thread.assert_called_once_with(1, 100, chat_id=42)
+        mock_router.unbind_thread.assert_called_once_with(
+            1, 100, chat_id=42, retirement_reason="remote_deleted"
+        )
         if expect_kill:
             mock_tmux.kill_window.assert_called_once_with(window_id)
         else:

--- a/tests/ccgram/handlers/topics/test_window_launch_service.py
+++ b/tests/ccgram/handlers/topics/test_window_launch_service.py
@@ -426,8 +426,8 @@ class TestLaunchWindowFailure:
                     cleanup_order.append(f"close:{target_id}") or True
                 )
             )
-            m.router.unbind_thread.side_effect = lambda *_args, **_kwargs: cleanup_order.append(
-                "unbind"
+            m.router.unbind_thread.side_effect = lambda *_args, **_kwargs: (
+                cleanup_order.append("unbind")
             )
             m.orchestration.clear_pending_creation.side_effect = lambda *_: (
                 cleanup_order.append("clear-pending")

--- a/tests/ccgram/handlers/topics/test_window_launch_service.py
+++ b/tests/ccgram/handlers/topics/test_window_launch_service.py
@@ -407,7 +407,12 @@ class TestLaunchWindowFailure:
 
         m.mux.kill_window.assert_awaited_once_with("@5")
         m.orchestration.clear_pending_creation.assert_called_once_with("@5")
-        m.router.unbind_thread.assert_called_once_with(100, 42)
+        m.router.unbind_thread.assert_called_once_with(
+            100,
+            42,
+            retirement_reason="system_replacement",
+            cleanup_eligible=True,
+        )
 
     async def test_session_map_timeout_closes_target_before_unbinding_late_hook(
         self, tmp_path
@@ -421,7 +426,7 @@ class TestLaunchWindowFailure:
                     cleanup_order.append(f"close:{target_id}") or True
                 )
             )
-            m.router.unbind_thread.side_effect = lambda *_: cleanup_order.append(
+            m.router.unbind_thread.side_effect = lambda *_args, **_kwargs: cleanup_order.append(
                 "unbind"
             )
             m.orchestration.clear_pending_creation.side_effect = lambda *_: (
@@ -437,7 +442,12 @@ class TestLaunchWindowFailure:
 
         assert result.success is False
         m.mux.kill_window.assert_awaited_once_with("@5")
-        m.router.unbind_thread.assert_called_once_with(100, 42)
+        m.router.unbind_thread.assert_called_once_with(
+            100,
+            42,
+            retirement_reason="system_replacement",
+            cleanup_eligible=True,
+        )
         # The target is closed before the pending guard and binding are removed,
         # so a late hook cannot adopt it into an orphan topic.
         assert cleanup_order == ["close:@5", "clear-pending", "unbind"]

--- a/tests/ccgram/test_thread_router.py
+++ b/tests/ccgram/test_thread_router.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ccgram.thread_router import ThreadRouter
+from ccgram.thread_router import _RETIRED_TOPIC_LIMIT, ThreadRouter
 
 
 @pytest.fixture
@@ -59,6 +59,101 @@ class TestUnbindThread:
         router.bind_thread(100, 1, "@1")
         router.unbind_thread(100, 1)
         assert 100 not in router.thread_bindings
+
+
+class TestRetiredTopics:
+    def test_persists_eligible_topic_across_restart(self, router: ThreadRouter) -> None:
+        router.bind_thread(100, 42, "@1", chat_id=-999)
+        router.unbind_thread(
+            100,
+            42,
+            chat_id=-999,
+            retirement_reason="system_replacement",
+            cleanup_eligible=True,
+        )
+
+        restored = ThreadRouter(
+            schedule_save=lambda: None,
+            has_window_state=lambda _wid: False,
+        )
+        restored.from_dict(router.to_dict())
+
+        retired = list(restored.iter_retired_topics())
+        assert len(retired) == 1
+        assert retired[0].chat_id == -999
+        assert retired[0].thread_id == 42
+        assert retired[0].reason == "system_replacement"
+        assert retired[0].cleanup_eligible is True
+
+    def test_restart_discards_record_for_an_active_rebound_topic(
+        self, router: ThreadRouter
+    ) -> None:
+        router.from_dict(
+            {
+                "chat_thread_bindings": {"100:-999:42": "@2"},
+                "retired_topics": [
+                    {
+                        "user_id": 100,
+                        "chat_id": -999,
+                        "thread_id": 42,
+                        "reason": "system_replacement",
+                        "cleanup_eligible": True,
+                        "sequence": 1,
+                    }
+                ],
+            }
+        )
+
+        assert router.get_window_for_chat_thread(-999, 42) == "@2"
+        assert list(router.iter_retired_topics()) == []
+
+    def test_default_unbind_preserves_remote_topic_intent(self, router: ThreadRouter) -> None:
+        router.bind_thread(100, 42, "@1", chat_id=-999)
+        router.unbind_thread(100, 42, chat_id=-999)
+
+        retired = list(router.iter_retired_topics())
+        assert len(retired) == 1
+        assert retired[0].reason == "keep_remote"
+        assert retired[0].cleanup_eligible is False
+
+    def test_rebind_clears_retired_topic_before_sync_can_delete(
+        self, router: ThreadRouter
+    ) -> None:
+        router.bind_thread(100, 42, "@1", chat_id=-999)
+        router.unbind_thread(
+            100,
+            42,
+            chat_id=-999,
+            retirement_reason="system_replacement",
+            cleanup_eligible=True,
+        )
+        router.bind_thread(100, 42, "@2", chat_id=-999)
+
+        assert list(router.iter_retired_topics()) == []
+
+    def test_retention_drops_oldest_topics(self, router: ThreadRouter) -> None:
+        for thread_id in range(1, _RETIRED_TOPIC_LIMIT + 3):
+            router.bind_thread(100, thread_id, f"@{thread_id}", chat_id=-999)
+            router.unbind_thread(
+                100,
+                thread_id,
+                chat_id=-999,
+                retirement_reason="system_replacement",
+                cleanup_eligible=True,
+            )
+
+        retired = list(router.iter_retired_topics())
+        assert len(retired) == _RETIRED_TOPIC_LIMIT
+        assert retired[0].thread_id == 3
+        assert retired[-1].thread_id == _RETIRED_TOPIC_LIMIT + 2
+
+    def test_chatless_binding_is_not_treated_as_a_known_forum_topic(
+        self, router: ThreadRouter
+    ) -> None:
+        router.bind_thread(100, 42, "@1")
+        router.unbind_thread(100, 42, cleanup_eligible=True)
+
+        assert list(router.iter_retired_topics()) == []
 
 
 class TestReverseIndex:

--- a/tests/ccgram/test_thread_router.py
+++ b/tests/ccgram/test_thread_router.py
@@ -107,7 +107,9 @@ class TestRetiredTopics:
         assert router.get_window_for_chat_thread(-999, 42) == "@2"
         assert list(router.iter_retired_topics()) == []
 
-    def test_default_unbind_preserves_remote_topic_intent(self, router: ThreadRouter) -> None:
+    def test_default_unbind_preserves_remote_topic_intent(
+        self, router: ThreadRouter
+    ) -> None:
         router.bind_thread(100, 42, "@1", chat_id=-999)
         router.unbind_thread(100, 42, chat_id=-999)
 

--- a/tests/ccgram/test_transcript_reader.py
+++ b/tests/ccgram/test_transcript_reader.py
@@ -42,9 +42,7 @@ async def test_same_transcript_reuses_offset_after_session_map_refresh(
             last_byte_offset=len(first.encode()),
         )
     )
-    state.begin_skip(
-        BacklogSkipIntent("sess-before-rename", "@1", 1, 4, 99, 50, 0)
-    )
+    state.begin_skip(BacklogSkipIntent("sess-before-rename", "@1", 1, 4, 99, 50, 0))
     reader = TranscriptReader(state, IdleTracker())
 
     messages = []

--- a/tests/ccgram/test_transcript_reader.py
+++ b/tests/ccgram/test_transcript_reader.py
@@ -5,8 +5,20 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from ccgram.idle_tracker import IdleTracker
-from ccgram.monitor_state import MonitorState, TrackedSession
+from ccgram.monitor_state import BacklogSkipIntent, MonitorState, TrackedSession
 from ccgram.transcript_reader import TranscriptReader, _StableRead
+
+
+def test_clear_session_cancels_pending_skip_barrier(tmp_path) -> None:
+    state = MonitorState(state_file=tmp_path / "monitor.json")
+    state.update_session(TrackedSession("sess", str(tmp_path / "session.jsonl")))
+    state.begin_skip(BacklogSkipIntent("sess", "@1", 1, 4, 99, 10, 0))
+    reader = TranscriptReader(state, IdleTracker())
+
+    reader.clear_session("sess")
+
+    assert "sess" not in state.pending_skips
+    assert state.get_session("sess") is None
 
 
 async def test_same_transcript_reuses_offset_after_session_map_refresh(
@@ -30,6 +42,9 @@ async def test_same_transcript_reuses_offset_after_session_map_refresh(
             last_byte_offset=len(first.encode()),
         )
     )
+    state.begin_skip(
+        BacklogSkipIntent("sess-before-rename", "@1", 1, 4, 99, 50, 0)
+    )
     reader = TranscriptReader(state, IdleTracker())
 
     messages = []
@@ -44,6 +59,7 @@ async def test_same_transcript_reuses_offset_after_session_map_refresh(
     tracked = state.get_session("sess-after-rename")
     assert tracked is not None
     assert tracked.parsed_offset == session_file.stat().st_size
+    assert "sess-before-rename" not in state.pending_skips
 
 
 async def test_catch_up_read_after_restart_is_not_activity(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- batch eligible queued transcript text into one Telegram request while preserving entity boundaries, retries, ordering, and delivery receipts
- persist a bounded registry of known retired topics and let `/sync` delete or close only eligible locally owned orphans
- show source-scoped backlog progress and add a severe-only, confirmed **Jump to live** action with a durable skip notice barrier
- document operational behavior, permissions, Bot API discovery limits, and at-least-once delivery trade-offs

## Safety contracts

- active or rebound topics are rechecked and never selected for cleanup
- explicit `/unbind` keeps the remote topic by default
- bots cannot enumerate unknown Telegram forum topics; cleanup is limited to locally recorded retired topics
- Jump to live is per source/topic, snapshots EOF at confirmation, preserves raw transcripts, and advances the durable watermark only after the visible skipped-range notice is delivered
- failed/restarted skip notices retain the previous watermark and resume safely
- batching never crosses chat, thread, window, role, source, tool/media, pagination, TTS, status, or backlog-notice boundaries

## Validation

- focused affected-area tests: 796 passed
- unit: 6640 passed, 30 skipped
- integration: 334 passed, 6 skipped
- Ruff lint/format, Pyright, Deptry, lazy-import lint, Markdownlint, and `git diff --check` passed
- GitNexus index rebuilt and compare analysis completed; shared delivery/router paths report critical blast radius and require the review gate below

## Operational notes

- `deleteForumTopic` requires Telegram `can_delete_messages`; ccgram falls back to `closeForumTopic` when deletion is unavailable
- at-least-once delivery can duplicate output after ambiguous Telegram acceptance or a crash before local checkpoint persistence
- severe backlog defaults: 100 pending source messages or five minutes oldest age
