### PR TITLE
Fix provider detection when foreground pgid is unavailable

### DIFF
--- a/src/ccgram/multiplexer/base.py
+++ b/src/ccgram/multiplexer/base.py
@@ -83,7 +83,7 @@ class ForegroundInfo:
     """
 
     pid: int
-    pgid: int
+    pgid: int  # Zero when the backend cannot provide a process-group ID.
     argv: list[str]
     cwd: str
     tty: str = ""  # Empty when not available (herdr on macOS)

--- a/src/ccgram/providers/process_detection.py
+++ b/src/ccgram/providers/process_detection.py
@@ -131,8 +131,10 @@ async def detect_provider_cached(window_id: str, fg: ForegroundInfo | None) -> s
     ``classify_provider_from_argv`` is skipped.  Returns ``""`` when there is
     no foreground process to classify.
     """
-    if fg is None or not fg.argv or fg.pgid == 0:
+    if fg is None or not fg.argv:
         return ""
+    if fg.pgid == 0:
+        return classify_provider_from_argv(fg.argv)
 
     cached = _pgid_cache.get(window_id)
     if cached and cached[0] == fg.pgid:

--- a/tests/ccgram/providers/test_process_detection.py
+++ b/tests/ccgram/providers/test_process_detection.py
@@ -134,11 +134,19 @@ class TestDetectProviderCached:
         assert result == ""
         assert "@0" not in _pgid_cache
 
-    async def test_zero_pgid_returns_empty(self) -> None:
-        fg = ForegroundInfo(pid=0, pgid=0, argv=["bun", "claude"], cwd="/tmp")
-        result = await detect_provider_cached("@0", fg)
-        assert result == ""
-        assert "@0" not in _pgid_cache
+    async def test_zero_pgid_classifies_without_cache(self) -> None:
+        _pgid_cache["@0"] = (8668, "claude")
+        fg = ForegroundInfo(pid=0, pgid=0, argv=["bun", "codex"], cwd="/tmp")
+
+        with patch(
+            "ccgram.providers.process_detection.classify_provider_from_argv"
+        ) as mock_classify:
+            mock_classify.return_value = "codex"
+            result = await detect_provider_cached("@0", fg)
+
+        assert result == "codex"
+        mock_classify.assert_called_once_with(["bun", "codex"])
+        assert _pgid_cache["@0"] == (8668, "claude")
 
     async def test_unrecognized_argv_not_cached(self) -> None:
         result = await detect_provider_cached("@0", _fg(["vim", "x.py"], 555))


### PR DESCRIPTION
## Summary

- classify a foreground provider when the backend knows argv but cannot provide a process-group ID
- bypass the PGID cache for pgid=0 without reading or writing stale entries
- document that ForegroundInfo.pgid may be zero
- add regression coverage for wrapped providers and stale-cache isolation

Fixes #201

Validated with the provider and Herdr integration suites.