### PR TITLE
Support private topics and harden topic routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.4] - 2026-08-31
+
+### Added
+
+- Support Telegram topics in private bot chats. Topic 1 remains the General/control topic.
+- Add direct Telegram buttons for supported numbered and yes/no agent prompts.
+
+### Fixed
+
+- Prevent one chat window from remaining bound to topics owned by different users.
+- Reject hook events with a backend or session prefix that does not match the active session.
+
+### Contributors
+
+- Thanks to [@bjesuiter](https://github.com/bjesuiter) for the private-chat topic request in #156.
+- Thanks to [@Akash-Saini-ai](https://github.com/Akash-Saini-ai) for the direct-choice request in #193.
+- Thanks to [@paoloantinori](https://github.com/paoloantinori) for the production reports in #196 and #202.
+
 ## [4.9.3] - 2026-08-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This means:
 
 ```mermaid
 graph LR
-  subgraph phone["📱 Telegram Group (Forum Topics)"]
+  subgraph phone["📱 Telegram Topics (Group or Private Chat)"]
     direction TB
     T1["💬 api — Claude"]
     T2["💬 ui — Codex"]
@@ -62,7 +62,7 @@ Each Telegram topic maps to one tmux window. With Herdr, it maps instead to one 
 
 ## What You Can Do
 
-- **Bind agents to topics** — one agent per Telegram topic; create via directory browser
+- **Bind agents to topics** — one agent per group or private-chat topic; create via directory browser
 - **Auto-detect providers** — Supports Claude Code, Codex, Gemini, Pi, and Shell simultaneously
 - **Monitor live** — Terminal screenshots on demand or auto-refresh every 5 seconds
 - **Send commands** — Slash commands, voice messages (transcribed via Whisper), or raw shell input
@@ -70,6 +70,7 @@ Each Telegram topic maps to one tmux window. With Herdr, it maps instead to one 
 - **Recover gracefully** — Resume, continue, or start fresh if a session crashes
 - **Send workspace files** — Share files to Telegram via `/send` (glob, path, or substring search)
 - **Action toolbar** — Provider-specific buttons for common actions (Screenshot, Mode, Esc, Enter, etc.)
+- **Direct choices** — Answer supported numbered and yes/no agent prompts with one tap
 
 ## Delivery and Sync Safety
 
@@ -91,16 +92,19 @@ uv tool install ccgram          # recommended
 **Telegram setup:**
 
 1. Create a bot via [@BotFather](https://t.me/BotFather) — [full instructions](docs/guides.md#getting-started)
-2. Add bot to a Telegram group with Topics enabled; promote to Admin
+2. Choose one topic setup:
+   - **Private chat:** Enable Topics for the bot in BotFather. Topic 1 is the control topic.
+   - **Group:** Add the bot to a Topics-enabled group and promote it to Admin.
 3. Create `~/.ccgram/.env`:
 
 ```ini
 TELEGRAM_BOT_TOKEN=your_bot_token_here
 ALLOWED_USERS=your_telegram_user_id
+# Group setup only:
 CCGRAM_GROUP_ID=your_telegram_group_id
 ```
 
-Get user ID from [@userinfobot](https://t.me/userinfobot). Get group ID via [@RawDataBot](https://t.me/RawDataBot) (prefix Peer ID with `-100`).
+Get your user ID from [@userinfobot](https://t.me/userinfobot). For a group, get its ID via [@RawDataBot](https://t.me/RawDataBot) and prefix the Peer ID with `-100`.
 
 **Run:**
 
@@ -108,7 +112,7 @@ Get user ID from [@userinfobot](https://t.me/userinfobot). Get group ID via [@Ra
 ccgram
 ```
 
-Open your Telegram group, create a topic, send a message — directory browser appears. Pick a project directory, choose your agent (Claude, Codex, Gemini, Pi, or Shell), and you're connected.
+Open the configured group or private bot chat. Create a topic and send a message. The directory browser appears. Pick a project directory and an agent (Claude, Codex, Gemini, Pi, or Shell).
 
 **Prerequisites:** Python 3.14+, [tmux](https://github.com/tmux/tmux), [herdr](https://github.com/ogulcancelik/herdr), or [agterm](https://github.com/umputun/agterm), and one agent CLI. CCGram does not modify agent SDKs.
 

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -39,29 +39,25 @@ You need a Telegram bot token to run CCGram. Create one via [@BotFather](https:/
    - Name: anything (e.g., "MyCodeBot")
    - Username: must be unique and end with `bot` (e.g., "my_code_bot")
    - You'll receive a **Bot Token** — save this for `TELEGRAM_BOT_TOKEN`
-3. **Configure bot settings:** Send `/mybots` → select your bot → **Bot Settings**
-   - Enable **Allow Groups**: On
-   - Enable **Group Privacy**: Off _(required so the bot sees all messages in topics)_
-   - Enable **Topics**: On
-4. **Add bot to your Telegram group:**
-   - Create or open a Telegram group with Topics enabled
-   - Invite the bot to the group
-   - **Promote the bot to Administrator** with these permissions:
-     - Create Topics
-     - Pin Messages
-     - Read Messages / View The Chat
-5. **Get your user ID:** Open [@userinfobot](https://t.me/userinfobot) → it shows your numeric user ID. Save this for `ALLOWED_USERS`
-6. **Get your group ID:** Open [@RawDataBot](https://t.me/RawDataBot) in the group → under **Peer ID**, note the number (remove leading `-100`, or keep it — both formats work)
-   - Save this for `CCGRAM_GROUP_ID` (prefix with `-100` if needed)
+3. **Configure bot settings:** Send `/mybots` → select your bot → **Bot Settings**.
+   - Enable **Topics** for a private-chat setup.
+   - Enable **Allow Groups** for a group setup.
+   - Disable **Group Privacy** so the bot can read all group-topic messages.
+4. **Choose a topic setup:**
+   - **Private chat:** Open the bot chat. Topic 1 is the General/control topic.
+   - **Group:** Create or open a Topics-enabled group. Add the bot and promote it to Administrator with Create Topics, Pin Messages, and Read Messages permissions.
+5. **Get your user ID:** Open [@userinfobot](https://t.me/userinfobot). Save the numeric ID for `ALLOWED_USERS`.
+6. **For a group, get its ID:** Open [@RawDataBot](https://t.me/RawDataBot) in the group. Save the Peer ID for `CCGRAM_GROUP_ID`. Both forms with and without the `-100` prefix work.
 7. **Create `~/.ccgram/.env`:**
 
    ```ini
    TELEGRAM_BOT_TOKEN=your_bot_token_here
    ALLOWED_USERS=your_user_id_here
+   # Group setup only:
    CCGRAM_GROUP_ID=your_group_id_here
    ```
 
-8. **Test:** Run `ccgram` and create a new topic in your Telegram group. Send a message and the directory browser should appear.
+8. **Test:** Run `ccgram`. Create a topic in the configured chat and send a message. The directory browser must appear.
 
 ### Validation
 

--- a/src/ccgram/handlers/callback_data.py
+++ b/src/ccgram/handlers/callback_data.py
@@ -52,6 +52,7 @@ CB_ASK_ENTER = "aq:enter:"  # aq:enter:<window>
 CB_ASK_SPACE = "aq:spc:"  # aq:spc:<window>
 CB_ASK_TAB = "aq:tab:"  # aq:tab:<window>
 CB_ASK_REFRESH = "aq:ref:"  # aq:ref:<window>
+CB_ASK_CHOICE = "aq:pick:"  # aq:pick:<key>:<sequence>:<window>
 
 # Sessions dashboard
 CB_SESSIONS_REFRESH = "sess:ref"

--- a/src/ccgram/handlers/callback_helpers.py
+++ b/src/ccgram/handlers/callback_helpers.py
@@ -37,14 +37,61 @@ def parse_target(target: str) -> tuple[str, str | None]:
     return target, None
 
 
+GENERAL_TOPIC_ID = 1
+"""Telegram's General topic: the explicit control lane, never a session."""
+
+
+def direct_messages_topic_id(message: object) -> int | None:
+    """Return an observed private direct-message topic ID, if supported.
+
+    A positive ``chat_id`` or ``message_thread_id`` is not enough to infer the
+    newer private threaded-DM feature. Telegram explicitly advertises it with
+    both ``chat.is_direct_messages`` and ``message.direct_messages_topic``.
+    Ordinary unthreaded private DMs therefore keep their legacy ``None``
+    thread identity.
+    """
+    chat = getattr(message, "chat", None)
+    topic = getattr(message, "direct_messages_topic", None)
+    topic_id = getattr(topic, "topic_id", None)
+    if getattr(chat, "is_direct_messages", None) is True and isinstance(topic_id, int):
+        return topic_id
+    return None
+
+
+def is_direct_messages_topic(message: object) -> bool:
+    """Return whether *message* carries supported private-topic metadata."""
+    return direct_messages_topic_id(message) is not None
+
+
 def get_thread_id(update: Update) -> int | None:
-    """Extract thread_id from an update, returning None if not in a named topic."""
+    """Extract a non-General topic ID from a forum or direct-message update.
+
+    Topic 1 is an explicit General/control invariant in both topic-capable
+    surfaces. It must not become a session binding or be replaced by ``/new``.
+    """
     msg = update.message or (
         update.callback_query.message if update.callback_query else None
     )
     if msg is None:
         return None
+
+    direct_topic_id = direct_messages_topic_id(msg)
+    if direct_topic_id is not None:
+        chat_id = getattr(getattr(msg, "chat", None), "id", None)
+        if isinstance(chat_id, int) and direct_topic_id != GENERAL_TOPIC_ID:
+            thread_router.mark_direct_message_topic(chat_id, direct_topic_id)
+        return direct_topic_id if direct_topic_id != GENERAL_TOPIC_ID else None
+
+    # Forum topic IDs are valid only for group/supergroup forum messages.
+    # Keep ordinary private DMs on their pre-threaded legacy path even if a
+    # future update happens to expose a thread-like field without capability
+    # metadata.
+    if getattr(getattr(msg, "chat", None), "type", None) not in (
+        "group",
+        "supergroup",
+    ):
+        return None
     tid = getattr(msg, "message_thread_id", None)
-    if tid is None or tid == 1:
+    if not isinstance(tid, int) or tid == GENERAL_TOPIC_ID:
         return None
     return tid

--- a/src/ccgram/handlers/callback_helpers.py
+++ b/src/ccgram/handlers/callback_helpers.py
@@ -85,13 +85,14 @@ def get_thread_id(update: Update) -> int | None:
     # Forum topic IDs are valid only for group/supergroup forum messages.
     # Keep ordinary private DMs on their pre-threaded legacy path even if a
     # future update happens to expose a thread-like field without capability
-    # metadata.
-    if getattr(getattr(msg, "chat", None), "type", None) not in (
-        "group",
-        "supergroup",
-    ):
-        return None
+    # metadata. Test doubles and compatible update objects can omit chat.type;
+    # preserve their prior thread-ID behavior.
+    chat_type = getattr(getattr(msg, "chat", None), "type", None)
     tid = getattr(msg, "message_thread_id", None)
+    if not isinstance(chat_type, str):
+        return tid if isinstance(tid, int) and tid != GENERAL_TOPIC_ID else None
+    if chat_type not in ("group", "supergroup"):
+        return None
     if not isinstance(tid, int) or tid == GENERAL_TOPIC_ID:
         return None
     return tid

--- a/src/ccgram/handlers/callback_helpers.py
+++ b/src/ccgram/handlers/callback_helpers.py
@@ -41,30 +41,26 @@ GENERAL_TOPIC_ID = 1
 """Telegram's General topic: the explicit control lane, never a session."""
 
 
-def direct_messages_topic_id(message: object) -> int | None:
-    """Return an observed private direct-message topic ID, if supported.
+def private_topic_id(message: object) -> int | None:
+    """Return an observed private-chat topic ID, if present.
 
-    A positive ``chat_id`` or ``message_thread_id`` is not enough to infer the
-    newer private threaded-DM feature. Telegram explicitly advertises it with
-    both ``chat.is_direct_messages`` and ``message.direct_messages_topic``.
-    Ordinary unthreaded private DMs therefore keep their legacy ``None``
-    thread identity.
+    Private bot topics use the regular topic-message shape: a private chat,
+    ``is_topic_message``, and an integer ``message_thread_id``. Ordinary
+    private DMs deliberately keep their legacy ``None`` thread identity.
     """
     chat = getattr(message, "chat", None)
-    topic = getattr(message, "direct_messages_topic", None)
-    topic_id = getattr(topic, "topic_id", None)
-    if getattr(chat, "is_direct_messages", None) is True and isinstance(topic_id, int):
-        return topic_id
+    thread_id = getattr(message, "message_thread_id", None)
+    if (
+        getattr(chat, "type", None) == "private"
+        and getattr(message, "is_topic_message", None) is True
+        and isinstance(thread_id, int)
+    ):
+        return thread_id
     return None
 
 
-def is_direct_messages_topic(message: object) -> bool:
-    """Return whether *message* carries supported private-topic metadata."""
-    return direct_messages_topic_id(message) is not None
-
-
 def get_thread_id(update: Update) -> int | None:
-    """Extract a non-General topic ID from a forum or direct-message update.
+    """Extract a non-General topic ID from a forum or private-topic update.
 
     Topic 1 is an explicit General/control invariant in both topic-capable
     surfaces. It must not become a session binding or be replaced by ``/new``.
@@ -75,16 +71,16 @@ def get_thread_id(update: Update) -> int | None:
     if msg is None:
         return None
 
-    direct_topic_id = direct_messages_topic_id(msg)
-    if direct_topic_id is not None:
+    private_thread_id = private_topic_id(msg)
+    if private_thread_id is not None:
         chat_id = getattr(getattr(msg, "chat", None), "id", None)
-        if isinstance(chat_id, int) and direct_topic_id != GENERAL_TOPIC_ID:
-            thread_router.mark_direct_message_topic(chat_id, direct_topic_id)
-        return direct_topic_id if direct_topic_id != GENERAL_TOPIC_ID else None
+        if isinstance(chat_id, int):
+            thread_router.mark_private_topic_chat(chat_id)
+        return private_thread_id if private_thread_id != GENERAL_TOPIC_ID else None
 
     # Forum topic IDs are valid only for group/supergroup forum messages.
     # Keep ordinary private DMs on their pre-threaded legacy path even if a
-    # future update happens to expose a thread-like field without capability
+    # future update happens to expose a thread-like field without topic
     # metadata. Test doubles and compatible update objects can omit chat.type;
     # preserve their prior thread-ID behavior.
     chat_type = getattr(getattr(msg, "chat", None), "type", None)

--- a/src/ccgram/handlers/cleanup.py
+++ b/src/ccgram/handlers/cleanup.py
@@ -103,7 +103,7 @@ async def clear_topic_state(
     if window_id:
         log_throttle_reset(f"topic-probe:{window_id}")
 
-    await clear_interactive_msg(user_id, client, thread_id)
+    await clear_interactive_msg(user_id, client, thread_id, chat_id)
 
     # user_data cleanup
     if user_data is not None and user_data.get(PENDING_THREAD_ID) == thread_id:

--- a/src/ccgram/handlers/cleanup.py
+++ b/src/ccgram/handlers/cleanup.py
@@ -103,7 +103,7 @@ async def clear_topic_state(
     if window_id:
         log_throttle_reset(f"topic-probe:{window_id}")
 
-    await clear_interactive_msg(user_id, client, thread_id, chat_id)
+    await clear_interactive_msg(user_id, client, thread_id, chat_id=chat_id)
 
     # user_data cleanup
     if user_data is not None and user_data.get(PENDING_THREAD_ID) == thread_id:

--- a/src/ccgram/handlers/hook_events.py
+++ b/src/ccgram/handlers/hook_events.py
@@ -54,9 +54,33 @@ def _resolve_users_for_window_key(
     return results
 
 
+def _resolve_user_chats_for_window_key(
+    window_key: str,
+) -> list[tuple[int, int, str, int | None]]:
+    """Resolve notification targets with their exact chat identity."""
+    window_id = strip_session_map_prefix(window_key, session_map_prefix())
+    if window_id is None:
+        return []
+    targets = [
+        (user_id, thread_id, window_id, chat_id)
+        for user_id, chat_id, thread_id, bound_wid in (
+            thread_router.iter_thread_bindings_with_chat()
+        )
+        if bound_wid == window_id
+    ]
+    if targets:
+        return targets
+    # Keep compatibility with lightweight routers used by integrations.
+    return [
+        (user_id, thread_id, window_id, None)
+        for user_id, thread_id, bound_wid in thread_router.iter_thread_bindings()
+        if bound_wid == window_id
+    ]
+
+
 async def _handle_notification(event: HookEvent, client: TelegramClient) -> None:
     """Handle a Notification event — render interactive UI."""
-    users = _resolve_users_for_window_key(event.window_key)
+    users = _resolve_user_chats_for_window_key(event.window_key)
     if not users:
         logger.debug(
             "No users bound for notification event window_key=%s", event.window_key
@@ -73,7 +97,7 @@ async def _handle_notification(event: HookEvent, client: TelegramClient) -> None
     )
     wait_header = classify_wait_message(event.data.get("message", ""))
 
-    for user_id, thread_id, window_id in users:
+    for user_id, thread_id, window_id, chat_id in users:
         if wait_header:
             session_lifecycle.handle_notification_wait(window_id, wait_header)
             await enqueue_status_update(
@@ -88,7 +112,11 @@ async def _handle_notification(event: HookEvent, client: TelegramClient) -> None
             continue
 
         # Skip if already in interactive mode for this window
-        existing = get_interactive_window(user_id, thread_id)
+        existing = (
+            get_interactive_window(user_id, thread_id, chat_id)
+            if chat_id is not None
+            else get_interactive_window(user_id, thread_id)
+        )
         if existing == window_id:
             logger.debug(
                 "Interactive mode already set for user=%d window=%s, skipping",
@@ -98,15 +126,26 @@ async def _handle_notification(event: HookEvent, client: TelegramClient) -> None
             continue
 
         # Set interactive mode before rendering to prevent racing with terminal scraping
-        set_interactive_mode(user_id, window_id, thread_id)
+        if chat_id is None:
+            set_interactive_mode(user_id, window_id, thread_id)
+        else:
+            set_interactive_mode(user_id, window_id, thread_id, chat_id)
 
         # Wait briefly for Claude Code to render the UI in the terminal
 
         await asyncio.sleep(0.3)
 
-        handled = await handle_interactive_ui(client, user_id, window_id, thread_id)
+        if chat_id is None:
+            handled = await handle_interactive_ui(client, user_id, window_id, thread_id)
+        else:
+            handled = await handle_interactive_ui(
+                client, user_id, window_id, thread_id, chat_id=chat_id
+            )
         if not handled:
-            clear_interactive_mode(user_id, thread_id)
+            if chat_id is None:
+                clear_interactive_mode(user_id, thread_id)
+            else:
+                clear_interactive_mode(user_id, thread_id, chat_id)
 
 
 _LLM_SUMMARY_TIMEOUT = 3.0  # seconds to wait for LLM summary before falling back to the standard completion text

--- a/src/ccgram/handlers/hook_events.py
+++ b/src/ccgram/handlers/hook_events.py
@@ -15,6 +15,7 @@ import structlog
 from ..claude_task_state import classify_wait_message, claude_task_state
 from ..providers.base import HookEvent
 from ..session_lifecycle import session_lifecycle
+from ..session_map import session_map_prefix, strip_session_map_prefix
 from ..session_state_ports.live_session_state import has_task_snapshot
 from ..telegram_client import TelegramClient
 from ..thread_router import thread_router
@@ -32,24 +33,19 @@ from .status.topic_emoji import update_topic_emoji
 
 logger = structlog.get_logger()
 
-_WINDOW_KEY_PARTS = 2
-
 
 def _resolve_users_for_window_key(
     window_key: str,
 ) -> list[tuple[int, int, str]]:
-    """Resolve window_key to list of (user_id, thread_id, window_id).
+    """Resolve a current-backend window key to bound users.
 
-    The window_key format is "<prefix>:<opaque-window-id>" (e.g. "ccgram:@0"
-    for tmux and a durable opaque session target for Herdr). The prefix is a
-    single colon-free token, so split on the FIRST colon to recover the complete
-    target and look up thread bindings.
+    The session-map prefix identifies both the active backend and, for tmux,
+    its configured session. Strip only that exact prefix so opaque IDs retain
+    any colons they contain and stale events from another backend cannot route.
     """
-    # Extract the opaque target ("ccgram:@0" -> "@0").
-    parts = window_key.split(":", 1)
-    if len(parts) < _WINDOW_KEY_PARTS:
+    window_id = strip_session_map_prefix(window_key, session_map_prefix())
+    if window_id is None:
         return []
-    window_id = parts[1]
 
     results: list[tuple[int, int, str]] = []
     for user_id, thread_id, bound_wid in thread_router.iter_thread_bindings():

--- a/src/ccgram/handlers/hook_events.py
+++ b/src/ccgram/handlers/hook_events.py
@@ -113,7 +113,7 @@ async def _handle_notification(event: HookEvent, client: TelegramClient) -> None
 
         # Skip if already in interactive mode for this window
         existing = (
-            get_interactive_window(user_id, thread_id, chat_id)
+            get_interactive_window(user_id, thread_id, chat_id=chat_id)
             if chat_id is not None
             else get_interactive_window(user_id, thread_id)
         )
@@ -129,7 +129,7 @@ async def _handle_notification(event: HookEvent, client: TelegramClient) -> None
         if chat_id is None:
             set_interactive_mode(user_id, window_id, thread_id)
         else:
-            set_interactive_mode(user_id, window_id, thread_id, chat_id)
+            set_interactive_mode(user_id, window_id, thread_id, chat_id=chat_id)
 
         # Wait briefly for Claude Code to render the UI in the terminal
 
@@ -145,7 +145,7 @@ async def _handle_notification(event: HookEvent, client: TelegramClient) -> None
             if chat_id is None:
                 clear_interactive_mode(user_id, thread_id)
             else:
-                clear_interactive_mode(user_id, thread_id, chat_id)
+                clear_interactive_mode(user_id, thread_id, chat_id=chat_id)
 
 
 _LLM_SUMMARY_TIMEOUT = 3.0  # seconds to wait for LLM summary before falling back to the standard completion text

--- a/src/ccgram/handlers/interactive/interactive_callbacks.py
+++ b/src/ccgram/handlers/interactive/interactive_callbacks.py
@@ -185,10 +185,16 @@ async def handle_interactive_callback(
     thread_id = get_thread_id(update)
     message = query.message
     chat_id = message.chat.id if message is not None else None
-    # Legacy direct-message bindings have no stored chat ID; direct choices
-    # still verify their exact chat/message below.
+    private_topic = (
+        message is not None
+        and message.chat.type == "private"
+        and getattr(message, "is_topic_message", False) is True
+        and isinstance(getattr(message, "message_thread_id", None), int)
+    )
     ownership_chat_id = (
-        None if message is not None and message.chat.type == "private" else chat_id
+        chat_id
+        if private_topic or message is None or message.chat.type != "private"
+        else None
     )
     if not user_owns_window(user_id, window_id, ownership_chat_id):
         await query.answer("Not your session", show_alert=True)
@@ -250,8 +256,16 @@ async def _dispatch(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     message = query.message
     chat_id = message.chat.id if message is not None else None
+    private_topic = (
+        message is not None
+        and message.chat.type == "private"
+        and getattr(message, "is_topic_message", False) is True
+        and isinstance(getattr(message, "message_thread_id", None), int)
+    )
     ownership_chat_id = (
-        None if message is not None and message.chat.type == "private" else chat_id
+        chat_id
+        if private_topic or message is None or message.chat.type != "private"
+        else None
     )
     data = resolve_callback_data(
         query.data,

--- a/src/ccgram/handlers/interactive/interactive_callbacks.py
+++ b/src/ccgram/handlers/interactive/interactive_callbacks.py
@@ -17,6 +17,7 @@ from telegram import CallbackQuery, Update
 from ...telegram_client import PTBTelegramClient
 from ...multiplexer import multiplexer as tmux_manager
 from ..callback_data import (
+    CB_ASK_CHOICE,
     CB_ASK_DOWN,
     CB_ASK_ENTER,
     CB_ASK_ESC,
@@ -28,7 +29,12 @@ from ..callback_data import (
     CB_ASK_UP,
 )
 from ..callback_registry import register
-from .interactive_ui import clear_interactive_msg, handle_interactive_ui
+from .interactive_ui import (
+    advance_interactive_sequence,
+    clear_interactive_msg,
+    handle_interactive_ui,
+    is_current_interactive_prompt,
+)
 
 if TYPE_CHECKING:
     from telegram.ext import ContextTypes
@@ -59,7 +65,34 @@ INTERACTIVE_KEY_LABELS: dict[str, str] = {
 INTERACTIVE_PREFIXES: tuple[str, ...] = (
     *INTERACTIVE_KEY_MAP,
     CB_ASK_REFRESH,
+    CB_ASK_CHOICE,
 )
+
+
+def parse_direct_choice_callback(
+    data: str,
+) -> tuple[str, int, str, str | None] | None:
+    """Parse a direct choice callback without splitting opaque target IDs."""
+    if not data.startswith(CB_ASK_CHOICE):
+        return None
+    remainder = data.removeprefix(CB_ASK_CHOICE)
+    key, separator, remainder = remainder.partition(":")
+    sequence_text, separator2, target = remainder.partition(":")
+    if (
+        not separator
+        or not separator2
+        or key not in {"y", "n", "1", "2", "3", "4", "5", "6", "7", "8"}
+        or not sequence_text.isdecimal()
+        or not target
+    ):
+        return None
+    # Lazy: callback_data keeps the pane separator colocated with other formats.
+    from ..callback_data import CB_PANE_DELIMITER
+
+    if CB_PANE_DELIMITER in target:
+        window_id, pane_id = target.split(CB_PANE_DELIMITER, 1)
+        return key, int(sequence_text), window_id, pane_id
+    return key, int(sequence_text), target, None
 
 
 def match_interactive_prefix(data: str) -> tuple[str, str, str | None] | None:
@@ -72,6 +105,11 @@ def match_interactive_prefix(data: str) -> tuple[str, str, str | None] | None:
       - ``"aq:enter:@12|%5"``      → tmux: window @12, pane %5
       - callback target suffixes remain opaque and are resolved by the backend
     """
+    direct_choice = parse_direct_choice_callback(data)
+    if direct_choice is not None:
+        _, _, window_id, pane_id = direct_choice
+        return CB_ASK_CHOICE, window_id, pane_id
+
     # Lazy: avoid a module-level import that ruff flags as unused before the
     # function body is reached; CB_PANE_DELIMITER is a plain string constant.
     from ..callback_data import CB_PANE_DELIMITER
@@ -84,6 +122,41 @@ def match_interactive_prefix(data: str) -> tuple[str, str, str | None] | None:
                 return prefix, window_id, pane_id
             return prefix, remainder, None
     return None
+
+
+async def _handle_direct_choice(
+    query: CallbackQuery,
+    user_id: int,
+    thread_id: int | None,
+    chat_id: int | None,
+    message_id: int | None,
+    window_id: str,
+    pane_id: str | None,
+    choice: tuple[str, int, str, str | None] | None,
+) -> None:
+    """Send one validated direct choice and invalidate its sequence."""
+    if choice is None:
+        await query.answer("This prompt has expired", show_alert=True)
+        return
+    key, sequence, _window_id, _pane_id = choice
+    if not is_current_interactive_prompt(
+        user_id, thread_id, window_id, chat_id, message_id, sequence
+    ):
+        await query.answer("This prompt has expired", show_alert=True)
+        return
+    advance_interactive_sequence(user_id, thread_id)
+    enter = key in {"y", "n"}
+    if pane_id:
+        await tmux_manager.send_keys_to_pane(
+            pane_id, key, enter=enter, literal=True, window_id=window_id
+        )
+    else:
+        window = await tmux_manager.find_window_by_id(window_id)
+        if window:
+            await tmux_manager.send_keys(
+                window.window_id, key, enter=enter, literal=True
+            )
+    await query.answer()
 
 
 async def handle_interactive_callback(
@@ -103,13 +176,32 @@ async def handle_interactive_callback(
     # cycle through registration side effects.
     from ..callback_helpers import get_thread_id, user_owns_window
 
-    if not user_owns_window(user_id, window_id):
+    thread_id = get_thread_id(update)
+    message = query.message
+    chat_id = message.chat.id if message is not None else None
+    # Legacy direct-message bindings have no stored chat ID; direct choices
+    # still verify their exact chat/message below.
+    ownership_chat_id = (
+        None if message is not None and message.chat.type == "private" else chat_id
+    )
+    if not user_owns_window(user_id, window_id, ownership_chat_id):
         await query.answer("Not your session", show_alert=True)
         return
 
-    thread_id = get_thread_id(update)
-    client = PTBTelegramClient(context.bot)
+    if cb_prefix == CB_ASK_CHOICE:
+        await _handle_direct_choice(
+            query,
+            user_id,
+            thread_id,
+            chat_id,
+            message.message_id if message is not None else None,
+            window_id,
+            pane_id,
+            parse_direct_choice_callback(data),
+        )
+        return
 
+    client = PTBTelegramClient(context.bot)
     if cb_prefix == CB_ASK_REFRESH:
         await handle_interactive_ui(
             client, user_id, window_id, thread_id, pane_id=pane_id
@@ -150,7 +242,16 @@ async def _dispatch(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     # Lazy: resolve tokens only when an interactive callback is dispatched.
     from ..callback_tokens import resolve_callback_data
 
-    data = resolve_callback_data(query.data, user.id, user_owns_window)
+    message = query.message
+    chat_id = message.chat.id if message is not None else None
+    ownership_chat_id = (
+        None if message is not None and message.chat.type == "private" else chat_id
+    )
+    data = resolve_callback_data(
+        query.data,
+        user.id,
+        lambda uid, window_id: user_owns_window(uid, window_id, ownership_chat_id),
+    )
     if data is None:
         await query.answer("This button has expired", show_alert=True)
         return

--- a/src/ccgram/handlers/interactive/interactive_callbacks.py
+++ b/src/ccgram/handlers/interactive/interactive_callbacks.py
@@ -144,18 +144,24 @@ async def _handle_direct_choice(
     ):
         await query.answer("This prompt has expired", show_alert=True)
         return
-    advance_interactive_sequence(user_id, thread_id)
     enter = key in {"y", "n"}
-    if pane_id:
-        await tmux_manager.send_keys_to_pane(
-            pane_id, key, enter=enter, literal=True, window_id=window_id
-        )
-    else:
-        window = await tmux_manager.find_window_by_id(window_id)
-        if window:
-            await tmux_manager.send_keys(
+    try:
+        if pane_id:
+            sent = await tmux_manager.send_keys_to_pane(
+                pane_id, key, enter=enter, literal=True, window_id=window_id
+            )
+        else:
+            window = await tmux_manager.find_window_by_id(window_id)
+            sent = bool(window) and await tmux_manager.send_keys(
                 window.window_id, key, enter=enter, literal=True
             )
+    except Exception:  # noqa: BLE001 — report any backend delivery failure to user
+        logger.warning("Failed to send direct interactive choice", exc_info=True)
+        sent = False
+    if not sent:
+        await query.answer("Unable to send choice. Try again.", show_alert=True)
+        return
+    advance_interactive_sequence(user_id, thread_id, chat_id=chat_id)
     await query.answer()
 
 
@@ -204,7 +210,7 @@ async def handle_interactive_callback(
     client = PTBTelegramClient(context.bot)
     if cb_prefix == CB_ASK_REFRESH:
         await handle_interactive_ui(
-            client, user_id, window_id, thread_id, pane_id=pane_id
+            client, user_id, window_id, thread_id, pane_id=pane_id, chat_id=chat_id
         )
         await query.answer("\U0001f504")
     else:
@@ -221,10 +227,10 @@ async def handle_interactive_callback(
         if sent and refresh_ui:
             await asyncio.sleep(0.5)
             await handle_interactive_ui(
-                client, user_id, window_id, thread_id, pane_id=pane_id
+                client, user_id, window_id, thread_id, pane_id=pane_id, chat_id=chat_id
             )
         elif sent and not refresh_ui:
-            await clear_interactive_msg(user_id, client, thread_id)
+            await clear_interactive_msg(user_id, client, thread_id, chat_id=chat_id)
         await query.answer(INTERACTIVE_KEY_LABELS.get(cb_prefix, ""))
 
 

--- a/src/ccgram/handlers/interactive/interactive_ui.py
+++ b/src/ccgram/handlers/interactive/interactive_ui.py
@@ -16,6 +16,7 @@ State dicts are keyed by (user_id, thread_id_or_0) for Telegram topic support.
 
 import asyncio
 import contextlib
+import re
 import time
 
 import structlog
@@ -30,6 +31,7 @@ from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
 from ...topic_state_registry import topic_state
 from ..callback_data import (
+    CB_ASK_CHOICE,
     CB_ASK_DOWN,
     CB_ASK_ENTER,
     CB_ASK_ESC,
@@ -65,6 +67,15 @@ _interactive_msgs: dict[tuple[int, int], int] = {}
 # Track interactive mode: (user_id, thread_id_or_0) -> window_id
 _interactive_mode: dict[tuple[int, int], str] = {}
 
+# The chat/message that owns the currently rendered keyboard. Direct choices
+# are accepted only from this exact Telegram prompt, not a copied callback.
+_interactive_contexts: dict[tuple[int, int], tuple[int, int]] = {}
+
+# A sequence changes whenever the rendered interactive prompt changes and after
+# a direct choice is used. This invalidates delayed or double-tapped choices.
+_interactive_sequences: dict[tuple[int, int], int] = {}
+_interactive_contents: dict[tuple[int, int], str] = {}
+
 # Cooldown to prevent flood when interactive sends fail repeatedly
 _send_cooldowns: dict[tuple[int, int], float] = {}
 _SEND_RETRY_INTERVAL = 5.0  # seconds between retries for failed sends
@@ -81,6 +92,12 @@ INTERACTIVE_INSTRUCTION_LINE = (
 
 # Hard ceiling per Telegram message; leave headroom for entities.
 _TELEGRAM_MAX_TEXT = 4096
+_MAX_DIRECT_CHOICES = 8
+_MIN_NUMBERED_DIRECT_CHOICES = 2
+_CURSOR_MARKER_RE = re.compile(r"^\s*[←→❯>]")
+_DIRECT_CHOICE_ACTION_RE = re.compile(
+    r"(?im)^\s*(?:Esc to|Enter to|Press enter to|ctrl-g to edit)"
+)
 
 
 def format_interactive_message(
@@ -142,7 +159,11 @@ def set_interactive_mode(
 def clear_interactive_mode(user_id: int, thread_id: int | None = None) -> None:
     """Clear interactive mode for a user (without deleting message)."""
     logger.debug("Clear interactive mode: user=%d, thread=%s", user_id, thread_id)
-    _interactive_mode.pop((user_id, thread_id or 0), None)
+    ikey = (user_id, thread_id or 0)
+    _interactive_mode.pop(ikey, None)
+    _interactive_contexts.pop(ikey, None)
+    _interactive_sequences.pop(ikey, None)
+    _interactive_contents.pop(ikey, None)
 
 
 def get_interactive_msg_id(user_id: int, thread_id: int | None = None) -> int | None:
@@ -150,10 +171,89 @@ def get_interactive_msg_id(user_id: int, thread_id: int | None = None) -> int | 
     return _interactive_msgs.get((user_id, thread_id or 0))
 
 
+def parse_direct_choices(content: str) -> tuple[tuple[str, str], ...]:
+    """Extract safe one-tap choices from a single-select interactive prompt.
+
+    Only a contiguous, sequential ``1.``-style list (two through eight items)
+    or an otherwise bare Yes/No choice is eligible. Checkbox lists are
+    multi-select prompts, so they retain the navigation keyboard.
+    """
+    if "☐" in content or "☑" in content:
+        return ()
+
+    numbered: list[tuple[str, str]] = []
+    option_pattern = re.compile(r"^\s*(?:[←→❯>]\s*)?(\d+)\.\s+(.+?)\s*$")
+    for line in content.splitlines():
+        match = option_pattern.fullmatch(line)
+        if match is None:
+            if numbered:
+                break
+            continue
+        number, label = match.groups()
+        expected = len(numbered) + 1
+        if int(number) != expected or expected > _MAX_DIRECT_CHOICES:
+            return ()
+        numbered.append((number, f"{number}. {label}"))
+    has_selection_affordance = _DIRECT_CHOICE_ACTION_RE.search(content) or any(
+        _CURSOR_MARKER_RE.search(line) for line in content.splitlines()
+    )
+    if len(numbered) >= _MIN_NUMBERED_DIRECT_CHOICES and has_selection_affordance:
+        return tuple(numbered)
+
+    words = re.findall(r"(?m)^\s*(?:[←→❯>]\s*)?(Yes|No)\s*$", content, re.IGNORECASE)
+    if {word.lower() for word in words} == {"yes", "no"} and len(
+        words
+    ) == _MIN_NUMBERED_DIRECT_CHOICES:
+        return (("y", "Yes"), ("n", "No"))
+    inline_yes_no = re.search(
+        r"(?m)^\s*(?:[←→❯>]\s*)?Yes\s+(?:[←→❯>]\s*)?No\s*$",
+        content,
+        re.IGNORECASE,
+    )
+    return (("y", "Yes"), ("n", "No")) if inline_yes_no else ()
+
+
+def _next_interactive_sequence(ikey: tuple[int, int], content: str) -> int:
+    """Return the sequence for *content*, advancing when the prompt changes."""
+    if _interactive_contents.get(ikey) != content:
+        _interactive_contents[ikey] = content
+        _interactive_sequences[ikey] = _interactive_sequences.get(ikey, 0) + 1
+    return _interactive_sequences.setdefault(ikey, 1)
+
+
+def is_current_interactive_prompt(
+    user_id: int,
+    thread_id: int | None,
+    window_id: str,
+    chat_id: int | None,
+    message_id: int | None,
+    sequence: int,
+) -> bool:
+    """Whether a direct-choice callback belongs to the currently shown prompt."""
+    if chat_id is None or message_id is None:
+        return False
+    ikey = (user_id, thread_id or 0)
+    return (
+        _interactive_mode.get(ikey) == window_id
+        and _interactive_msgs.get(ikey) == message_id
+        and _interactive_contexts.get(ikey) == (chat_id, message_id)
+        and _interactive_sequences.get(ikey) == sequence
+    )
+
+
+def advance_interactive_sequence(user_id: int, thread_id: int | None) -> None:
+    """Invalidate direct choices after one of them has been accepted."""
+    ikey = (user_id, thread_id or 0)
+    if ikey in _interactive_sequences:
+        _interactive_sequences[ikey] += 1
+
+
 def _build_interactive_keyboard(
     window_id: str,
     ui_name: str = "",
     pane_id: str | None = None,
+    direct_choices: tuple[tuple[str, str], ...] = (),
+    sequence: int = 0,
 ) -> InlineKeyboardMarkup:
     """Build keyboard for interactive UI navigation.
 
@@ -177,7 +277,20 @@ def _build_interactive_keyboard(
             callback_data=compact_callback_data(prefix, f"{prefix}{target}", window_id),
         )
 
+    def choice_btn(key: str, label: str) -> InlineKeyboardButton:
+        payload = f"{CB_ASK_CHOICE}{key}:{sequence}:{target}"
+        return InlineKeyboardButton(
+            label,
+            callback_data=compact_callback_data(CB_ASK_CHOICE, payload, window_id),
+        )
+
     rows: list[list[InlineKeyboardButton]] = []
+    # Direct choices come first, while the complete navigation keyboard remains
+    # available for multi-select and unrecognised prompts.
+    for start in range(0, len(direct_choices), 2):
+        rows.append(
+            [choice_btn(key, label) for key, label in direct_choices[start : start + 2]]
+        )
     # Row 1: directional keys
     rows.append(
         [
@@ -369,22 +482,29 @@ async def handle_interactive_ui(
     if not captured:
         return False
 
-    ui_name, text = captured
+    ui_name, content = captured
     pane_name = _lookup_pane_name(window_id, pane_id) if pane_id else None
-    text = format_interactive_message(text, pane_id=pane_id, pane_name=pane_name)
+    text = format_interactive_message(content, pane_id=pane_id, pane_name=pane_name)
     ikey = (user_id, thread_id or 0)
+    sequence = _next_interactive_sequence(ikey, text)
     chat_id = thread_router.resolve_chat_id(user_id, thread_id)
-    keyboard = _build_interactive_keyboard(window_id, ui_name=ui_name, pane_id=pane_id)
+    keyboard = _build_interactive_keyboard(
+        window_id,
+        ui_name=ui_name,
+        pane_id=pane_id,
+        direct_choices=parse_direct_choices(content),
+        sequence=sequence,
+    )
 
     # Try editing existing interactive message first
     existing_msg_id = _interactive_msgs.get(ikey)
     if existing_msg_id:
-        return (
-            await _edit_interactive_msg(
-                client, chat_id, existing_msg_id, text, keyboard, ikey, window_id
-            )
-            or False
+        edited = await _edit_interactive_msg(
+            client, chat_id, existing_msg_id, text, keyboard, ikey, window_id
         )
+        if edited:
+            _interactive_contexts[ikey] = (chat_id, existing_msg_id)
+        return edited or False
 
     # Cooldown: prevent rapid retries when sends fail
     now = time.monotonic()
@@ -416,6 +536,7 @@ async def handle_interactive_ui(
     )
     if sent:
         _interactive_msgs[ikey] = sent.message_id
+        _interactive_contexts[ikey] = (chat_id, sent.message_id)
         _interactive_mode[ikey] = window_id
         _send_cooldowns.pop(ikey, None)
     return sent is not None
@@ -430,6 +551,9 @@ async def clear_interactive_msg(
     ikey = (user_id, thread_id or 0)
     msg_id = _interactive_msgs.pop(ikey, None)
     _interactive_mode.pop(ikey, None)
+    _interactive_contexts.pop(ikey, None)
+    _interactive_sequences.pop(ikey, None)
+    _interactive_contents.pop(ikey, None)
     _send_cooldowns.pop(ikey, None)
     logger.debug(
         "Clear interactive msg: user=%d, thread=%s, msg_id=%s",

--- a/src/ccgram/handlers/interactive/interactive_ui.py
+++ b/src/ccgram/handlers/interactive/interactive_ui.py
@@ -9,9 +9,10 @@ Handles interactive terminal UIs displayed by Claude Code:
 Provides:
   - Keyboard navigation (up/down/left/right/enter/esc)
   - Terminal capture and display
-  - Interactive mode tracking per user and thread
+  - Interactive mode tracking per user, chat, and thread
 
-State dicts are keyed by (user_id, thread_id_or_0) for Telegram topic support.
+State dicts are keyed by ``(user_id, chat_id, thread_id_or_0)``. This keeps
+identical topic IDs in separate chats from sharing interactive callbacks.
 """
 
 import asyncio
@@ -61,23 +62,25 @@ INTERACTIVE_TOOL_NAMES = frozenset(
     }
 )
 
-# Track interactive UI message IDs: (user_id, thread_id_or_0) -> message_id
-_interactive_msgs: dict[tuple[int, int], int] = {}
+InteractiveKey = tuple[int, int, int]
 
-# Track interactive mode: (user_id, thread_id_or_0) -> window_id
-_interactive_mode: dict[tuple[int, int], str] = {}
+# Track interactive UI message IDs: (user_id, chat_id, thread_id_or_0) -> message_id
+_interactive_msgs: dict[InteractiveKey, int] = {}
+
+# Track interactive mode: (user_id, chat_id, thread_id_or_0) -> window_id
+_interactive_mode: dict[InteractiveKey, str] = {}
 
 # The chat/message that owns the currently rendered keyboard. Direct choices
 # are accepted only from this exact Telegram prompt, not a copied callback.
-_interactive_contexts: dict[tuple[int, int], tuple[int, int]] = {}
+_interactive_contexts: dict[InteractiveKey, tuple[int, int]] = {}
 
 # A sequence changes whenever the rendered interactive prompt changes and after
 # a direct choice is used. This invalidates delayed or double-tapped choices.
-_interactive_sequences: dict[tuple[int, int], int] = {}
-_interactive_contents: dict[tuple[int, int], str] = {}
+_interactive_sequences: dict[InteractiveKey, int] = {}
+_interactive_contents: dict[InteractiveKey, str] = {}
 
 # Cooldown to prevent flood when interactive sends fail repeatedly
-_send_cooldowns: dict[tuple[int, int], float] = {}
+_send_cooldowns: dict[InteractiveKey, float] = {}
 _SEND_RETRY_INTERVAL = 5.0  # seconds between retries for failed sends
 _DEAD_TOPIC_RETRY_INTERVAL = 60.0  # longer backoff when topic is deleted
 
@@ -96,8 +99,26 @@ _MAX_DIRECT_CHOICES = 8
 _MIN_NUMBERED_DIRECT_CHOICES = 2
 _CURSOR_MARKER_RE = re.compile(r"^\s*[←→❯>]")
 _DIRECT_CHOICE_ACTION_RE = re.compile(
-    r"(?im)^\s*(?:Esc to|Enter to|Press enter to|ctrl-g to edit)"
+    r"(?i)^\s*(?:Esc to|Enter to|Press enter to|ctrl-g to edit)"
 )
+_NUMBERED_OPTION_RE = re.compile(r"^\s*(?:[←→❯>]\s*)?(\d+)\.\s+(.+?)\s*$")
+_MULTI_SELECT_RE = re.compile(
+    r"(?i)\b(?:select|choose|pick)\b[^\n]*(?:all|multiple|more than one)\b"
+)
+
+
+def _interactive_key(
+    user_id: int,
+    thread_id: int | None = None,
+    chat_id: int | None = None,
+) -> InteractiveKey:
+    """Build the interactive-state key, resolving chat for non-callback paths."""
+    resolved_chat_id = (
+        thread_router.resolve_chat_id(user_id, thread_id)
+        if chat_id is None
+        else chat_id
+    )
+    return user_id, resolved_chat_id, thread_id or 0
 
 
 def format_interactive_message(
@@ -132,73 +153,138 @@ def format_interactive_message(
 
 @topic_state.register("topic")
 def clear_send_cooldowns(user_id: int, thread_id: int) -> None:
-    """Clear send cooldown for this topic (called on topic cleanup)."""
-    _send_cooldowns.pop((user_id, thread_id or 0), None)
+    """Clear send cooldowns for this topic in every chat on topic cleanup."""
+    topic = thread_id or 0
+    for ikey in tuple(_send_cooldowns):
+        if ikey[0] == user_id and ikey[2] == topic:
+            _send_cooldowns.pop(ikey, None)
 
 
-def get_interactive_window(user_id: int, thread_id: int | None = None) -> str | None:
-    """Get the window_id for user's interactive mode."""
-    return _interactive_mode.get((user_id, thread_id or 0))
+def get_interactive_window(
+    user_id: int,
+    thread_id: int | None = None,
+    *,
+    chat_id: int | None = None,
+) -> str | None:
+    """Get the window ID for a user's chat/topic interactive mode."""
+    return _interactive_mode.get(_interactive_key(user_id, thread_id, chat_id))
 
 
 def set_interactive_mode(
     user_id: int,
     window_id: str,
     thread_id: int | None = None,
+    *,
+    chat_id: int | None = None,
 ) -> None:
-    """Set interactive mode for a user."""
+    """Set interactive mode for a user's chat/topic."""
     logger.debug(
-        "Set interactive mode: user=%d, window_id=%s, thread=%s",
+        "Set interactive mode: user=%d, window_id=%s, thread=%s, chat=%s",
         user_id,
         window_id,
         thread_id,
+        chat_id,
     )
-    _interactive_mode[(user_id, thread_id or 0)] = window_id
+    _interactive_mode[_interactive_key(user_id, thread_id, chat_id)] = window_id
 
 
-def clear_interactive_mode(user_id: int, thread_id: int | None = None) -> None:
-    """Clear interactive mode for a user (without deleting message)."""
-    logger.debug("Clear interactive mode: user=%d, thread=%s", user_id, thread_id)
-    ikey = (user_id, thread_id or 0)
+def clear_interactive_mode(
+    user_id: int,
+    thread_id: int | None = None,
+    *,
+    chat_id: int | None = None,
+) -> None:
+    """Clear interactive mode for a user's chat/topic without deleting it."""
+    logger.debug(
+        "Clear interactive mode: user=%d, thread=%s, chat=%s",
+        user_id,
+        thread_id,
+        chat_id,
+    )
+    ikey = _interactive_key(user_id, thread_id, chat_id)
     _interactive_mode.pop(ikey, None)
     _interactive_contexts.pop(ikey, None)
     _interactive_sequences.pop(ikey, None)
     _interactive_contents.pop(ikey, None)
 
 
-def get_interactive_msg_id(user_id: int, thread_id: int | None = None) -> int | None:
-    """Get the interactive message ID for a user."""
-    return _interactive_msgs.get((user_id, thread_id or 0))
+def get_interactive_msg_id(
+    user_id: int,
+    thread_id: int | None = None,
+    *,
+    chat_id: int | None = None,
+) -> int | None:
+    """Get the interactive message ID for a user's chat/topic."""
+    return _interactive_msgs.get(_interactive_key(user_id, thread_id, chat_id))
+
+
+def _numbered_menu_blocks(
+    lines: list[str],
+) -> list[tuple[int, int, tuple[tuple[str, str], ...]]]:
+    """Find contiguous sequential numbered menu blocks and their line ranges."""
+    blocks: list[tuple[int, int, tuple[tuple[str, str], ...]]] = []
+    index = 0
+    while index < len(lines):
+        first = _NUMBERED_OPTION_RE.fullmatch(lines[index])
+        if first is None or first.group(1) != "1":
+            index += 1
+            continue
+
+        start = index
+        choices: list[tuple[str, str]] = []
+        expected = 1
+        while index < len(lines):
+            option = _NUMBERED_OPTION_RE.fullmatch(lines[index])
+            if option is None:
+                break
+            number, label = option.groups()
+            if int(number) != expected:
+                break
+            choices.append((number, f"{number}. {label}"))
+            expected += 1
+            index += 1
+
+        if len(choices) >= _MIN_NUMBERED_DIRECT_CHOICES:
+            blocks.append((start, index - 1, tuple(choices)))
+        if index == start:
+            index += 1
+    return blocks
 
 
 def parse_direct_choices(content: str) -> tuple[tuple[str, str], ...]:
-    """Extract safe one-tap choices from a single-select interactive prompt.
+    """Extract direct choices only from the active single-select menu.
 
-    Only a contiguous, sequential ``1.``-style list (two through eight items)
-    or an otherwise bare Yes/No choice is eligible. Checkbox lists are
-    multi-select prompts, so they retain the navigation keyboard.
+    Numbered options must form a contiguous sequential menu with two through
+    eight choices. The candidate nearest a cursor marker or action footer wins;
+    ties are ambiguous and deliberately retain the navigation keyboard. This
+    prevents unrelated numbered prose elsewhere in a terminal capture from
+    becoming one-tap input. Explicit multi-select prompts never get buttons.
     """
-    if "☐" in content or "☑" in content:
+    if "☐" in content or "☑" in content or _MULTI_SELECT_RE.search(content):
         return ()
 
-    numbered: list[tuple[str, str]] = []
-    option_pattern = re.compile(r"^\s*(?:[←→❯>]\s*)?(\d+)\.\s+(.+?)\s*$")
-    for line in content.splitlines():
-        match = option_pattern.fullmatch(line)
-        if match is None:
-            if numbered:
-                break
-            continue
-        number, label = match.groups()
-        expected = len(numbered) + 1
-        if int(number) != expected or expected > _MAX_DIRECT_CHOICES:
-            return ()
-        numbered.append((number, f"{number}. {label}"))
-    has_selection_affordance = _DIRECT_CHOICE_ACTION_RE.search(content) or any(
-        _CURSOR_MARKER_RE.search(line) for line in content.splitlines()
-    )
-    if len(numbered) >= _MIN_NUMBERED_DIRECT_CHOICES and has_selection_affordance:
-        return tuple(numbered)
+    lines = content.splitlines()
+    blocks = _numbered_menu_blocks(lines)
+    anchors = [
+        index
+        for index, line in enumerate(lines)
+        if _CURSOR_MARKER_RE.search(line) or _DIRECT_CHOICE_ACTION_RE.search(line)
+    ]
+    if anchors:
+        ranked = sorted(
+            (
+                min(min(abs(anchor - start), abs(anchor - end)) for anchor in anchors),
+                choices,
+            )
+            for start, end, choices in blocks
+        )
+        if ranked and ranked[0][0] < len(lines):
+            nearest_distance, nearest_choices = ranked[0]
+            if (
+                len(nearest_choices) <= _MAX_DIRECT_CHOICES
+                and sum(distance == nearest_distance for distance, _ in ranked) == 1
+            ):
+                return nearest_choices
 
     words = re.findall(r"(?m)^\s*(?:[←→❯>]\s*)?(Yes|No)\s*$", content, re.IGNORECASE)
     if {word.lower() for word in words} == {"yes", "no"} and len(
@@ -213,7 +299,7 @@ def parse_direct_choices(content: str) -> tuple[tuple[str, str], ...]:
     return (("y", "Yes"), ("n", "No")) if inline_yes_no else ()
 
 
-def _next_interactive_sequence(ikey: tuple[int, int], content: str) -> int:
+def _next_interactive_sequence(ikey: InteractiveKey, content: str) -> int:
     """Return the sequence for *content*, advancing when the prompt changes."""
     if _interactive_contents.get(ikey) != content:
         _interactive_contents[ikey] = content
@@ -232,7 +318,7 @@ def is_current_interactive_prompt(
     """Whether a direct-choice callback belongs to the currently shown prompt."""
     if chat_id is None or message_id is None:
         return False
-    ikey = (user_id, thread_id or 0)
+    ikey = _interactive_key(user_id, thread_id, chat_id)
     return (
         _interactive_mode.get(ikey) == window_id
         and _interactive_msgs.get(ikey) == message_id
@@ -241,9 +327,14 @@ def is_current_interactive_prompt(
     )
 
 
-def advance_interactive_sequence(user_id: int, thread_id: int | None) -> None:
-    """Invalidate direct choices after one of them has been accepted."""
-    ikey = (user_id, thread_id or 0)
+def advance_interactive_sequence(
+    user_id: int,
+    thread_id: int | None,
+    *,
+    chat_id: int | None = None,
+) -> None:
+    """Invalidate direct choices after one of them has been delivered."""
+    ikey = _interactive_key(user_id, thread_id, chat_id)
     if ikey in _interactive_sequences:
         _interactive_sequences[ikey] += 1
 
@@ -326,7 +417,7 @@ async def _edit_interactive_msg(
     msg_id: int,
     text: str,
     keyboard: InlineKeyboardMarkup,
-    ikey: tuple[int, int],
+    ikey: InteractiveKey,
     window_id: str,
 ) -> bool | None:
     """Try to edit an existing interactive message.
@@ -418,7 +509,7 @@ async def _send_interactive_with_retry(
     text: str,
     keyboard: InlineKeyboardMarkup,
     thread_kwargs: dict[str, int],
-    ikey: tuple[int, int],
+    ikey: InteractiveKey,
     thread_id: int | None,
     window_id: str,
     now: float,
@@ -467,6 +558,8 @@ async def handle_interactive_ui(
     window_id: str,
     thread_id: int | None = None,
     pane_id: str | None = None,
+    *,
+    chat_id: int | None = None,
 ) -> bool:
     """Capture terminal and send interactive UI content to user.
 
@@ -485,9 +578,13 @@ async def handle_interactive_ui(
     ui_name, content = captured
     pane_name = _lookup_pane_name(window_id, pane_id) if pane_id else None
     text = format_interactive_message(content, pane_id=pane_id, pane_name=pane_name)
-    ikey = (user_id, thread_id or 0)
+    resolved_chat_id = (
+        thread_router.resolve_chat_id(user_id, thread_id)
+        if chat_id is None
+        else chat_id
+    )
+    ikey = _interactive_key(user_id, thread_id, resolved_chat_id)
     sequence = _next_interactive_sequence(ikey, text)
-    chat_id = thread_router.resolve_chat_id(user_id, thread_id)
     keyboard = _build_interactive_keyboard(
         window_id,
         ui_name=ui_name,
@@ -500,10 +597,10 @@ async def handle_interactive_ui(
     existing_msg_id = _interactive_msgs.get(ikey)
     if existing_msg_id:
         edited = await _edit_interactive_msg(
-            client, chat_id, existing_msg_id, text, keyboard, ikey, window_id
+            client, resolved_chat_id, existing_msg_id, text, keyboard, ikey, window_id
         )
         if edited:
-            _interactive_contexts[ikey] = (chat_id, existing_msg_id)
+            _interactive_contexts[ikey] = (resolved_chat_id, existing_msg_id)
         return edited or False
 
     # Cooldown: prevent rapid retries when sends fail
@@ -522,10 +619,10 @@ async def handle_interactive_ui(
     )
     _send_cooldowns[ikey] = now
     # Send as plain text — terminal content should not be formatted.
-    await rate_limit_send(chat_id)
+    await rate_limit_send(resolved_chat_id)
     sent = await _send_interactive_with_retry(
         client,
-        chat_id=chat_id,
+        chat_id=resolved_chat_id,
         text=text,
         keyboard=keyboard,
         thread_kwargs=thread_kwargs,
@@ -536,7 +633,7 @@ async def handle_interactive_ui(
     )
     if sent:
         _interactive_msgs[ikey] = sent.message_id
-        _interactive_contexts[ikey] = (chat_id, sent.message_id)
+        _interactive_contexts[ikey] = (resolved_chat_id, sent.message_id)
         _interactive_mode[ikey] = window_id
         _send_cooldowns.pop(ikey, None)
     return sent is not None
@@ -546,9 +643,16 @@ async def clear_interactive_msg(
     user_id: int,
     client: TelegramClient | None = None,
     thread_id: int | None = None,
+    *,
+    chat_id: int | None = None,
 ) -> None:
-    """Clear tracked interactive message, delete from chat, and exit interactive mode."""
-    ikey = (user_id, thread_id or 0)
+    """Clear the tracked interactive message for one user/chat/topic."""
+    resolved_chat_id = (
+        thread_router.resolve_chat_id(user_id, thread_id)
+        if chat_id is None
+        else chat_id
+    )
+    ikey = _interactive_key(user_id, thread_id, resolved_chat_id)
     msg_id = _interactive_msgs.pop(ikey, None)
     _interactive_mode.pop(ikey, None)
     _interactive_contexts.pop(ikey, None)
@@ -556,12 +660,12 @@ async def clear_interactive_msg(
     _interactive_contents.pop(ikey, None)
     _send_cooldowns.pop(ikey, None)
     logger.debug(
-        "Clear interactive msg: user=%d, thread=%s, msg_id=%s",
+        "Clear interactive msg: user=%d, thread=%s, chat=%s, msg_id=%s",
         user_id,
         thread_id,
+        resolved_chat_id,
         msg_id,
     )
     if client and msg_id:
-        chat_id = thread_router.resolve_chat_id(user_id, thread_id)
         with contextlib.suppress(TelegramError):
-            await client.delete_message(chat_id=chat_id, message_id=msg_id)
+            await client.delete_message(chat_id=resolved_chat_id, message_id=msg_id)

--- a/src/ccgram/handlers/messaging_pipeline/message_routing.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_routing.py
@@ -188,20 +188,22 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
                 continue
 
         if msg.tool_name in INTERACTIVE_TOOL_NAMES and msg.content_type == "tool_use":
-            set_interactive_mode(user_id, window_id, thread_id)
+            set_interactive_mode(user_id, window_id, thread_id, chat_id)
             queue = get_message_queue(user_id)
             if queue:
                 await queue.join()
             await asyncio.sleep(0.3)
-            handled = await handle_interactive_ui(client, user_id, window_id, thread_id)
+            handled = await handle_interactive_ui(
+                client, user_id, window_id, thread_id, chat_id=chat_id
+            )
             if handled:
                 await _update_window_offset(user_id, window_id)
                 continue
             else:
-                clear_interactive_mode(user_id, thread_id)
+                clear_interactive_mode(user_id, thread_id, chat_id)
 
-        if get_interactive_msg_id(user_id, thread_id):
-            await clear_interactive_msg(user_id, client, thread_id)
+        if get_interactive_msg_id(user_id, thread_id, chat_id):
+            await clear_interactive_msg(user_id, client, thread_id, chat_id)
 
         if await _handle_assistant_stream(
             msg,

--- a/src/ccgram/handlers/messaging_pipeline/message_routing.py
+++ b/src/ccgram/handlers/messaging_pipeline/message_routing.py
@@ -188,7 +188,7 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
                 continue
 
         if msg.tool_name in INTERACTIVE_TOOL_NAMES and msg.content_type == "tool_use":
-            set_interactive_mode(user_id, window_id, thread_id, chat_id)
+            set_interactive_mode(user_id, window_id, thread_id, chat_id=chat_id)
             queue = get_message_queue(user_id)
             if queue:
                 await queue.join()
@@ -200,10 +200,10 @@ async def handle_new_message(msg: NewMessage, client: TelegramClient) -> None:  
                 await _update_window_offset(user_id, window_id)
                 continue
             else:
-                clear_interactive_mode(user_id, thread_id, chat_id)
+                clear_interactive_mode(user_id, thread_id, chat_id=chat_id)
 
-        if get_interactive_msg_id(user_id, thread_id, chat_id):
-            await clear_interactive_msg(user_id, client, thread_id, chat_id)
+        if get_interactive_msg_id(user_id, thread_id, chat_id=chat_id):
+            await clear_interactive_msg(user_id, client, thread_id, chat_id=chat_id)
 
         if await _handle_assistant_stream(
             msg,

--- a/src/ccgram/handlers/sync_command.py
+++ b/src/ccgram/handlers/sync_command.py
@@ -124,8 +124,6 @@ async def _sync_live_topic_names(
         if window_id not in live_ids:
             continue
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
-        if chat_id == user_id:
-            continue
         bindings.append((chat_id, thread_id, window_id))
 
     sem = asyncio.Semaphore(_TELEGRAM_API_CONCURRENCY)
@@ -341,40 +339,31 @@ async def _close_ghost_topics(
         if current_window_id != window_id:
             continue
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
-        topic_removed = False
-        if chat_id == user_id:
+        topic_removed = await _remove_topic(client, chat_id, thread_id)
+        if not topic_removed:
             logger.warning(
-                "No group chat_id for ghost topic thread=%d, skipping close",
+                "Failed to delete/close ghost topic thread=%d window=%s",
                 thread_id,
+                window_id,
             )
-        else:
-            topic_removed = await _remove_topic(client, chat_id, thread_id)
-            if not topic_removed:
-                logger.warning(
-                    "Failed to delete/close ghost topic thread=%d window=%s",
-                    thread_id,
-                    window_id,
-                )
-                manual_close_count += 1
-                continue
-        if topic_removed or chat_id == user_id:
-            try:
-                await clear_topic_state(
-                    user_id, thread_id, client=client, window_id=window_id
-                )
-                thread_router.unbind_thread(
-                    user_id,
-                    thread_id,
-                    retirement_reason="remote_removed",
-                )
-                if topic_removed:
-                    closed_count += 1
-            except OSError, TelegramError:
-                logger.exception(
-                    "Failed to clean up ghost binding thread=%d window=%s",
-                    thread_id,
-                    window_id,
-                )
+            manual_close_count += 1
+            continue
+        try:
+            await clear_topic_state(
+                user_id, thread_id, client=client, window_id=window_id
+            )
+            thread_router.unbind_thread(
+                user_id,
+                thread_id,
+                retirement_reason="remote_removed",
+            )
+            closed_count += 1
+        except OSError, TelegramError:
+            logger.exception(
+                "Failed to clean up ghost binding thread=%d window=%s",
+                thread_id,
+                window_id,
+            )
     return closed_count, manual_close_count
 
 
@@ -425,8 +414,6 @@ async def _probe_dead_topics(client: TelegramClient) -> list[AuditIssue]:
         (uid, tid, wid, thread_router.resolve_chat_id(uid, tid))
         for uid, tid, wid in thread_router.iter_thread_bindings()
     ]
-    # Only probe bindings with a group chat (chat_id != user_id)
-    bindings = [(uid, tid, wid, cid) for uid, tid, wid, cid in bindings if cid != uid]
     if not bindings:
         return []
 
@@ -527,8 +514,7 @@ async def _recreate_dead_topics(
                 thread_router.bind_thread(
                     user_id, thread_id, window_id, window_name=name, chat_id=chat_id
                 )
-                if chat_id != user_id:
-                    thread_router.set_group_chat_id(user_id, thread_id, chat_id)
+                thread_router.set_group_chat_id(user_id, thread_id, chat_id)
     return recreated
 
 

--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -456,10 +456,12 @@ async def _forward_message(
         _bash_capture_tasks[(user_id, thread_id)] = task
 
     # If in interactive mode, refresh the UI after sending text
-    interactive_window = get_interactive_window(user_id, thread_id)
+    interactive_window = get_interactive_window(user_id, thread_id, message.chat.id)
     if interactive_window and interactive_window == window_id:
         await asyncio.sleep(0.2)
-        await handle_interactive_ui(client, user_id, window_id, thread_id)
+        await handle_interactive_ui(
+            client, user_id, window_id, thread_id, chat_id=message.chat.id
+        )
 
 
 async def text_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -456,7 +456,9 @@ async def _forward_message(
         _bash_capture_tasks[(user_id, thread_id)] = task
 
     # If in interactive mode, refresh the UI after sending text
-    interactive_window = get_interactive_window(user_id, thread_id, message.chat.id)
+    interactive_window = get_interactive_window(
+        user_id, thread_id, chat_id=message.chat.id
+    )
     if interactive_window and interactive_window == window_id:
         await asyncio.sleep(0.2)
         await handle_interactive_ui(

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -237,8 +237,8 @@ async def _auto_detect_provider(window_id: str) -> None:
 
 
 def collect_target_chats(window_id: str) -> set[int]:
-    """Collect unique group chat IDs for topic creation."""
-    seen_chats: set[int] = set()
+    """Collect topic-capable group and private chat IDs for topic creation."""
+    seen_chats = set(thread_router.iter_direct_message_chat_ids())
     for user_id, thread_id, _ in thread_router.iter_thread_bindings():
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
         if isinstance(chat_id, int) and chat_id < 0:

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -237,8 +237,8 @@ async def _auto_detect_provider(window_id: str) -> None:
 
 
 def collect_target_chats(window_id: str) -> set[int]:
-    """Collect topic-capable group and private chat IDs for topic creation."""
-    seen_chats = set(thread_router.iter_direct_message_chat_ids())
+    """Collect topic-capable group and observed private-topic chats."""
+    seen_chats = set(thread_router.iter_private_topic_chat_ids())
     for user_id, thread_id, _ in thread_router.iter_thread_bindings():
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
         if isinstance(chat_id, int) and chat_id < 0:
@@ -326,7 +326,27 @@ async def create_topic_in_chat(
     *,
     user_id: int | None = None,
 ) -> bool:
-    """Create and bind one forum topic, returning whether it succeeded."""
+    """Create and bind one topic, returning whether it succeeded."""
+    if chat_id > 0:
+        try:
+            bot_user = await client.get_me()
+        except TelegramError:
+            logger.warning(
+                "Skipping private topic creation for window %s in chat %d: "
+                "could not observe bot topic capability",
+                window_id,
+                chat_id,
+            )
+            return False
+        if getattr(bot_user, "has_topics_enabled", None) is not True:
+            logger.info(
+                "Skipping private topic creation for window %s in chat %d: "
+                "bot topics are not enabled",
+                window_id,
+                chat_id,
+            )
+            return False
+
     owner_id = _find_topic_owner(chat_id, window_id, user_id)
     if owner_id is None:
         logger.warning(
@@ -404,8 +424,6 @@ async def _rebind_existing_topic_by_name(
         if await tmux_manager.find_window_by_id(old_window_id):
             continue
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
-        if chat_id == user_id:
-            continue
         matches.append((user_id, thread_id, old_window_id, chat_id))
 
     if len(matches) != 1:

--- a/src/ccgram/handlers/topics/window_callbacks.py
+++ b/src/ccgram/handlers/topics/window_callbacks.py
@@ -23,7 +23,7 @@ from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
 from ..telegram_origin import send_telegram_to_window
 from ..callback_data import CB_WIN_BIND, CB_WIN_CANCEL, CB_WIN_NEW
-from ..callback_helpers import get_thread_id, is_direct_messages_topic
+from ..callback_helpers import get_thread_id
 from .directory_browser import (
     BROWSE_DIRS_KEY,
     BROWSE_PAGE_KEY,
@@ -65,9 +65,7 @@ def _store_group_chat_id(
 async def _rename_forum_topic(
     client: TelegramClient, chat_id: int, thread_id: int, display: str, window_id: str
 ) -> None:
-    """Rename a forum topic, leaving observed private direct topics untouched."""
-    if thread_router.is_direct_message_topic(chat_id, thread_id):
-        return
+    """Rename a topic in either a forum or a private topic chat."""
     try:
         await client.edit_forum_topic(
             chat_id=chat_id,
@@ -250,12 +248,6 @@ async def _handle_bind(
         ),
     )
     _store_group_chat_id(user_id, thread_id, update, query)
-    topic_message = (
-        update.callback_query.message if update.callback_query else query.message
-    )
-    if topic_message and is_direct_messages_topic(topic_message):
-        thread_router.mark_direct_message_topic(topic_message.chat.id, thread_id)
-
     client: TelegramClient = PTBTelegramClient(context.bot)
     detected = await _detect_and_setup_provider(
         selected_wid,

--- a/src/ccgram/handlers/topics/window_callbacks.py
+++ b/src/ccgram/handlers/topics/window_callbacks.py
@@ -23,7 +23,7 @@ from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
 from ..telegram_origin import send_telegram_to_window
 from ..callback_data import CB_WIN_BIND, CB_WIN_CANCEL, CB_WIN_NEW
-from ..callback_helpers import get_thread_id
+from ..callback_helpers import get_thread_id, is_direct_messages_topic
 from .directory_browser import (
     BROWSE_DIRS_KEY,
     BROWSE_PAGE_KEY,
@@ -60,6 +60,24 @@ def _store_group_chat_id(
     chat = _get_topic_chat(update, query)
     if chat and chat.type in ("group", "supergroup"):
         thread_router.set_group_chat_id(user_id, thread_id, chat.id)
+
+
+async def _rename_forum_topic(
+    client: TelegramClient, chat_id: int, thread_id: int, display: str, window_id: str
+) -> None:
+    """Rename a forum topic, leaving observed private direct topics untouched."""
+    if thread_router.is_direct_message_topic(chat_id, thread_id):
+        return
+    try:
+        await client.edit_forum_topic(
+            chat_id=chat_id,
+            message_thread_id=thread_id,
+            name=format_topic_name_for_mode(
+                display, window_query.get_approval_mode(window_id)
+            ),
+        )
+    except TelegramError as exc:
+        logger.debug("Failed to rename topic: %s", exc)
 
 
 async def handle_window_callback(
@@ -232,6 +250,11 @@ async def _handle_bind(
         ),
     )
     _store_group_chat_id(user_id, thread_id, update, query)
+    topic_message = (
+        update.callback_query.message if update.callback_query else query.message
+    )
+    if topic_message and is_direct_messages_topic(topic_message):
+        thread_router.mark_direct_message_topic(topic_message.chat.id, thread_id)
 
     client: TelegramClient = PTBTelegramClient(context.bot)
     detected = await _detect_and_setup_provider(
@@ -242,16 +265,13 @@ async def _handle_bind(
         thread_id=thread_id,
     )
 
-    try:
-        await client.edit_forum_topic(
-            chat_id=thread_router.resolve_chat_id(user_id, thread_id),
-            message_thread_id=thread_id,
-            name=format_topic_name_for_mode(
-                display, window_query.get_approval_mode(selected_wid)
-            ),
-        )
-    except TelegramError as e:
-        logger.debug("Failed to rename topic: %s", e)
+    await _rename_forum_topic(
+        client,
+        thread_router.resolve_chat_id(user_id, thread_id),
+        thread_id,
+        display,
+        selected_wid,
+    )
 
     await safe_edit(
         query,

--- a/src/ccgram/handlers/topics/window_launch_service.py
+++ b/src/ccgram/handlers/topics/window_launch_service.py
@@ -24,7 +24,6 @@ from ...session_map import session_map_sync
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
 from ..telegram_origin import send_telegram_to_window
-from ..callback_helpers import is_direct_messages_topic
 from ...user_preferences import user_preferences
 from ... import window_query
 from ...window_state_store import CCGRAM_CREATED_WINDOW_ORIGIN
@@ -373,8 +372,6 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         )
         if chat and chat.type in ("group", "supergroup"):
             thread_router.set_group_chat_id(user_id, pending_thread_id, chat.id)
-        elif chat and query_message and is_direct_messages_topic(query_message):
-            thread_router.mark_direct_message_topic(chat.id, pending_thread_id)
 
     provider = provider_registry.get(provider_name)
     try:
@@ -434,15 +431,14 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         return WindowLaunchResult(success=True, window_id=created_wid)
 
     chat_id = thread_router.resolve_chat_id(user_id, pending_thread_id)
-    if not thread_router.is_direct_message_topic(chat_id, pending_thread_id):
-        try:
-            await context.bot.edit_forum_topic(
-                chat_id=chat_id,
-                message_thread_id=pending_thread_id,
-                name=format_topic_name_for_mode(created_wname, approval_mode),
-            )
-        except TelegramError as e:
-            logger.debug("Failed to rename topic: %s", e)
+    try:
+        await context.bot.edit_forum_topic(
+            chat_id=chat_id,
+            message_thread_id=pending_thread_id,
+            name=format_topic_name_for_mode(created_wname, approval_mode),
+        )
+    except TelegramError as e:
+        logger.debug("Failed to rename topic: %s", e)
 
     await safe_edit(
         query,

--- a/src/ccgram/handlers/topics/window_launch_service.py
+++ b/src/ccgram/handlers/topics/window_launch_service.py
@@ -24,6 +24,7 @@ from ...session_map import session_map_sync
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
 from ..telegram_origin import send_telegram_to_window
+from ..callback_helpers import is_direct_messages_topic
 from ...user_preferences import user_preferences
 from ... import window_query
 from ...window_state_store import CCGRAM_CREATED_WINDOW_ORIGIN
@@ -368,10 +369,12 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
             pending_thread_id,
             created_wid,
             window_name=created_wname,
-            chat_id=chat.id if chat and chat.type in ("group", "supergroup") else None,
+            chat_id=chat.id if chat else None,
         )
         if chat and chat.type in ("group", "supergroup"):
             thread_router.set_group_chat_id(user_id, pending_thread_id, chat.id)
+        elif chat and query_message and is_direct_messages_topic(query_message):
+            thread_router.mark_direct_message_topic(chat.id, pending_thread_id)
 
     provider = provider_registry.get(provider_name)
     try:
@@ -430,14 +433,16 @@ async def launch_window(  # noqa: PLR0912, PLR0915, C901
         await safe_edit(query, f"✅ {message}")
         return WindowLaunchResult(success=True, window_id=created_wid)
 
-    try:
-        await context.bot.edit_forum_topic(
-            chat_id=thread_router.resolve_chat_id(user_id, pending_thread_id),
-            message_thread_id=pending_thread_id,
-            name=format_topic_name_for_mode(created_wname, approval_mode),
-        )
-    except TelegramError as e:
-        logger.debug("Failed to rename topic: %s", e)
+    chat_id = thread_router.resolve_chat_id(user_id, pending_thread_id)
+    if not thread_router.is_direct_message_topic(chat_id, pending_thread_id):
+        try:
+            await context.bot.edit_forum_topic(
+                chat_id=chat_id,
+                message_thread_id=pending_thread_id,
+                name=format_topic_name_for_mode(created_wname, approval_mode),
+            )
+        except TelegramError as e:
+            logger.debug("Failed to rename topic: %s", e)
 
     await safe_edit(
         query,

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -203,8 +203,9 @@ class SessionManager:
         # Load user preferences (starred dirs, MRU, read offsets)
         user_preferences.from_dict(state)
 
-        # Load routing data into ThreadRouter (handles dedup + reverse index)
-        thread_router.from_dict(state)
+        # Load routing data into ThreadRouter (handles normalization, dedup,
+        # and reverse-index rebuild). Persist any repaired persisted claims.
+        routing_repaired = thread_router.from_dict(state)
 
         # Detect old format: keys that don't look like window IDs
         needs_migration = False
@@ -226,7 +227,7 @@ class SessionManager:
                 "Detected old-format state (window_name keys), "
                 "will re-resolve on startup"
             )
-        if migrated:
+        if migrated or routing_repaired:
             self._save_state()
 
     @staticmethod

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -127,6 +127,18 @@ def session_map_prefix() -> str:
     return session_map_prefix_for(config.multiplexer_name, config.tmux_session_name)
 
 
+def strip_session_map_prefix(window_key: str, prefix: str) -> str | None:
+    """Return a window ID only when ``window_key`` has the exact ``prefix``.
+
+    ``events.jsonl`` and ``session_map.json`` share this key scheme. A target
+    alone is not enough to route a hook event: another backend or tmux session
+    can use the same target, so callers must reject unmatched prefixes.
+    """
+    if not window_key.startswith(prefix):
+        return None
+    return window_key.removeprefix(prefix)
+
+
 def is_backend_window_id(window_id: str) -> bool:
     """Validate a prefix-stripped session_map window id for the active backend.
 
@@ -239,9 +251,11 @@ def parse_session_map(raw: dict[str, Any], prefix: str) -> dict[str, dict[str, s
         return {}
     result: dict[str, dict[str, str]] = {}
     for key, info in raw.items():
-        if not isinstance(key, str) or not key.startswith(prefix):
+        if not isinstance(key, str):
             continue
-        window_name = key[len(prefix) :]
+        window_name = strip_session_map_prefix(key, prefix)
+        if window_name is None:
+            continue
         # A Herdr prefix alone is not authority: only an exact versioned
         # guarded-session target is accepted. Raw tab/pane IDs are legacy
         # migration records and must not reach monitor lifecycle processing.

--- a/src/ccgram/telegram_client.py
+++ b/src/ccgram/telegram_client.py
@@ -26,34 +26,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol, cast, runtime_checkable
 
-from telegram import Bot, BotCommand, ChatFullInfo, File, ForumTopic, Message
+from telegram import Bot, BotCommand, ChatFullInfo, File, ForumTopic, Message, User
 from telegram._botcommandscope import BotCommandScope
 from telegram._files.inputmedia import InputMedia
 from telegram._reaction import ReactionType
-
-
-def _route_direct_message_topic(
-    chat_id: int | str, kwargs: dict[str, Any]
-) -> dict[str, Any]:
-    """Use the direct-message API parameter only for observed capable topics.
-
-    The internal router deliberately stores a topic ID uniformly. Telegram's
-    Bot API, however, requires ``direct_messages_topic_id`` for private
-    threaded DMs and ``message_thread_id`` for forum supergroups.
-    """
-    thread_id = kwargs.get("message_thread_id")
-    if not isinstance(chat_id, int) or not isinstance(thread_id, int):
-        return kwargs
-
-    # Lazy: avoid making the Telegram seam own session initialization.
-    from .thread_router import thread_router
-
-    if not thread_router.is_direct_message_topic(chat_id, thread_id):
-        return kwargs
-    routed = dict(kwargs)
-    routed.pop("message_thread_id")
-    routed.setdefault("direct_messages_topic_id", thread_id)
-    return routed
 
 
 @runtime_checkable
@@ -142,6 +118,8 @@ class TelegramClient(Protocol):
 
     async def get_chat(self, chat_id: int | str, **kwargs: Any) -> ChatFullInfo: ...
 
+    async def get_me(self, **kwargs: Any) -> User: ...
+
     async def get_file(self, file_id: str, **kwargs: Any) -> File: ...
 
     async def create_forum_topic(
@@ -221,7 +199,7 @@ class PTBTelegramClient:
         return await self._bot.send_message(
             chat_id=chat_id,
             text=text,
-            **_route_direct_message_topic(chat_id, kwargs),
+            **kwargs,
         )
 
     async def edit_message_text(
@@ -269,7 +247,7 @@ class PTBTelegramClient:
         return await self._bot.send_photo(
             chat_id=chat_id,
             photo=photo,
-            **_route_direct_message_topic(chat_id, kwargs),
+            **kwargs,
         )
 
     async def send_document(
@@ -278,18 +256,14 @@ class PTBTelegramClient:
         return await self._bot.send_document(
             chat_id=chat_id,
             document=document,
-            **_route_direct_message_topic(chat_id, kwargs),
+            **kwargs,
         )
 
     async def send_chat_action(
         self, chat_id: int | str, action: str, **kwargs: Any
     ) -> bool:
-        # Bot API has no direct_messages_topic_id for chat actions. Do not
-        # leak the forum-only parameter into an observed private topic.
-        routed = _route_direct_message_topic(chat_id, kwargs)
-        routed.pop("direct_messages_topic_id", None)
         return await self._bot.send_chat_action(
-            chat_id=chat_id, action=action, **routed
+            chat_id=chat_id, action=action, **kwargs
         )
 
     async def send_voice(
@@ -298,7 +272,7 @@ class PTBTelegramClient:
         return await self._bot.send_voice(
             chat_id=chat_id,
             voice=voice,
-            **_route_direct_message_topic(chat_id, kwargs),
+            **kwargs,
         )
 
     async def set_message_reaction(
@@ -314,6 +288,9 @@ class PTBTelegramClient:
 
     async def get_chat(self, chat_id: int | str, **kwargs: Any) -> ChatFullInfo:
         return await self._bot.get_chat(chat_id=chat_id, **kwargs)
+
+    async def get_me(self, **kwargs: Any) -> User:
+        return await self._bot.get_me(**kwargs)
 
     async def get_file(self, file_id: str, **kwargs: Any) -> File:
         return await self._bot.get_file(file_id=file_id, **kwargs)
@@ -442,7 +419,7 @@ class FakeTelegramClient:
             {
                 "chat_id": chat_id,
                 "text": text,
-                **_route_direct_message_topic(chat_id, kwargs),
+                **kwargs,
             },
         )
 
@@ -497,7 +474,7 @@ class FakeTelegramClient:
             {
                 "chat_id": chat_id,
                 "photo": photo,
-                **_route_direct_message_topic(chat_id, kwargs),
+                **kwargs,
             },
         )
 
@@ -509,17 +486,15 @@ class FakeTelegramClient:
             {
                 "chat_id": chat_id,
                 "document": document,
-                **_route_direct_message_topic(chat_id, kwargs),
+                **kwargs,
             },
         )
 
     async def send_chat_action(
         self, chat_id: int | str, action: str, **kwargs: Any
     ) -> bool:
-        routed = _route_direct_message_topic(chat_id, kwargs)
-        routed.pop("direct_messages_topic_id", None)
         return self._record(
-            "send_chat_action", {"chat_id": chat_id, "action": action, **routed}
+            "send_chat_action", {"chat_id": chat_id, "action": action, **kwargs}
         )
 
     async def send_voice(
@@ -530,7 +505,7 @@ class FakeTelegramClient:
             {
                 "chat_id": chat_id,
                 "voice": voice,
-                **_route_direct_message_topic(chat_id, kwargs),
+                **kwargs,
             },
         )
 
@@ -553,6 +528,9 @@ class FakeTelegramClient:
 
     async def get_chat(self, chat_id: int | str, **kwargs: Any) -> ChatFullInfo:
         return self._record("get_chat", {"chat_id": chat_id, **kwargs})
+
+    async def get_me(self, **kwargs: Any) -> User:
+        return self._record("get_me", kwargs)
 
     async def get_file(self, file_id: str, **kwargs: Any) -> File:
         return self._record("get_file", {"file_id": file_id, **kwargs})

--- a/src/ccgram/telegram_client.py
+++ b/src/ccgram/telegram_client.py
@@ -32,6 +32,30 @@ from telegram._files.inputmedia import InputMedia
 from telegram._reaction import ReactionType
 
 
+def _route_direct_message_topic(
+    chat_id: int | str, kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    """Use the direct-message API parameter only for observed capable topics.
+
+    The internal router deliberately stores a topic ID uniformly. Telegram's
+    Bot API, however, requires ``direct_messages_topic_id`` for private
+    threaded DMs and ``message_thread_id`` for forum supergroups.
+    """
+    thread_id = kwargs.get("message_thread_id")
+    if not isinstance(chat_id, int) or not isinstance(thread_id, int):
+        return kwargs
+
+    # Lazy: avoid making the Telegram seam own session initialization.
+    from .thread_router import thread_router
+
+    if not thread_router.is_direct_message_topic(chat_id, thread_id):
+        return kwargs
+    routed = dict(kwargs)
+    routed.pop("message_thread_id")
+    routed.setdefault("direct_messages_topic_id", thread_id)
+    return routed
+
+
 @runtime_checkable
 class TelegramClient(Protocol):
     """Narrow seam over the PTB ``Bot`` methods used in this codebase.
@@ -194,7 +218,11 @@ class PTBTelegramClient:
     async def send_message(
         self, chat_id: int | str, text: str, **kwargs: Any
     ) -> Message:
-        return await self._bot.send_message(chat_id=chat_id, text=text, **kwargs)
+        return await self._bot.send_message(
+            chat_id=chat_id,
+            text=text,
+            **_route_direct_message_topic(chat_id, kwargs),
+        )
 
     async def edit_message_text(
         self,
@@ -238,26 +266,40 @@ class PTBTelegramClient:
     async def send_photo(
         self, chat_id: int | str, photo: Any, **kwargs: Any
     ) -> Message:
-        return await self._bot.send_photo(chat_id=chat_id, photo=photo, **kwargs)
+        return await self._bot.send_photo(
+            chat_id=chat_id,
+            photo=photo,
+            **_route_direct_message_topic(chat_id, kwargs),
+        )
 
     async def send_document(
         self, chat_id: int | str, document: Any, **kwargs: Any
     ) -> Message:
         return await self._bot.send_document(
-            chat_id=chat_id, document=document, **kwargs
+            chat_id=chat_id,
+            document=document,
+            **_route_direct_message_topic(chat_id, kwargs),
         )
 
     async def send_chat_action(
         self, chat_id: int | str, action: str, **kwargs: Any
     ) -> bool:
+        # Bot API has no direct_messages_topic_id for chat actions. Do not
+        # leak the forum-only parameter into an observed private topic.
+        routed = _route_direct_message_topic(chat_id, kwargs)
+        routed.pop("direct_messages_topic_id", None)
         return await self._bot.send_chat_action(
-            chat_id=chat_id, action=action, **kwargs
+            chat_id=chat_id, action=action, **routed
         )
 
     async def send_voice(
         self, chat_id: int | str, voice: Any, **kwargs: Any
     ) -> Message:
-        return await self._bot.send_voice(chat_id=chat_id, voice=voice, **kwargs)
+        return await self._bot.send_voice(
+            chat_id=chat_id,
+            voice=voice,
+            **_route_direct_message_topic(chat_id, kwargs),
+        )
 
     async def set_message_reaction(
         self,
@@ -396,7 +438,12 @@ class FakeTelegramClient:
         self, chat_id: int | str, text: str, **kwargs: Any
     ) -> Message:
         return self._record(
-            "send_message", {"chat_id": chat_id, "text": text, **kwargs}
+            "send_message",
+            {
+                "chat_id": chat_id,
+                "text": text,
+                **_route_direct_message_topic(chat_id, kwargs),
+            },
         )
 
     async def edit_message_text(
@@ -446,28 +493,45 @@ class FakeTelegramClient:
         self, chat_id: int | str, photo: Any, **kwargs: Any
     ) -> Message:
         return self._record(
-            "send_photo", {"chat_id": chat_id, "photo": photo, **kwargs}
+            "send_photo",
+            {
+                "chat_id": chat_id,
+                "photo": photo,
+                **_route_direct_message_topic(chat_id, kwargs),
+            },
         )
 
     async def send_document(
         self, chat_id: int | str, document: Any, **kwargs: Any
     ) -> Message:
         return self._record(
-            "send_document", {"chat_id": chat_id, "document": document, **kwargs}
+            "send_document",
+            {
+                "chat_id": chat_id,
+                "document": document,
+                **_route_direct_message_topic(chat_id, kwargs),
+            },
         )
 
     async def send_chat_action(
         self, chat_id: int | str, action: str, **kwargs: Any
     ) -> bool:
+        routed = _route_direct_message_topic(chat_id, kwargs)
+        routed.pop("direct_messages_topic_id", None)
         return self._record(
-            "send_chat_action", {"chat_id": chat_id, "action": action, **kwargs}
+            "send_chat_action", {"chat_id": chat_id, "action": action, **routed}
         )
 
     async def send_voice(
         self, chat_id: int | str, voice: Any, **kwargs: Any
     ) -> Message:
         return self._record(
-            "send_voice", {"chat_id": chat_id, "voice": voice, **kwargs}
+            "send_voice",
+            {
+                "chat_id": chat_id,
+                "voice": voice,
+                **_route_direct_message_topic(chat_id, kwargs),
+            },
         )
 
     async def set_message_reaction(

--- a/src/ccgram/thread_router.py
+++ b/src/ccgram/thread_router.py
@@ -91,11 +91,10 @@ class ThreadRouter:
         self.thread_bindings: dict[int, dict[int, str]] = {}
         # Chat-scoped bindings preserve Telegram's chat-local thread identity.
         self.chat_thread_bindings: dict[tuple[int, int, int], str] = {}
-        # Chat/topic pairs observed with Bot API direct-message topic metadata.
-        # This is deliberately capability-driven: a positive chat ID alone is
-        # not evidence that it accepts ``direct_messages_topic_id``.
-        self.direct_message_topics: set[tuple[int, int]] = set()
-        # "user_id:thread_id" -> chat_id for legacy/direct-message bindings.
+        # Private chats observed to carry Telegram's regular topic-message
+        # metadata. A positive chat ID alone is not enough to infer this.
+        self.private_topic_chats: set[int] = set()
+        # "user_id:thread_id" -> chat_id for legacy and chat-scoped bindings.
         self.group_chat_ids: dict[str, int] = {}
         self.default_group_id = default_group_id
         # window_id -> display name (window_name)
@@ -113,7 +112,7 @@ class ThreadRouter:
         self.thread_bindings.clear()
         self.group_chat_ids.clear()
         self.chat_thread_bindings.clear()
-        self.direct_message_topics.clear()
+        self.private_topic_chats.clear()
         self.window_display_names.clear()
         self._window_to_thread.clear()
         self._chat_window_to_thread.clear()
@@ -194,10 +193,7 @@ class ThreadRouter:
                 f"{uid}:{chat_id}:{tid}": wid
                 for (uid, chat_id, tid), wid in self.chat_thread_bindings.items()
             },
-            "direct_message_topics": [
-                f"{chat_id}:{thread_id}"
-                for chat_id, thread_id in sorted(self.direct_message_topics)
-            ],
+            "private_topic_chats": sorted(self.private_topic_chats),
             "window_display_names": self.window_display_names,
             "retired_topics": [
                 {
@@ -227,15 +223,18 @@ class ThreadRouter:
         for key, wid in data.get("chat_thread_bindings", {}).items():
             uid, chat_id, tid = (int(part) for part in key.split(":", 2))
             self.chat_thread_bindings[(uid, chat_id, tid)] = wid
-        self.direct_message_topics = set()
-        raw_direct_topics = data.get("direct_message_topics", [])
-        for key in raw_direct_topics if isinstance(raw_direct_topics, list) else []:
+        raw_private_chats = data.get("private_topic_chats", [])
+        self.private_topic_chats = {
+            chat_id for chat_id in raw_private_chats if isinstance(chat_id, int)
+        }
+        # Migrate short-lived state written by the previous direct-message
+        # topic implementation without retaining its incorrect API shape.
+        for key in data.get("direct_message_topics", []):
             try:
-                chat_id, thread_id = (int(part) for part in key.split(":", 1))
+                chat_id, _thread_id = (int(part) for part in key.split(":", 1))
             except AttributeError, TypeError, ValueError:
                 continue
-            if thread_id > 1:
-                self.direct_message_topics.add((chat_id, thread_id))
+            self.private_topic_chats.add(chat_id)
         self.window_display_names = data.get("window_display_names", {})
         self._retired_topics = self._load_retired_topics(data.get("retired_topics", []))
         self._next_retired_sequence = (
@@ -277,7 +276,6 @@ class ThreadRouter:
                 not isinstance(reason, str)
                 or not reason
                 or not isinstance(cleanup_eligible, bool)
-                or topic.chat_id == topic.user_id
                 or topic.thread_id <= 0
                 or topic.sequence <= 0
             ):
@@ -317,8 +315,8 @@ class ThreadRouter:
         reason: str,
         cleanup_eligible: bool,
     ) -> None:
-        """Remember a known local forum topic, never an inferred Telegram topic."""
-        if chat_id is None or chat_id == user_id:
+        """Remember a known local topic, never an inferred Telegram topic."""
+        if chat_id is None:
             return
         self._retired_topics = [
             topic
@@ -593,28 +591,20 @@ class ThreadRouter:
     # Chat capability and ID management
     # ------------------------------------------------------------------
 
-    def mark_direct_message_topic(self, chat_id: int, thread_id: int) -> None:
-        """Record Bot API metadata proving this private topic is supported.
-
-        Topic 1 is Telegram's General/control lane, never a session topic.
-        """
-        if (
-            not isinstance(chat_id, int)
-            or not isinstance(thread_id, int)
-            or thread_id <= 1
-            or (chat_id, thread_id) in self.direct_message_topics
-        ):
+    def mark_private_topic_chat(self, chat_id: int) -> None:
+        """Record a private chat observed with valid topic-message metadata."""
+        if not isinstance(chat_id, int) or chat_id in self.private_topic_chats:
             return
-        self.direct_message_topics.add((chat_id, thread_id))
+        self.private_topic_chats.add(chat_id)
         self._schedule_save()
 
-    def is_direct_message_topic(self, chat_id: int, thread_id: int) -> bool:
-        """Return whether this exact chat/topic was observed as a direct DM topic."""
-        return (chat_id, thread_id) in self.direct_message_topics
+    def is_private_topic_chat(self, chat_id: int) -> bool:
+        """Return whether *chat_id* was observed as a private topic chat."""
+        return chat_id in self.private_topic_chats
 
-    def iter_direct_message_chat_ids(self) -> Iterator[int]:
-        """Iterate private chats with observed direct-message topic support."""
-        yield from sorted({chat_id for chat_id, _ in self.direct_message_topics})
+    def iter_private_topic_chat_ids(self) -> Iterator[int]:
+        """Iterate private chats that have supplied topic-message metadata."""
+        yield from sorted(self.private_topic_chats)
 
     def set_group_chat_id(self, user_id: int, thread_id: int, chat_id: int) -> None:
         """Store the group chat ID and promote the binding to chat scope."""

--- a/src/ccgram/thread_router.py
+++ b/src/ccgram/thread_router.py
@@ -149,6 +149,29 @@ class ThreadRouter:
                                 keep,
                             )
 
+        self._dedup_chat_thread_bindings()
+
+    def _dedup_chat_thread_bindings(self) -> None:
+        """Keep one deterministic chat-scoped binding for each window."""
+        window_bindings: dict[str, list[tuple[int, int, int]]] = {}
+        for key, wid in self.chat_thread_bindings.items():
+            window_bindings.setdefault(wid, []).append(key)
+        for wid, keys in window_bindings.items():
+            if len(keys) <= 1:
+                continue
+            keep = max(keys, key=lambda key: (key[2], key[0], key[1]))
+            for key in keys:
+                if key == keep:
+                    continue
+                del self.chat_thread_bindings[key]
+                logger.warning(
+                    "Startup: removed duplicate binding thread %d -> window %s "
+                    "(keeping thread %d)",
+                    key[2],
+                    wid,
+                    keep[2],
+                )
+
     # ------------------------------------------------------------------
     # Serialization
     # ------------------------------------------------------------------
@@ -329,15 +352,12 @@ class ThreadRouter:
             stale = [
                 candidate
                 for candidate, wid in self.chat_thread_bindings.items()
-                if candidate[0] == user_id
-                and candidate[1] == chat_id
-                and wid == window_id
-                and candidate != key
+                if wid == window_id and candidate != key
             ]
             for candidate in stale:
                 self.chat_thread_bindings.pop(candidate, None)
                 self._chat_window_to_thread.pop(
-                    (user_id, candidate[1], window_id), None
+                    (candidate[0], candidate[1], window_id), None
                 )
             self.chat_thread_bindings[key] = window_id
             self._chat_window_to_thread[(user_id, chat_id, window_id)] = thread_id

--- a/src/ccgram/thread_router.py
+++ b/src/ccgram/thread_router.py
@@ -91,6 +91,10 @@ class ThreadRouter:
         self.thread_bindings: dict[int, dict[int, str]] = {}
         # Chat-scoped bindings preserve Telegram's chat-local thread identity.
         self.chat_thread_bindings: dict[tuple[int, int, int], str] = {}
+        # Chat/topic pairs observed with Bot API direct-message topic metadata.
+        # This is deliberately capability-driven: a positive chat ID alone is
+        # not evidence that it accepts ``direct_messages_topic_id``.
+        self.direct_message_topics: set[tuple[int, int]] = set()
         # "user_id:thread_id" -> chat_id for legacy/direct-message bindings.
         self.group_chat_ids: dict[str, int] = {}
         self.default_group_id = default_group_id
@@ -109,6 +113,7 @@ class ThreadRouter:
         self.thread_bindings.clear()
         self.group_chat_ids.clear()
         self.chat_thread_bindings.clear()
+        self.direct_message_topics.clear()
         self.window_display_names.clear()
         self._window_to_thread.clear()
         self._chat_window_to_thread.clear()
@@ -152,21 +157,22 @@ class ThreadRouter:
         self._dedup_chat_thread_bindings()
 
     def _dedup_chat_thread_bindings(self) -> None:
-        """Keep one deterministic chat-scoped binding for each window."""
-        window_bindings: dict[str, list[tuple[int, int, int]]] = {}
+        """Keep one deterministic binding per chat and window."""
+        window_bindings: dict[tuple[int, str], list[tuple[int, int, int]]] = {}
         for key, wid in self.chat_thread_bindings.items():
-            window_bindings.setdefault(wid, []).append(key)
-        for wid, keys in window_bindings.items():
+            window_bindings.setdefault((key[1], wid), []).append(key)
+        for (chat_id, wid), keys in window_bindings.items():
             if len(keys) <= 1:
                 continue
-            keep = max(keys, key=lambda key: (key[2], key[0], key[1]))
+            keep = max(keys, key=lambda key: (key[2], key[0]))
             for key in keys:
                 if key == keep:
                     continue
                 del self.chat_thread_bindings[key]
                 logger.warning(
-                    "Startup: removed duplicate binding thread %d -> window %s "
-                    "(keeping thread %d)",
+                    "Startup: removed duplicate binding chat %d thread %d -> "
+                    "window %s (keeping thread %d)",
+                    chat_id,
                     key[2],
                     wid,
                     keep[2],
@@ -188,6 +194,10 @@ class ThreadRouter:
                 f"{uid}:{chat_id}:{tid}": wid
                 for (uid, chat_id, tid), wid in self.chat_thread_bindings.items()
             },
+            "direct_message_topics": [
+                f"{chat_id}:{thread_id}"
+                for chat_id, thread_id in sorted(self.direct_message_topics)
+            ],
             "window_display_names": self.window_display_names,
             "retired_topics": [
                 {
@@ -217,6 +227,15 @@ class ThreadRouter:
         for key, wid in data.get("chat_thread_bindings", {}).items():
             uid, chat_id, tid = (int(part) for part in key.split(":", 2))
             self.chat_thread_bindings[(uid, chat_id, tid)] = wid
+        self.direct_message_topics = set()
+        raw_direct_topics = data.get("direct_message_topics", [])
+        for key in raw_direct_topics if isinstance(raw_direct_topics, list) else []:
+            try:
+                chat_id, thread_id = (int(part) for part in key.split(":", 1))
+            except AttributeError, TypeError, ValueError:
+                continue
+            if thread_id > 1:
+                self.direct_message_topics.add((chat_id, thread_id))
         self.window_display_names = data.get("window_display_names", {})
         self._retired_topics = self._load_retired_topics(data.get("retired_topics", []))
         self._next_retired_sequence = (
@@ -352,7 +371,7 @@ class ThreadRouter:
             stale = [
                 candidate
                 for candidate, wid in self.chat_thread_bindings.items()
-                if wid == window_id and candidate != key
+                if candidate[1] == chat_id and wid == window_id and candidate != key
             ]
             for candidate in stale:
                 self.chat_thread_bindings.pop(candidate, None)
@@ -571,8 +590,31 @@ class ThreadRouter:
         return {window_id for _, _, window_id in self.iter_thread_bindings()}
 
     # ------------------------------------------------------------------
-    # Group chat ID management
+    # Chat capability and ID management
     # ------------------------------------------------------------------
+
+    def mark_direct_message_topic(self, chat_id: int, thread_id: int) -> None:
+        """Record Bot API metadata proving this private topic is supported.
+
+        Topic 1 is Telegram's General/control lane, never a session topic.
+        """
+        if (
+            not isinstance(chat_id, int)
+            or not isinstance(thread_id, int)
+            or thread_id <= 1
+            or (chat_id, thread_id) in self.direct_message_topics
+        ):
+            return
+        self.direct_message_topics.add((chat_id, thread_id))
+        self._schedule_save()
+
+    def is_direct_message_topic(self, chat_id: int, thread_id: int) -> bool:
+        """Return whether this exact chat/topic was observed as a direct DM topic."""
+        return (chat_id, thread_id) in self.direct_message_topics
+
+    def iter_direct_message_chat_ids(self) -> Iterator[int]:
+        """Iterate private chats with observed direct-message topic support."""
+        yield from sorted({chat_id for chat_id, _ in self.direct_message_topics})
 
     def set_group_chat_id(self, user_id: int, thread_id: int, chat_id: int) -> None:
         """Store the group chat ID and promote the binding to chat scope."""

--- a/src/ccgram/thread_router.py
+++ b/src/ccgram/thread_router.py
@@ -133,8 +133,48 @@ class ThreadRouter:
         for (uid, chat_id, _tid), wid in self.chat_thread_bindings.items():
             self._chat_window_to_thread[(uid, chat_id, wid)] = _tid
 
-    def _dedup_thread_bindings(self) -> None:
+    def _remove_group_routing_metadata(self, user_id: int, thread_id: int) -> bool:
+        """Remove routing metadata belonging to one evicted topic claim."""
+        prefix = f"{user_id}:{thread_id}"
+        stale_keys = [
+            key
+            for key in self.group_chat_ids
+            if key == prefix or key.startswith(f"{prefix}:")
+        ]
+        for key in stale_keys:
+            del self.group_chat_ids[key]
+        return bool(stale_keys)
+
+    def _normalize_group_backed_bindings(self) -> bool:
+        """Promote legacy bindings with a persisted chat ID to chat scope.
+
+        ``thread_bindings`` predates chat-local topic identity.  A matching
+        ``group_chat_ids`` entry is sufficient evidence to promote one of
+        those rows; an already chat-scoped row for the same topic wins over
+        the older representation.  The routing metadata becomes redundant
+        after promotion and must not survive as a stale fallback route.
+        """
+        changed = False
+        for user_id, bindings in list(self.thread_bindings.items()):
+            for thread_id, window_id in list(bindings.items()):
+                metadata_key = f"{user_id}:{thread_id}"
+                chat_id = self.group_chat_ids.get(metadata_key)
+                if not isinstance(chat_id, int) or isinstance(chat_id, bool):
+                    continue
+                del bindings[thread_id]
+                scoped_key = (user_id, chat_id, thread_id)
+                # A natively scoped row is the newer, unambiguous record for
+                # this exact topic, so never overwrite it based on JSON order.
+                self.chat_thread_bindings.setdefault(scoped_key, window_id)
+                self._remove_group_routing_metadata(user_id, thread_id)
+                changed = True
+            if not bindings:
+                del self.thread_bindings[user_id]
+        return changed
+
+    def _dedup_thread_bindings(self) -> bool:
         """Enforce 1 window = 1 thread.  Keep highest thread_id per window."""
+        changed = False
         for _uid, bindings in self.thread_bindings.items():
             window_threads: dict[str, list[int]] = {}
             for tid, wid in bindings.items():
@@ -145,6 +185,7 @@ class ThreadRouter:
                     for tid in tids:
                         if tid != keep:
                             del bindings[tid]
+                            changed = True
                             logger.warning(
                                 "Startup: removed duplicate binding "
                                 "thread %d -> window %s (keeping %d)",
@@ -153,10 +194,11 @@ class ThreadRouter:
                                 keep,
                             )
 
-        self._dedup_chat_thread_bindings()
+        return self._dedup_chat_thread_bindings() or changed
 
-    def _dedup_chat_thread_bindings(self) -> None:
+    def _dedup_chat_thread_bindings(self) -> bool:
         """Keep one deterministic binding per chat and window."""
+        changed = False
         window_bindings: dict[tuple[int, str], list[tuple[int, int, int]]] = {}
         for key, wid in self.chat_thread_bindings.items():
             window_bindings.setdefault((key[1], wid), []).append(key)
@@ -168,6 +210,8 @@ class ThreadRouter:
                 if key == keep:
                     continue
                 del self.chat_thread_bindings[key]
+                self._remove_group_routing_metadata(key[0], key[2])
+                changed = True
                 logger.warning(
                     "Startup: removed duplicate binding chat %d thread %d -> "
                     "window %s (keeping thread %d)",
@@ -176,6 +220,7 @@ class ThreadRouter:
                     wid,
                     keep[2],
                 )
+        return changed
 
     # ------------------------------------------------------------------
     # Serialization
@@ -208,11 +253,12 @@ class ThreadRouter:
             ],
         }
 
-    def from_dict(self, data: dict[str, Any]) -> None:
-        """Restore routing state from persisted data.
+    def from_dict(self, data: dict[str, Any]) -> bool:
+        """Restore routing state and return whether persisted routing was repaired.
 
-        Does NOT call ``_schedule_save`` — loading from disk must not
-        trigger a write.
+        Loading itself does not schedule persistence.  The owning
+        ``SessionManager`` saves once when this method reports a normalization
+        or de-duplication repair.
         """
         self.thread_bindings = {
             int(uid): {int(tid): wid for tid, wid in bindings.items()}
@@ -240,7 +286,8 @@ class ThreadRouter:
         self._next_retired_sequence = (
             max((topic.sequence for topic in self._retired_topics), default=0) + 1
         )
-        self._dedup_thread_bindings()
+        repaired = self._normalize_group_backed_bindings()
+        repaired = self._dedup_thread_bindings() or repaired
         self._rebuild_reverse_index()
         for (
             _user_id,
@@ -249,6 +296,7 @@ class ThreadRouter:
             _window_id,
         ) in self.iter_thread_bindings_with_chat():
             self._restore_active_topic(chat_id, thread_id)
+        return repaired
 
     @staticmethod
     def _load_retired_topics(raw_topics: Any) -> list[RetiredTopic]:
@@ -350,6 +398,35 @@ class ThreadRouter:
     # Thread binding operations
     # ------------------------------------------------------------------
 
+    def _bind_chat_scoped(
+        self, user_id: int, chat_id: int, thread_id: int, window_id: str
+    ) -> None:
+        """Claim a window once within a chat, evicting stale topic owners."""
+        key = (user_id, chat_id, thread_id)
+        old_window = self.chat_thread_bindings.get(key)
+        if old_window is not None and old_window != window_id:
+            self._chat_window_to_thread.pop((user_id, chat_id, old_window), None)
+        old_thread = self._chat_window_to_thread.pop(
+            (user_id, chat_id, window_id), None
+        )
+        if old_thread is not None and old_thread != thread_id:
+            self.chat_thread_bindings.pop((user_id, chat_id, old_thread), None)
+            self._remove_group_routing_metadata(user_id, old_thread)
+        stale = [
+            candidate
+            for candidate, wid in self.chat_thread_bindings.items()
+            if candidate[1] == chat_id and wid == window_id and candidate != key
+        ]
+        for candidate in stale:
+            self.chat_thread_bindings.pop(candidate, None)
+            self._chat_window_to_thread.pop(
+                (candidate[0], candidate[1], window_id), None
+            )
+            self._remove_group_routing_metadata(candidate[0], candidate[2])
+        self.chat_thread_bindings[key] = window_id
+        self._chat_window_to_thread[(user_id, chat_id, window_id)] = thread_id
+        self._remove_group_routing_metadata(user_id, thread_id)
+
     def bind_thread(
         self,
         user_id: int,
@@ -360,24 +437,7 @@ class ThreadRouter:
     ) -> None:
         """Bind a topic, using chat-scoped identity when ``chat_id`` is known."""
         if chat_id is not None:
-            key = (user_id, chat_id, thread_id)
-            old_thread = self._chat_window_to_thread.pop(
-                (user_id, chat_id, window_id), None
-            )
-            if old_thread is not None and old_thread != thread_id:
-                self.chat_thread_bindings.pop((user_id, chat_id, old_thread), None)
-            stale = [
-                candidate
-                for candidate, wid in self.chat_thread_bindings.items()
-                if candidate[1] == chat_id and wid == window_id and candidate != key
-            ]
-            for candidate in stale:
-                self.chat_thread_bindings.pop(candidate, None)
-                self._chat_window_to_thread.pop(
-                    (candidate[0], candidate[1], window_id), None
-                )
-            self.chat_thread_bindings[key] = window_id
-            self._chat_window_to_thread[(user_id, chat_id, window_id)] = thread_id
+            self._bind_chat_scoped(user_id, chat_id, thread_id, window_id)
         else:
             if user_id not in self.thread_bindings:
                 self.thread_bindings[user_id] = {}
@@ -607,16 +667,15 @@ class ThreadRouter:
         yield from sorted(self.private_topic_chats)
 
     def set_group_chat_id(self, user_id: int, thread_id: int, chat_id: int) -> None:
-        """Store the group chat ID and promote the binding to chat scope."""
+        """Store a chat ID, promoting an existing legacy binding when present."""
         bindings = self.thread_bindings.get(user_id)
         if bindings and thread_id in bindings:
             window_id = bindings.pop(thread_id)
+            self._window_to_thread.pop((user_id, window_id), None)
             if not bindings:
                 self.thread_bindings.pop(user_id, None)
-            self._window_to_thread.pop((user_id, window_id), None)
-            self.chat_thread_bindings[(user_id, chat_id, thread_id)] = window_id
-            self._chat_window_to_thread[(user_id, chat_id, window_id)] = thread_id
-            self._restore_active_topic(chat_id, thread_id)
+            self.bind_thread(user_id, thread_id, window_id, chat_id=chat_id)
+            return
         key = f"{user_id}:{thread_id}"
         if self.group_chat_ids.get(key) != chat_id:
             self.group_chat_ids[key] = chat_id

--- a/src/ccgram/utils.py
+++ b/src/ccgram/utils.py
@@ -355,16 +355,21 @@ _general_topic_pin_cache: dict[int, bool] = {}
 
 
 def is_general_topic(message: Message) -> bool:
-    """Return True if the message is in the General (default) forum topic.
+    """Return True if the message is in Telegram's General/control topic.
 
-    In Telegram forum groups, messages sent directly in the General topic
-    (not as replies) may have message_thread_id=None instead of 1.
-    We check chat.is_forum to distinguish General-topic messages from
-    non-forum contexts.
+    Forum-group General messages may omit ``message_thread_id``. Private
+    threaded DMs advertise their capability explicitly and carry the General
+    control lane as ``direct_messages_topic.topic_id == 1``; topic 1 is never
+    eligible to become a ccgram session in either surface.
     """
+    chat = message.chat
     thread_id = getattr(message, "message_thread_id", None)
-    is_forum = getattr(message.chat, "is_forum", False) if message.chat else False
-    return is_forum and (thread_id is None or thread_id == 1)
+    is_forum = getattr(chat, "is_forum", False) if chat else False
+    if is_forum and (thread_id is None or thread_id == 1):
+        return True
+    direct_topic = getattr(message, "direct_messages_topic", None)
+    direct_topic_id = getattr(direct_topic, "topic_id", None)
+    return getattr(chat, "is_direct_messages", None) is True and direct_topic_id == 1
 
 
 async def handle_general_topic_message(

--- a/src/ccgram/utils.py
+++ b/src/ccgram/utils.py
@@ -358,18 +358,20 @@ def is_general_topic(message: Message) -> bool:
     """Return True if the message is in Telegram's General/control topic.
 
     Forum-group General messages may omit ``message_thread_id``. Private
-    threaded DMs advertise their capability explicitly and carry the General
-    control lane as ``direct_messages_topic.topic_id == 1``; topic 1 is never
-    eligible to become a ccgram session in either surface.
+    topics use ``is_topic_message`` with ``message_thread_id == 1`` for their
+    control lane; topic 1 is never eligible to become a ccgram session in
+    either surface.
     """
     chat = message.chat
     thread_id = getattr(message, "message_thread_id", None)
     is_forum = getattr(chat, "is_forum", False) if chat else False
     if is_forum and (thread_id is None or thread_id == 1):
         return True
-    direct_topic = getattr(message, "direct_messages_topic", None)
-    direct_topic_id = getattr(direct_topic, "topic_id", None)
-    return getattr(chat, "is_direct_messages", None) is True and direct_topic_id == 1
+    return (
+        getattr(chat, "type", None) == "private"
+        and getattr(message, "is_topic_message", None) is True
+        and thread_id == 1
+    )
 
 
 async def handle_general_topic_message(

--- a/tests/ccgram/handlers/interactive/test_direct_choices.py
+++ b/tests/ccgram/handlers/interactive/test_direct_choices.py
@@ -17,6 +17,7 @@ from ccgram.handlers.interactive.interactive_ui import (
     _interactive_msgs,
     _interactive_sequences,
     handle_interactive_ui,
+    is_current_interactive_prompt,
     parse_direct_choices,
 )
 
@@ -42,6 +43,38 @@ class TestParseDirectChoices:
         assert parse_direct_choices("Would you like to proceed?\n  Yes     No\n") == (
             ("y", "Yes"),
             ("n", "No"),
+        )
+
+    def test_selects_menu_block_nearest_action_footer(self) -> None:
+        choices = parse_direct_choices(
+            "Previous output:\n"
+            "  1. First prose item\n"
+            "  2. Second prose item\n"
+            "Pick a deployment:\n"
+            "  1. Staging\n"
+            "  2. Production\n"
+            "  Enter to select"
+        )
+
+        assert choices == (("1", "1. Staging"), ("2", "2. Production"))
+
+    def test_rejects_ambiguous_numbered_blocks_around_action_footer(self) -> None:
+        assert (
+            parse_direct_choices(
+                "  1. Earlier\n  2. Menu\n  Enter to select\n  1. Later\n  2. Menu"
+            )
+            == ()
+        )
+
+    def test_rejects_textual_multi_select_prompt(self) -> None:
+        assert (
+            parse_direct_choices(
+                "Choose all applicable environments:\n"
+                "  ❯ 1. Staging\n"
+                "    2. Production\n"
+                "  Enter to select"
+            )
+            == ()
         )
 
     @pytest.mark.parametrize(
@@ -97,7 +130,7 @@ class TestDirectChoiceKeyboard:
 
         keyboard = client.send_message.call_args.kwargs["reply_markup"]
         assert _button_data(keyboard)[0] == f"{CB_ASK_CHOICE}1:1:@12"
-        assert _interactive_contexts[(10, 42)] == (-100, 99)
+        assert _interactive_contexts[(10, -100, 42)] == (-100, 99)
 
 
 def _callback_update(*, chat_id: int, thread_id: int | None, message_id: int):
@@ -147,10 +180,10 @@ class TestDirectChoiceCallbacks:
     async def test_sends_direct_choice_only_for_current_chat_thread_and_sequence(
         self,
     ) -> None:
-        _interactive_mode[(10, 42)] = "@12"
-        _interactive_msgs[(10, 42)] = 99
-        _interactive_contexts[(10, 42)] = (-100, 99)
-        _interactive_sequences[(10, 42)] = 7
+        _interactive_mode[(10, -100, 42)] = "@12"
+        _interactive_msgs[(10, -100, 42)] = 99
+        _interactive_contexts[(10, -100, 42)] = (-100, 99)
+        _interactive_sequences[(10, -100, 42)] = 7
         query, update = _callback_update(chat_id=-100, thread_id=42, message_id=99)
 
         multiplexer = MagicMock()
@@ -182,7 +215,7 @@ class TestDirectChoiceCallbacks:
         multiplexer.send_keys.assert_awaited_once_with(
             "@12", "1", enter=False, literal=True
         )
-        assert _interactive_sequences[(10, 42)] == 8
+        assert _interactive_sequences[(10, -100, 42)] == 8
 
     @pytest.mark.parametrize(
         ("chat_id", "thread_id", "message_id", "sequence"),
@@ -192,10 +225,10 @@ class TestDirectChoiceCallbacks:
     async def test_rejects_direct_choice_without_current_prompt_ownership(
         self, chat_id: int, thread_id: int, message_id: int, sequence: int
     ) -> None:
-        _interactive_mode[(10, 42)] = "@12"
-        _interactive_msgs[(10, 42)] = 99
-        _interactive_contexts[(10, 42)] = (-100, 99)
-        _interactive_sequences[(10, 42)] = 7
+        _interactive_mode[(10, -100, 42)] = "@12"
+        _interactive_msgs[(10, -100, 42)] = 99
+        _interactive_contexts[(10, -100, 42)] = (-100, 99)
+        _interactive_sequences[(10, -100, 42)] = 7
         query, update = _callback_update(
             chat_id=chat_id, thread_id=thread_id, message_id=message_id
         )
@@ -230,3 +263,52 @@ class TestDirectChoiceCallbacks:
         query.answer.assert_awaited_once_with(
             "This prompt has expired", show_alert=True
         )
+
+    async def test_keeps_choice_current_when_key_delivery_fails(self) -> None:
+        _interactive_mode[(10, -100, 42)] = "@12"
+        _interactive_msgs[(10, -100, 42)] = 99
+        _interactive_contexts[(10, -100, 42)] = (-100, 99)
+        _interactive_sequences[(10, -100, 42)] = 7
+        query, update = _callback_update(chat_id=-100, thread_id=42, message_id=99)
+
+        multiplexer = MagicMock()
+        multiplexer.find_window_by_id = AsyncMock(
+            return_value=MagicMock(window_id="@12")
+        )
+        multiplexer.send_keys = AsyncMock(return_value=False)
+        with (
+            patch(
+                "ccgram.handlers.callback_helpers.user_owns_window",
+                return_value=True,
+            ),
+            patch(
+                "ccgram.handlers.interactive.interactive_callbacks.tmux_manager",
+                multiplexer,
+            ),
+        ):
+            await handle_interactive_callback(
+                query,
+                10,
+                f"{CB_ASK_CHOICE}1:7:@12",
+                update,
+                MagicMock(),
+            )
+
+        assert _interactive_sequences[(10, -100, 42)] == 7
+        query.answer.assert_awaited_once_with(
+            "Unable to send choice. Try again.", show_alert=True
+        )
+
+    def test_interactive_state_is_scoped_to_chat_as_well_as_thread(self) -> None:
+        _interactive_mode[(10, -100, 42)] = "@12"
+        _interactive_msgs[(10, -100, 42)] = 99
+        _interactive_contexts[(10, -100, 42)] = (-100, 99)
+        _interactive_sequences[(10, -100, 42)] = 7
+        _interactive_mode[(10, -101, 42)] = "@13"
+        _interactive_msgs[(10, -101, 42)] = 99
+        _interactive_contexts[(10, -101, 42)] = (-101, 99)
+        _interactive_sequences[(10, -101, 42)] = 7
+
+        assert is_current_interactive_prompt(10, 42, "@12", -100, 99, 7)
+        assert is_current_interactive_prompt(10, 42, "@13", -101, 99, 7)
+        assert not is_current_interactive_prompt(10, 42, "@12", -101, 99, 7)

--- a/tests/ccgram/handlers/interactive/test_direct_choices.py
+++ b/tests/ccgram/handlers/interactive/test_direct_choices.py
@@ -103,6 +103,7 @@ class TestDirectChoiceKeyboard:
 def _callback_update(*, chat_id: int, thread_id: int | None, message_id: int):
     message = MagicMock()
     message.chat.id = chat_id
+    message.chat.type = "supergroup"
     message.message_id = message_id
     message.message_thread_id = thread_id
     query = AsyncMock()

--- a/tests/ccgram/handlers/interactive/test_direct_choices.py
+++ b/tests/ccgram/handlers/interactive/test_direct_choices.py
@@ -1,0 +1,231 @@
+"""Tests for one-tap selections in interactive terminal prompts."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ccgram.handlers.callback_data import CB_ASK_CHOICE
+from ccgram.handlers.interactive.interactive_callbacks import (
+    handle_interactive_callback,
+    parse_direct_choice_callback,
+)
+from ccgram.handlers.interactive.interactive_ui import (
+    _build_interactive_keyboard,
+    _interactive_contexts,
+    _interactive_contents,
+    _interactive_mode,
+    _interactive_msgs,
+    _interactive_sequences,
+    handle_interactive_ui,
+    parse_direct_choices,
+)
+
+
+def _button_data(keyboard) -> list[str]:
+    return [
+        str(button.callback_data)
+        for row in keyboard.inline_keyboard
+        for button in row
+        if button.callback_data
+    ]
+
+
+class TestParseDirectChoices:
+    def test_parses_bounded_numbered_single_select_options(self) -> None:
+        choices = parse_direct_choices(
+            "Pick a deployment:\n  ❯ 1. Staging\n    2. Production\n  Enter to select"
+        )
+
+        assert choices == (("1", "1. Staging"), ("2", "2. Production"))
+
+    def test_parses_yes_no_options_on_a_single_line(self) -> None:
+        assert parse_direct_choices("Would you like to proceed?\n  Yes     No\n") == (
+            ("y", "Yes"),
+            ("n", "No"),
+        )
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "Choose any:\n  ☐ 1. Alpha\n  ☐ 2. Beta\n  Enter to select",
+            "Notes:\n  1. This is prose\n  2. This is also prose",
+            "Pick one:\n" + "\n".join(f"  {i}. Option {i}" for i in range(1, 10)),
+        ],
+    )
+    def test_falls_back_for_multi_select_prose_and_unbounded_lists(
+        self, content: str
+    ) -> None:
+        assert parse_direct_choices(content) == ()
+
+
+class TestDirectChoiceKeyboard:
+    def test_prepends_direct_choice_buttons_before_navigation(self) -> None:
+        keyboard = _build_interactive_keyboard(
+            "@12",
+            direct_choices=(("1", "1. Staging"), ("2", "2. Production")),
+            sequence=7,
+        )
+
+        first_row = keyboard.inline_keyboard[0]
+        assert [button.text for button in first_row] == ["1. Staging", "2. Production"]
+        assert _button_data(keyboard)[0] == f"{CB_ASK_CHOICE}1:7:@12"
+
+    async def test_rendered_prompt_wires_parsed_choices_to_the_current_sequence(
+        self,
+    ) -> None:
+        client = AsyncMock()
+        client.send_message.return_value = MagicMock(message_id=99)
+        with (
+            patch(
+                "ccgram.handlers.interactive.interactive_ui._capture_interactive_content",
+                new_callable=AsyncMock,
+                return_value=(
+                    "AskUserQuestion",
+                    "Pick one:\n  1. Alpha\n  2. Beta\n  Enter to select",
+                ),
+            ),
+            patch(
+                "ccgram.handlers.interactive.interactive_ui.thread_router.resolve_chat_id",
+                return_value=-100,
+            ),
+            patch(
+                "ccgram.handlers.interactive.interactive_ui.rate_limit_send",
+                new_callable=AsyncMock,
+            ),
+        ):
+            assert await handle_interactive_ui(client, 10, "@12", thread_id=42)
+
+        keyboard = client.send_message.call_args.kwargs["reply_markup"]
+        assert _button_data(keyboard)[0] == f"{CB_ASK_CHOICE}1:1:@12"
+        assert _interactive_contexts[(10, 42)] == (-100, 99)
+
+
+def _callback_update(*, chat_id: int, thread_id: int | None, message_id: int):
+    message = MagicMock()
+    message.chat.id = chat_id
+    message.message_id = message_id
+    message.message_thread_id = thread_id
+    query = AsyncMock()
+    query.message = message
+    update = MagicMock()
+    update.message = None
+    update.callback_query = query
+    return query, update
+
+
+@pytest.fixture(autouse=True)
+def _clear_interactive_state():
+    for state in (
+        _interactive_contexts,
+        _interactive_contents,
+        _interactive_mode,
+        _interactive_msgs,
+        _interactive_sequences,
+    ):
+        state.clear()
+    yield
+    for state in (
+        _interactive_contexts,
+        _interactive_contents,
+        _interactive_mode,
+        _interactive_msgs,
+        _interactive_sequences,
+    ):
+        state.clear()
+
+
+class TestDirectChoiceCallbacks:
+    def test_parses_choice_sequence_and_opaque_pane_target(self) -> None:
+        assert parse_direct_choice_callback(f"{CB_ASK_CHOICE}2:7:w2:t1|w2:p1") == (
+            "2",
+            7,
+            "w2:t1",
+            "w2:p1",
+        )
+
+    async def test_sends_direct_choice_only_for_current_chat_thread_and_sequence(
+        self,
+    ) -> None:
+        _interactive_mode[(10, 42)] = "@12"
+        _interactive_msgs[(10, 42)] = 99
+        _interactive_contexts[(10, 42)] = (-100, 99)
+        _interactive_sequences[(10, 42)] = 7
+        query, update = _callback_update(chat_id=-100, thread_id=42, message_id=99)
+
+        multiplexer = MagicMock()
+        multiplexer.find_window_by_id = AsyncMock(
+            return_value=MagicMock(window_id="@12")
+        )
+        multiplexer.send_keys = AsyncMock(return_value=True)
+        with (
+            patch(
+                "ccgram.handlers.callback_helpers.user_owns_window",
+                return_value=True,
+            ),
+            patch(
+                "ccgram.handlers.interactive.interactive_callbacks.tmux_manager",
+                multiplexer,
+            ),
+            patch(
+                "ccgram.handlers.interactive.interactive_callbacks.PTBTelegramClient"
+            ),
+        ):
+            await handle_interactive_callback(
+                query,
+                10,
+                f"{CB_ASK_CHOICE}1:7:@12",
+                update,
+                MagicMock(),
+            )
+
+        multiplexer.send_keys.assert_awaited_once_with(
+            "@12", "1", enter=False, literal=True
+        )
+        assert _interactive_sequences[(10, 42)] == 8
+
+    @pytest.mark.parametrize(
+        ("chat_id", "thread_id", "message_id", "sequence"),
+        [(-101, 42, 99, 7), (-100, 43, 99, 7), (-100, 42, 99, 6)],
+        ids=["wrong-chat", "wrong-thread", "stale-sequence"],
+    )
+    async def test_rejects_direct_choice_without_current_prompt_ownership(
+        self, chat_id: int, thread_id: int, message_id: int, sequence: int
+    ) -> None:
+        _interactive_mode[(10, 42)] = "@12"
+        _interactive_msgs[(10, 42)] = 99
+        _interactive_contexts[(10, 42)] = (-100, 99)
+        _interactive_sequences[(10, 42)] = 7
+        query, update = _callback_update(
+            chat_id=chat_id, thread_id=thread_id, message_id=message_id
+        )
+
+        multiplexer = MagicMock()
+        multiplexer.find_window_by_id = AsyncMock(
+            return_value=MagicMock(window_id="@12")
+        )
+        multiplexer.send_keys = AsyncMock()
+        with (
+            patch(
+                "ccgram.handlers.callback_helpers.user_owns_window",
+                return_value=True,
+            ),
+            patch(
+                "ccgram.handlers.interactive.interactive_callbacks.tmux_manager",
+                multiplexer,
+            ),
+            patch(
+                "ccgram.handlers.interactive.interactive_callbacks.PTBTelegramClient"
+            ),
+        ):
+            await handle_interactive_callback(
+                query,
+                10,
+                f"{CB_ASK_CHOICE}1:{sequence}:@12",
+                update,
+                MagicMock(),
+            )
+
+        multiplexer.send_keys.assert_not_awaited()
+        query.answer.assert_awaited_once_with(
+            "This prompt has expired", show_alert=True
+        )

--- a/tests/ccgram/handlers/interactive/test_direct_choices.py
+++ b/tests/ccgram/handlers/interactive/test_direct_choices.py
@@ -169,6 +169,29 @@ def _clear_interactive_state():
 
 
 class TestDirectChoiceCallbacks:
+    async def test_private_topic_callback_uses_chat_scoped_ownership(self) -> None:
+        _interactive_mode[(10, 100, 42)] = "@12"
+        _interactive_msgs[(10, 100, 42)] = 99
+        _interactive_contexts[(10, 100, 42)] = (100, 99)
+        _interactive_sequences[(10, 100, 42)] = 7
+        query, update = _callback_update(chat_id=100, thread_id=42, message_id=99)
+        query.message.chat.type = "private"
+        query.message.is_topic_message = True
+
+        with patch(
+            "ccgram.handlers.callback_helpers.user_owns_window",
+            return_value=False,
+        ) as owns:
+            await handle_interactive_callback(
+                query,
+                10,
+                f"{CB_ASK_CHOICE}1:7:@12",
+                update,
+                MagicMock(),
+            )
+
+        owns.assert_called_once_with(10, "@12", 100)
+
     def test_parses_choice_sequence_and_opaque_pane_target(self) -> None:
         assert parse_direct_choice_callback(f"{CB_ASK_CHOICE}2:7:w2:t1|w2:p1") == (
             "2",

--- a/tests/ccgram/handlers/interactive/test_interactive_ui.py
+++ b/tests/ccgram/handlers/interactive/test_interactive_ui.py
@@ -173,17 +173,17 @@ class TestInteractiveModeTracking:
         _interactive_mode.clear()
 
     def test_set_and_get(self) -> None:
-        set_interactive_mode(100, "@0", thread_id=42)
-        assert get_interactive_window(100, 42) == "@0"
+        set_interactive_mode(100, "@0", thread_id=42, chat_id=-999)
+        assert get_interactive_window(100, 42, chat_id=-999) == "@0"
 
     def test_clear(self) -> None:
-        set_interactive_mode(100, "@0", thread_id=42)
-        clear_interactive_mode(100, thread_id=42)
-        assert get_interactive_window(100, 42) is None
+        set_interactive_mode(100, "@0", thread_id=42, chat_id=-999)
+        clear_interactive_mode(100, thread_id=42, chat_id=-999)
+        assert get_interactive_window(100, 42, chat_id=-999) is None
 
     def test_none_thread_uses_zero(self) -> None:
-        set_interactive_mode(100, "@0", thread_id=None)
-        assert get_interactive_window(100, None) == "@0"
+        set_interactive_mode(100, "@0", thread_id=None, chat_id=-999)
+        assert get_interactive_window(100, None, chat_id=-999) == "@0"
 
 
 @pytest.fixture
@@ -216,13 +216,13 @@ class TestSendCooldown:
         with _interactive_env(bot):
             assert await handle_interactive_ui(bot, 100, "@2", thread_id=42) is False
 
-        remaining = _send_cooldowns[(100, 42)] - time.monotonic()
+        remaining = _send_cooldowns[(100, -999, 42)] - time.monotonic()
         assert remaining > _SEND_RETRY_INTERVAL
         assert remaining <= _DEAD_TOPIC_RETRY_INTERVAL
 
     async def test_cooldown_suppresses_the_next_send(self, _clear_send_state) -> None:
         bot = _sending_bot()
-        _send_cooldowns[(100, 42)] = time.monotonic()
+        _send_cooldowns[(100, -999, 42)] = time.monotonic()
 
         with _interactive_env(bot):
             assert await handle_interactive_ui(bot, 100, "@2", thread_id=42) is False
@@ -236,7 +236,7 @@ class TestSendCooldown:
         with _interactive_env(bot):
             assert await handle_interactive_ui(bot, 100, "@2", thread_id=42) is False
 
-        remaining = _send_cooldowns[(100, 42)] - time.monotonic()
+        remaining = _send_cooldowns[(100, -999, 42)] - time.monotonic()
         assert remaining <= _SEND_RETRY_INTERVAL
 
 

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_routing.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_routing.py
@@ -137,7 +137,7 @@ async def test_interactive_tool_use_handled_skips_enqueue(bot, mock_deps):
         ),
         bot,
     )
-    mock_deps["sim"].assert_called_once_with(100, "@5", 42, -100)
+    mock_deps["sim"].assert_called_once_with(100, "@5", 42, chat_id=-100)
     mock_deps["hui"].assert_called_once()
     mock_deps["eq"].assert_not_called()
 

--- a/tests/ccgram/handlers/messaging_pipeline/test_message_routing.py
+++ b/tests/ccgram/handlers/messaging_pipeline/test_message_routing.py
@@ -137,7 +137,7 @@ async def test_interactive_tool_use_handled_skips_enqueue(bot, mock_deps):
         ),
         bot,
     )
-    mock_deps["sim"].assert_called_once_with(100, "@5", 42)
+    mock_deps["sim"].assert_called_once_with(100, "@5", 42, -100)
     mock_deps["hui"].assert_called_once()
     mock_deps["eq"].assert_not_called()
 

--- a/tests/ccgram/handlers/test_callback_helpers.py
+++ b/tests/ccgram/handlers/test_callback_helpers.py
@@ -11,18 +11,14 @@ def _update(
     *,
     chat_type: str = "supergroup",
     message_thread_id: int | None = None,
-    is_direct_messages: bool | None = None,
-    direct_topic_id: int | None = None,
+    is_topic_message: bool = False,
 ) -> MagicMock:
     update = MagicMock()
     message = update.message
     message.message_thread_id = message_thread_id
+    message.is_topic_message = is_topic_message
     message.chat.type = chat_type
-    message.chat.is_direct_messages = is_direct_messages
-    if direct_topic_id is None:
-        message.direct_messages_topic = None
-    else:
-        message.direct_messages_topic.topic_id = direct_topic_id
+    message.chat.id = 100
     update.callback_query = None
     return update
 
@@ -37,30 +33,28 @@ class TestGetThreadId:
     ) -> None:
         assert get_thread_id(_update(message_thread_id=message_thread_id)) == expected
 
-    def test_recognizes_observed_private_direct_messages_topic(self) -> None:
+    def test_recognizes_private_topic_message(self) -> None:
         update = _update(
-            chat_type="private", is_direct_messages=True, direct_topic_id=42
+            chat_type="private", message_thread_id=42, is_topic_message=True
         )
 
         assert get_thread_id(update) == 42
 
-    def test_does_not_guess_private_topic_from_thread_id_without_capability(
+    def test_does_not_guess_private_topic_from_thread_id_without_topic_flag(
         self,
     ) -> None:
-        update = _update(
-            chat_type="private", message_thread_id=42, is_direct_messages=False
-        )
+        update = _update(chat_type="private", message_thread_id=42)
 
         assert get_thread_id(update) is None
 
     def test_keeps_unthreaded_private_dm_legacy_behavior(self) -> None:
-        update = _update(chat_type="private", is_direct_messages=False)
+        update = _update(chat_type="private")
 
         assert get_thread_id(update) is None
 
-    def test_direct_messages_general_topic_is_the_control_lane(self) -> None:
+    def test_private_general_topic_is_the_control_lane(self) -> None:
         update = _update(
-            chat_type="private", is_direct_messages=True, direct_topic_id=1
+            chat_type="private", message_thread_id=1, is_topic_message=True
         )
 
         assert get_thread_id(update) is None

--- a/tests/ccgram/handlers/test_callback_helpers.py
+++ b/tests/ccgram/handlers/test_callback_helpers.py
@@ -1,0 +1,66 @@
+"""Topic identity extraction across forum and private direct-message chats."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ccgram.handlers.callback_helpers import get_thread_id
+
+
+def _update(
+    *,
+    chat_type: str = "supergroup",
+    message_thread_id: int | None = None,
+    is_direct_messages: bool | None = None,
+    direct_topic_id: int | None = None,
+) -> MagicMock:
+    update = MagicMock()
+    message = update.message
+    message.message_thread_id = message_thread_id
+    message.chat.type = chat_type
+    message.chat.is_direct_messages = is_direct_messages
+    if direct_topic_id is None:
+        message.direct_messages_topic = None
+    else:
+        message.direct_messages_topic.topic_id = direct_topic_id
+    update.callback_query = None
+    return update
+
+
+class TestGetThreadId:
+    @pytest.mark.parametrize(
+        ("message_thread_id", "expected"),
+        [(42, 42), (1, None), (None, None)],
+    )
+    def test_supergroup_behavior_is_unchanged(
+        self, message_thread_id: int | None, expected: int | None
+    ) -> None:
+        assert get_thread_id(_update(message_thread_id=message_thread_id)) == expected
+
+    def test_recognizes_observed_private_direct_messages_topic(self) -> None:
+        update = _update(
+            chat_type="private", is_direct_messages=True, direct_topic_id=42
+        )
+
+        assert get_thread_id(update) == 42
+
+    def test_does_not_guess_private_topic_from_thread_id_without_capability(
+        self,
+    ) -> None:
+        update = _update(
+            chat_type="private", message_thread_id=42, is_direct_messages=False
+        )
+
+        assert get_thread_id(update) is None
+
+    def test_keeps_unthreaded_private_dm_legacy_behavior(self) -> None:
+        update = _update(chat_type="private", is_direct_messages=False)
+
+        assert get_thread_id(update) is None
+
+    def test_direct_messages_general_topic_is_the_control_lane(self) -> None:
+        update = _update(
+            chat_type="private", is_direct_messages=True, direct_topic_id=1
+        )
+
+        assert get_thread_id(update) is None

--- a/tests/ccgram/handlers/test_cleanup_gaps.py
+++ b/tests/ccgram/handlers/test_cleanup_gaps.py
@@ -35,9 +35,9 @@ class TestCancelBashCapture:
 
 class TestClearSendCooldowns:
     def test_clears_existing_cooldown(self) -> None:
-        _send_cooldowns[(1, 42)] = 123.0
+        _send_cooldowns[(1, -100, 42)] = 123.0
         clear_send_cooldowns(1, 42)
-        assert (1, 42) not in _send_cooldowns
+        assert (1, -100, 42) not in _send_cooldowns
 
     def test_missing_key_no_error(self) -> None:
         _send_cooldowns.clear()

--- a/tests/ccgram/handlers/test_hook_events.py
+++ b/tests/ccgram/handlers/test_hook_events.py
@@ -387,10 +387,10 @@ class TestHandleNotification:
         ):
             await dispatch_hook_event(_make_event(event_type="Notification"), bot)
 
-        get_mode.assert_called_once_with(100, 42, -101)
-        set_mode.assert_called_once_with(100, "@0", 42, -101)
+        get_mode.assert_called_once_with(100, 42, chat_id=-101)
+        set_mode.assert_called_once_with(100, "@0", 42, chat_id=-101)
         render.assert_awaited_once_with(ANY, 100, "@0", 42, chat_id=-101)
-        clear_mode.assert_called_once_with(100, 42, -101)
+        clear_mode.assert_called_once_with(100, 42, chat_id=-101)
 
 
 class TestHandleSubagentStart:

--- a/tests/ccgram/handlers/test_hook_events.py
+++ b/tests/ccgram/handlers/test_hook_events.py
@@ -362,6 +362,36 @@ class TestHandleNotification:
             assert claude_task_state.get_wait_header("@0") == "Approval needed: Bash"
             mock_enqueue.assert_awaited_once_with(ANY, 100, "@0", None, thread_id=42)
 
+    async def test_notification_keeps_chat_identity_for_interactive_state(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "ccgram.handlers.hook_events.thread_router.iter_thread_bindings",
+            lambda: iter(()),
+        )
+        monkeypatch.setattr(
+            "ccgram.handlers.hook_events.thread_router.iter_thread_bindings_with_chat",
+            lambda: iter(((100, -101, 42, "@0"),)),
+        )
+        bot = AsyncMock(spec=Bot)
+        with (
+            patch(
+                "ccgram.handlers.hook_events.get_interactive_window", return_value=None
+            ) as get_mode,
+            patch("ccgram.handlers.hook_events.set_interactive_mode") as set_mode,
+            patch(
+                "ccgram.handlers.hook_events.handle_interactive_ui", return_value=False
+            ) as render,
+            patch("ccgram.handlers.hook_events.clear_interactive_mode") as clear_mode,
+            patch("asyncio.sleep"),
+        ):
+            await dispatch_hook_event(_make_event(event_type="Notification"), bot)
+
+        get_mode.assert_called_once_with(100, 42, -101)
+        set_mode.assert_called_once_with(100, "@0", 42, -101)
+        render.assert_awaited_once_with(ANY, 100, "@0", 42, chat_id=-101)
+        clear_mode.assert_called_once_with(100, 42, -101)
+
 
 class TestHandleSubagentStart:
     @pytest.mark.parametrize(

--- a/tests/ccgram/handlers/test_hook_events.py
+++ b/tests/ccgram/handlers/test_hook_events.py
@@ -6,6 +6,7 @@ import pytest
 from telegram import Bot
 
 from ccgram.claude_task_state import claude_task_state
+from ccgram.config import config
 from ccgram.handlers.callback_data import IDLE_STATUS_TEXT
 
 from ccgram.claude_task_state import (
@@ -65,13 +66,30 @@ class TestResolveUsersForWindowKey:
 
         assert _resolve_users_for_window_key("ccgram:@0") == [(111, 42, "@0")]
 
-    def test_herdr_window_id_keeps_its_own_colon(self, bindings) -> None:
-        """herdr keys are ``herdr:<pane_id>`` and the pane id itself contains a
-        colon (w2:p1). Splitting on the FIRST colon must recover "w2:p1"; an
-        rsplit would yield "p1", which never matches a bound window id."""
-        bindings((111, 42, "w2:p1"))
+    def test_herdr_window_id_keeps_its_own_colon(self, bindings, monkeypatch) -> None:
+        """An opaque target can contain colons after its backend prefix."""
+        monkeypatch.setattr(config, "multiplexer_name", "herdr")
+        bindings((111, 42, "opaque:target:id"))
 
-        assert _resolve_users_for_window_key("herdr:w2:p1") == [(111, 42, "w2:p1")]
+        assert _resolve_users_for_window_key("herdr:opaque:target:id") == [
+            (111, 42, "opaque:target:id")
+        ]
+
+    @pytest.mark.parametrize(
+        "window_key",
+        [
+            pytest.param("other-session:@0", id="wrong-tmux-session"),
+            pytest.param("herdr:@0", id="wrong-backend"),
+        ],
+    )
+    def test_rejects_wrong_backend_or_session_prefix(
+        self, bindings, monkeypatch, window_key: str
+    ) -> None:
+        monkeypatch.setattr(config, "multiplexer_name", "tmux")
+        monkeypatch.setattr(config, "tmux_session_name", "ccgram")
+        bindings((111, 42, "@0"))
+
+        assert _resolve_users_for_window_key(window_key) == []
 
     @pytest.mark.parametrize(
         "window_key",
@@ -152,6 +170,18 @@ class TestHandleStop:
         bot = AsyncMock(spec=Bot)
         with patch("ccgram.handlers.hook_events.enqueue_status_update") as mock_enqueue:
             event = _make_event(event_type="Stop")
+            await dispatch_hook_event(event, bot)
+            mock_enqueue.assert_not_called()
+
+    async def test_stop_wrong_prefix_has_no_users_and_skips_dispatch(
+        self, bindings, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(config, "multiplexer_name", "tmux")
+        monkeypatch.setattr(config, "tmux_session_name", "ccgram")
+        bindings((100, 42, "@0"))
+        bot = AsyncMock(spec=Bot)
+        with patch("ccgram.handlers.hook_events.enqueue_status_update") as mock_enqueue:
+            event = _make_event(event_type="Stop", window_key="other-session:@0")
             await dispatch_hook_event(event, bot)
             mock_enqueue.assert_not_called()
 

--- a/tests/ccgram/handlers/test_sync_command.py
+++ b/tests/ccgram/handlers/test_sync_command.py
@@ -856,16 +856,46 @@ class TestDeadTopicDetection:
         issues = await _probe_dead_topics(mock_bot)
         assert issues == []
 
-    async def test_probe_skips_bindings_without_group_chat(self, _patch_deps) -> None:
+    async def test_probe_includes_private_chat_binding(self, _patch_deps) -> None:
         _, _, _, mock_tr, _, _ = _patch_deps
         mock_tr.iter_thread_bindings.return_value = [(100, 42, "@2")]
         mock_tr.resolve_chat_id.return_value = 100
-
         mock_bot = AsyncMock()
+        mock_bot.send_message.return_value = MagicMock(message_id=999)
 
         issues = await _probe_dead_topics(mock_bot)
+
         assert issues == []
-        mock_bot.send_message.assert_not_called()
+        mock_bot.send_message.assert_awaited_once_with(
+            100,
+            ".",
+            message_thread_id=42,
+            disable_notification=True,
+        )
+        mock_bot.delete_message.assert_awaited_once_with(100, 999)
+
+
+class TestPrivateTopicSyncLifecycle:
+    async def test_closes_and_unbinds_private_ghost_topic(self, _patch_deps) -> None:
+        _, _, _, mock_tr, _, _ = _patch_deps
+        mock_tr.get_window_for_thread.return_value = "@2"
+        mock_tr.resolve_chat_id.return_value = 100
+        issue = AuditIssue(
+            "ghost_binding", "user:100 thread:42 window:@2 (private)", fixable=True
+        )
+        client = AsyncMock()
+
+        with patch(
+            "ccgram.handlers.sync_command.clear_topic_state", new_callable=AsyncMock
+        ) as clear_state:
+            closed, manual_close = await _close_ghost_topics(client, [issue])
+
+        assert (closed, manual_close) == (1, 0)
+        client.delete_forum_topic.assert_awaited_once_with(100, 42)
+        clear_state.assert_awaited_once_with(100, 42, client=client, window_id="@2")
+        mock_tr.unbind_thread.assert_called_once_with(
+            100, 42, retirement_reason="remote_removed"
+        )
 
 
 class TestDeadTopicRecreation:

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -121,18 +121,18 @@ class TestCollectTargetChats:
             ) as mock_router,
             patch("ccgram.handlers.topics.topic_orchestration.config") as mock_config,
         ):
-            mock_router.iter_direct_message_chat_ids.return_value = []
+            mock_router.iter_private_topic_chat_ids.return_value = []
             mock_router.iter_thread_bindings.return_value = []
             mock_router.group_chat_ids = {"100:5": 100}
             mock_config.group_id = None
             result = collect_target_chats("@5")
             assert result == set()
 
-    def test_includes_private_chat_with_observed_topic_capability(self):
+    def test_includes_private_chat_with_observed_topic_metadata(self):
         with patch(
             "ccgram.handlers.topics.topic_orchestration.thread_router"
         ) as mock_router:
-            mock_router.iter_direct_message_chat_ids.return_value = [100]
+            mock_router.iter_private_topic_chat_ids.return_value = [100]
             mock_router.iter_thread_bindings.return_value = []
             mock_router.group_chat_ids = {}
 
@@ -194,6 +194,49 @@ class TestHandleNewWindow:
             100, 77, "@2", window_name="proj", chat_id=-100100
         )
         mock_tr.set_group_chat_id.assert_called_once_with(100, 77, -100100)
+
+    async def test_private_topic_creation_requires_enabled_bot_capability(self) -> None:
+        event = _make_event()
+        bot = AsyncMock()
+        bot.get_me.return_value = MagicMock(has_topics_enabled=False)
+
+        with (
+            patch("ccgram.handlers.topics.topic_orchestration.session_manager"),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.thread_router"
+            ) as mock_tr,
+        ):
+            created = await handle_new_window(
+                event, bot, target_user_id=100, target_chat_id=100
+            )
+
+        assert created is False
+        bot.get_me.assert_awaited_once_with()
+        bot.create_forum_topic.assert_not_called()
+        mock_tr.bind_thread.assert_not_called()
+
+    async def test_private_topic_creation_uses_enabled_bot_capability(self) -> None:
+        event = _make_event()
+        bot = AsyncMock()
+        bot.get_me.return_value = MagicMock(has_topics_enabled=True)
+        bot.create_forum_topic.return_value = _make_topic(thread_id=42)
+
+        with (
+            patch("ccgram.handlers.topics.topic_orchestration.session_manager"),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.thread_router"
+            ) as mock_tr,
+        ):
+            created = await handle_new_window(
+                event, bot, target_user_id=100, target_chat_id=100
+            )
+
+        assert created is True
+        bot.get_me.assert_awaited_once_with()
+        bot.create_forum_topic.assert_awaited_once_with(chat_id=100, name="my-project")
+        mock_tr.bind_thread.assert_called_once_with(
+            100, 42, "@10", window_name="my-project", chat_id=100
+        )
 
     async def test_skips_already_bound(self):
         event = NewWindowEvent(

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -114,18 +114,29 @@ class TestCollectTargetChats:
             result = collect_target_chats("@5")
             assert result == set()
 
-    def test_skips_positive_ids(self):
+    def test_skips_positive_ids_without_private_topic_capability(self):
         with (
             patch(
                 "ccgram.handlers.topics.topic_orchestration.thread_router"
             ) as mock_router,
             patch("ccgram.handlers.topics.topic_orchestration.config") as mock_config,
         ):
+            mock_router.iter_direct_message_chat_ids.return_value = []
             mock_router.iter_thread_bindings.return_value = []
             mock_router.group_chat_ids = {"100:5": 100}
             mock_config.group_id = None
             result = collect_target_chats("@5")
             assert result == set()
+
+    def test_includes_private_chat_with_observed_topic_capability(self):
+        with patch(
+            "ccgram.handlers.topics.topic_orchestration.thread_router"
+        ) as mock_router:
+            mock_router.iter_direct_message_chat_ids.return_value = [100]
+            mock_router.iter_thread_bindings.return_value = []
+            mock_router.group_chat_ids = {}
+
+            assert collect_target_chats("@5") == {100}
 
 
 class TestHandleNewWindow:

--- a/tests/ccgram/handlers/topics/test_window_callbacks.py
+++ b/tests/ccgram/handlers/topics/test_window_callbacks.py
@@ -107,27 +107,24 @@ class TestBindWindowCallback:
         m.edit.assert_called_once()
         assert "my-project" in m.edit.call_args[0][1]
 
-    async def test_private_direct_topic_binds_without_forum_rename(self) -> None:
+    async def test_private_topic_binds_and_renames_with_regular_topic_api(self) -> None:
         query, update, context = _make_query_update_context(
             user_data={UNBOUND_WINDOWS_KEY: ["@5"], PENDING_THREAD_ID: 42}
         )
         message = update.callback_query.message
-        message.message_thread_id = None
+        message.message_thread_id = 42
+        message.is_topic_message = True
         message.chat.type = "private"
         message.chat.id = 100
-        message.chat.is_direct_messages = True
-        message.direct_messages_topic.topic_id = 42
 
         with _bind_env(_unbound_window("my-project")) as m:
             m.router.resolve_chat_id.return_value = 100
-            m.router.is_direct_message_topic.return_value = True
             await handle_window_callback(query, 100, f"{CB_WIN_BIND}0", update, context)
 
         m.router.bind_thread.assert_called_once_with(
             100, 42, "@5", window_name="my-project", chat_id=100
         )
-        m.router.mark_direct_message_topic.assert_called_once_with(100, 42)
-        context.bot.edit_forum_topic.assert_not_called()
+        context.bot.edit_forum_topic.assert_awaited_once()
 
     async def test_bind_forwards_pending_text(self) -> None:
         query, update, context = _make_query_update_context(

--- a/tests/ccgram/handlers/topics/test_window_callbacks.py
+++ b/tests/ccgram/handlers/topics/test_window_callbacks.py
@@ -107,6 +107,28 @@ class TestBindWindowCallback:
         m.edit.assert_called_once()
         assert "my-project" in m.edit.call_args[0][1]
 
+    async def test_private_direct_topic_binds_without_forum_rename(self) -> None:
+        query, update, context = _make_query_update_context(
+            user_data={UNBOUND_WINDOWS_KEY: ["@5"], PENDING_THREAD_ID: 42}
+        )
+        message = update.callback_query.message
+        message.message_thread_id = None
+        message.chat.type = "private"
+        message.chat.id = 100
+        message.chat.is_direct_messages = True
+        message.direct_messages_topic.topic_id = 42
+
+        with _bind_env(_unbound_window("my-project")) as m:
+            m.router.resolve_chat_id.return_value = 100
+            m.router.is_direct_message_topic.return_value = True
+            await handle_window_callback(query, 100, f"{CB_WIN_BIND}0", update, context)
+
+        m.router.bind_thread.assert_called_once_with(
+            100, 42, "@5", window_name="my-project", chat_id=100
+        )
+        m.router.mark_direct_message_topic.assert_called_once_with(100, 42)
+        context.bot.edit_forum_topic.assert_not_called()
+
     async def test_bind_forwards_pending_text(self) -> None:
         query, update, context = _make_query_update_context(
             user_data={

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -22,6 +22,29 @@ def mgr(monkeypatch) -> SessionManager:
     return SessionManager()
 
 
+class TestRoutingLoadRepair:
+    def test_persists_normalized_routing_claims(self, monkeypatch) -> None:
+        state = {
+            "thread_bindings": {"100": {"2": "@5"}},
+            "group_chat_ids": {"100:2": -1001},
+            "chat_thread_bindings": {"200:-1001:142": "@5"},
+        }
+        saves: list[None] = []
+        monkeypatch.setattr("ccgram.session.StatePersistence.load", lambda _self: state)
+        monkeypatch.setattr(
+            "ccgram.session.StatePersistence.schedule_save",
+            lambda _self: saves.append(None),
+        )
+
+        manager = SessionManager()
+
+        assert saves == [None]
+        assert manager.thread_bindings == {}
+        assert thread_router.get_window_for_thread(100, 2, -1001) is None
+        assert thread_router.get_window_for_thread(200, 142, -1001) == "@5"
+        assert manager.group_chat_ids == {}
+
+
 class TestLegacyHerdrMigration:
     def test_load_marks_every_legacy_id_without_short_circuit(
         self, monkeypatch

--- a/tests/ccgram/test_telegram_client.py
+++ b/tests/ccgram/test_telegram_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from telegram import BotCommand, InputMedia, Message
@@ -33,6 +33,7 @@ def fake_bot() -> MagicMock:
         "send_chat_action",
         "set_message_reaction",
         "get_chat",
+        "get_me",
         "get_file",
         "create_forum_topic",
         "edit_forum_topic",
@@ -70,19 +71,15 @@ class TestPTBTelegramClient:
             chat_id=42, text="hi", message_thread_id=7, parse_mode="MarkdownV2"
         )
 
-    async def test_routes_observed_private_topic_to_direct_messages_parameter(
+    async def test_private_topic_uses_regular_thread_parameter(
         self, fake_bot: MagicMock
     ) -> None:
         client = PTBTelegramClient(fake_bot)
 
-        with patch(
-            "ccgram.thread_router.thread_router.is_direct_message_topic",
-            return_value=True,
-        ):
-            await client.send_message(chat_id=42, text="hi", message_thread_id=7)
+        await client.send_message(chat_id=42, text="hi", message_thread_id=7)
 
         fake_bot.send_message.assert_awaited_once_with(
-            chat_id=42, text="hi", direct_messages_topic_id=7
+            chat_id=42, text="hi", message_thread_id=7
         )
 
     async def test_edit_message_text_delegates(self, fake_bot: MagicMock):
@@ -171,10 +168,12 @@ class TestPTBTelegramClient:
             chat_id=1, message_id=2, reaction="👍"
         )
 
-    async def test_get_chat_and_get_file_delegate(self, fake_bot: MagicMock):
+    async def test_get_chat_get_me_and_get_file_delegate(self, fake_bot: MagicMock):
         client = PTBTelegramClient(fake_bot)
         await client.get_chat(chat_id=42)
         fake_bot.get_chat.assert_awaited_once_with(chat_id=42)
+        await client.get_me()
+        fake_bot.get_me.assert_awaited_once_with()
         await client.get_file(file_id="ABC")
         fake_bot.get_file.assert_awaited_once_with(file_id="ABC")
 

--- a/tests/ccgram/test_telegram_client.py
+++ b/tests/ccgram/test_telegram_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from telegram import BotCommand, InputMedia, Message
@@ -68,6 +68,21 @@ class TestPTBTelegramClient:
         assert result is sentinel
         fake_bot.send_message.assert_awaited_once_with(
             chat_id=42, text="hi", message_thread_id=7, parse_mode="MarkdownV2"
+        )
+
+    async def test_routes_observed_private_topic_to_direct_messages_parameter(
+        self, fake_bot: MagicMock
+    ) -> None:
+        client = PTBTelegramClient(fake_bot)
+
+        with patch(
+            "ccgram.thread_router.thread_router.is_direct_message_topic",
+            return_value=True,
+        ):
+            await client.send_message(chat_id=42, text="hi", message_thread_id=7)
+
+        fake_bot.send_message.assert_awaited_once_with(
+            chat_id=42, text="hi", direct_messages_topic_id=7
         )
 
     async def test_edit_message_text_delegates(self, fake_bot: MagicMock):

--- a/tests/ccgram/test_thread_router.py
+++ b/tests/ccgram/test_thread_router.py
@@ -323,9 +323,42 @@ class TestToDictRoundtrip:
             "group_chat_ids": {},
             "window_display_names": {},
         }
-        router.from_dict(data)
+        assert router.from_dict(data) is True
         assert router.get_window_for_thread(100, 2) == "@1"
         assert router.get_window_for_thread(100, 1) is None
+
+    def test_from_dict_normalizes_mixed_legacy_and_scoped_claims(
+        self, router: ThreadRouter
+    ) -> None:
+        repaired = router.from_dict(
+            {
+                "thread_bindings": {"100": {"2": "@5"}},
+                "group_chat_ids": {"100:2": -1001},
+                "chat_thread_bindings": {"200:-1001:142": "@5"},
+            }
+        )
+
+        assert repaired is True
+        assert router.thread_bindings == {}
+        assert router.get_window_for_thread(100, 2, -1001) is None
+        assert router.get_window_for_thread(200, 142, -1001) == "@5"
+        assert router.get_thread_for_window(200, "@5", -1001) == 142
+        assert router.group_chat_ids == {}
+
+    def test_from_dict_keeps_a_window_claim_in_each_chat(
+        self, router: ThreadRouter
+    ) -> None:
+        repaired = router.from_dict(
+            {
+                "thread_bindings": {"100": {"2": "@5"}},
+                "group_chat_ids": {"100:2": -1001},
+                "chat_thread_bindings": {"200:-1002:142": "@5"},
+            }
+        )
+
+        assert repaired is True
+        assert router.get_window_for_thread(100, 2, -1001) == "@5"
+        assert router.get_window_for_thread(200, 142, -1002) == "@5"
 
 
 class TestChatScopedBindings:
@@ -367,6 +400,9 @@ class TestChatScopedBindings:
         self, router: ThreadRouter
     ) -> None:
         router.bind_thread(100, 2, "@5", chat_id=-1001)
+        # Simulate metadata persisted by an earlier version before it learned
+        # that chat-scoped rows make this fallback route redundant.
+        router.group_chat_ids["100:2"] = -1001
 
         router.bind_thread(200, 142, "@5", chat_id=-1001)
 
@@ -374,17 +410,21 @@ class TestChatScopedBindings:
         assert router.get_thread_for_window(100, "@5", -1001) is None
         assert router.get_window_for_thread(200, 142, -1001) == "@5"
         assert router.get_thread_for_window(200, "@5", -1001) == 142
+        assert "100:2" not in router.group_chat_ids
 
     def test_from_dict_repairs_cross_user_duplicate_window_deterministically(
         self, router: ThreadRouter
     ) -> None:
-        router.from_dict(
-            {
-                "chat_thread_bindings": {
-                    "200:-1001:142": "@5",
-                    "100:-1001:2": "@5",
+        assert (
+            router.from_dict(
+                {
+                    "chat_thread_bindings": {
+                        "200:-1001:142": "@5",
+                        "100:-1001:2": "@5",
+                    }
                 }
-            }
+            )
+            is True
         )
 
         assert router.get_window_for_thread(100, 2, -1001) is None

--- a/tests/ccgram/test_thread_router.py
+++ b/tests/ccgram/test_thread_router.py
@@ -343,6 +343,34 @@ class TestChatScopedBindings:
         assert restored.get_window_for_chat_thread(-1001, 7) == "@a"
         assert list(restored.iter_thread_bindings()) == [(100, 7, "@a")]
 
+    def test_cross_user_bind_evicts_existing_window_claim(
+        self, router: ThreadRouter
+    ) -> None:
+        router.bind_thread(100, 2, "@5", chat_id=-1001)
+
+        router.bind_thread(200, 142, "@5", chat_id=-1001)
+
+        assert router.get_window_for_thread(100, 2, -1001) is None
+        assert router.get_thread_for_window(100, "@5", -1001) is None
+        assert router.get_window_for_thread(200, 142, -1001) == "@5"
+        assert router.get_thread_for_window(200, "@5", -1001) == 142
+
+    def test_from_dict_repairs_cross_user_duplicate_window_deterministically(
+        self, router: ThreadRouter
+    ) -> None:
+        router.from_dict(
+            {
+                "chat_thread_bindings": {
+                    "200:-1001:142": "@5",
+                    "100:-1001:2": "@5",
+                }
+            }
+        )
+
+        assert router.get_window_for_thread(100, 2, -1001) is None
+        assert router.get_window_for_thread(200, 142, -1001) == "@5"
+        assert router.get_thread_for_window(200, "@5", -1001) == 142
+
 
 class TestUnbindChatScoped:
     def test_unbind_with_chat_id_removes_only_that_chat(

--- a/tests/ccgram/test_thread_router.py
+++ b/tests/ccgram/test_thread_router.py
@@ -158,9 +158,9 @@ class TestRetiredTopics:
         assert list(router.iter_retired_topics()) == []
 
 
-class TestDirectMessageTopics:
-    def test_observed_topic_persists_across_restart(self, router: ThreadRouter) -> None:
-        router.mark_direct_message_topic(100, 42)
+class TestPrivateTopicChats:
+    def test_observed_chat_persists_across_restart(self, router: ThreadRouter) -> None:
+        router.mark_private_topic_chat(100)
 
         restored = ThreadRouter(
             schedule_save=lambda: None,
@@ -168,14 +168,14 @@ class TestDirectMessageTopics:
         )
         restored.from_dict(router.to_dict())
 
-        assert restored.is_direct_message_topic(100, 42) is True
+        assert restored.is_private_topic_chat(100) is True
 
-    def test_general_topic_is_never_recorded_as_a_session_topic(
+    def test_previous_direct_message_state_migrates_to_private_chat(
         self, router: ThreadRouter
     ) -> None:
-        router.mark_direct_message_topic(100, 1)
+        router.from_dict({"direct_message_topics": ["100:1"]})
 
-        assert router.is_direct_message_topic(100, 1) is False
+        assert router.is_private_topic_chat(100) is True
 
 
 class TestReverseIndex:

--- a/tests/ccgram/test_thread_router.py
+++ b/tests/ccgram/test_thread_router.py
@@ -158,6 +158,26 @@ class TestRetiredTopics:
         assert list(router.iter_retired_topics()) == []
 
 
+class TestDirectMessageTopics:
+    def test_observed_topic_persists_across_restart(self, router: ThreadRouter) -> None:
+        router.mark_direct_message_topic(100, 42)
+
+        restored = ThreadRouter(
+            schedule_save=lambda: None,
+            has_window_state=lambda _wid: False,
+        )
+        restored.from_dict(router.to_dict())
+
+        assert restored.is_direct_message_topic(100, 42) is True
+
+    def test_general_topic_is_never_recorded_as_a_session_topic(
+        self, router: ThreadRouter
+    ) -> None:
+        router.mark_direct_message_topic(100, 1)
+
+        assert router.is_direct_message_topic(100, 1) is False
+
+
 class TestReverseIndex:
     def test_get_thread_for_window(self, router: ThreadRouter) -> None:
         router.bind_thread(100, 42, "@5")
@@ -370,6 +390,21 @@ class TestChatScopedBindings:
         assert router.get_window_for_thread(100, 2, -1001) is None
         assert router.get_window_for_thread(200, 142, -1001) == "@5"
         assert router.get_thread_for_window(200, "@5", -1001) == 142
+
+    def test_same_window_routes_independently_in_different_chats(
+        self, router: ThreadRouter
+    ) -> None:
+        router.bind_thread(100, 2, "@5", chat_id=-1001)
+        router.bind_thread(200, 142, "@5", chat_id=-1002)
+
+        restored = ThreadRouter(
+            schedule_save=lambda: None,
+            has_window_state=lambda _wid: False,
+        )
+        restored.from_dict(router.to_dict())
+
+        assert restored.get_window_for_thread(100, 2, -1001) == "@5"
+        assert restored.get_window_for_thread(200, 142, -1002) == "@5"
 
 
 class TestUnbindChatScoped:

--- a/tests/ccgram/test_utils.py
+++ b/tests/ccgram/test_utils.py
@@ -578,9 +578,9 @@ class TestIsGeneralTopic:
     ) -> None:
         assert is_general_topic(self._message(thread_id, is_forum=is_forum)) is expected
 
-    def test_direct_messages_topic_one_is_general_control_lane(self) -> None:
-        message = self._message(None, is_forum=False)
-        message.chat.is_direct_messages = True
-        message.direct_messages_topic.topic_id = 1
+    def test_private_topic_one_is_general_control_lane(self) -> None:
+        message = self._message(1, is_forum=False)
+        message.chat.type = "private"
+        message.is_topic_message = True
 
         assert is_general_topic(message) is True

--- a/tests/ccgram/test_utils.py
+++ b/tests/ccgram/test_utils.py
@@ -577,3 +577,10 @@ class TestIsGeneralTopic:
         self, thread_id: int | None, is_forum: bool | None, expected: bool
     ) -> None:
         assert is_general_topic(self._message(thread_id, is_forum=is_forum)) is expected
+
+    def test_direct_messages_topic_one_is_general_control_lane(self) -> None:
+        message = self._message(None, is_forum=False)
+        message.chat.is_direct_messages = True
+        message.direct_messages_topic.topic_id = 1
+
+        assert is_general_topic(message) is True


### PR DESCRIPTION
## Summary
- support Telegram topics in private bot chats while keeping topic 1 as the control lane
- add direct buttons for supported numbered and yes/no prompts
- prevent cross-user duplicate bindings for the same chat and window
- reject hook events whose backend or session prefix does not match the active session
- update setup docs and v4.9.4 release notes with contributor thanks

## Validation
- make lint
- make typecheck
- make test: 6831 passed, 32 skipped
- make test-integration: 322 passed, 8 skipped
- uv build
- pre-push architecture gate: 833 passed, 0 blocking findings

## Issues
Addresses #156, #193, #196, and #202.

Issues will be closed after the release is published.