### PR TITLE
Stop tmux reporting an outage as an empty server

### DIFF
--- a/src/ccgram/multiplexer/tmux.py
+++ b/src/ccgram/multiplexer/tmux.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 import libtmux
 from libtmux.exc import LibTmuxException
+from libtmux.neo import fetch_objs
 
 from ..config import config
 from .base import (
@@ -256,14 +257,32 @@ class TmuxManager:
 
         return await asyncio.to_thread(_sync_list_windows)
 
+    def _fetch_session(self) -> libtmux.Session | None:
+        """Find the configured session, letting a failed listing raise.
+
+        ``Server.sessions`` wraps its listing in ``except Exception: pass`` and
+        hands back an empty ``QueryList``, so an unreachable or broken tmux is
+        indistinguishable from a server with no sessions. Every caller that
+        needs the difference would read "no such session", and the
+        reconciliation listing would answer ``[]`` - a confirmed empty listing,
+        on which the audit closes topics and prunes state.
+
+        Going to ``fetch_objs`` directly keeps the failure visible. A listing
+        that succeeds without the configured session still means ``[]``: the
+        server answered, the session is genuinely not there.
+        """
+        objs = fetch_objs(list_cmd="list-sessions", server=self.server)
+        for obj in objs:
+            if obj.get("session_name") == self.session_name:
+                return libtmux.Session(server=self.server, **obj)
+        return None
+
     async def list_windows_for_reconciliation(self) -> list[TmuxWindow] | None:
         """List windows, or return None when tmux cannot confirm the session."""
 
         def _sync_list_windows() -> list[TmuxWindow] | None:
             try:
-                session = self.server.sessions.get(
-                    session_name=self.session_name, default=None
-                )
+                session = self._fetch_session()
                 if session is None:
                     return []
                 windows = [

--- a/tests/ccgram/test_multiplexer_tmux.py
+++ b/tests/ccgram/test_multiplexer_tmux.py
@@ -11,7 +11,7 @@ Covers:
 from __future__ import annotations
 
 from dataclasses import asdict
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -70,17 +70,40 @@ async def test_ensure_session_calls_get_or_create(mgr: TmuxManager) -> None:
         create.assert_called_once_with()
 
 
-async def test_reconciliation_listing_returns_none_without_session(
+async def test_reconciliation_listing_returns_empty_without_session(
     mgr: TmuxManager,
 ) -> None:
-    server = MagicMock()
-    server.sessions.get.return_value = None
-    mgr._server = server
+    """tmux answered, and the configured session is genuinely not there."""
+    with patch("ccgram.multiplexer.tmux.fetch_objs", return_value=[]):
+        assert await mgr.list_windows_for_reconciliation() == []
 
-    assert await mgr.list_windows_for_reconciliation() == []
 
-    server.sessions.get.side_effect = OSError("tmux unavailable")
-    assert await mgr.list_windows_for_reconciliation() is None
+async def test_reconciliation_listing_is_unknown_when_tmux_cannot_be_listed(
+    mgr: TmuxManager,
+) -> None:
+    """Through the real libtmux Server, because the stub cannot show this.
+
+    ``Server.sessions`` wraps its listing in ``except Exception: pass`` and
+    returns an empty QueryList, so a broken tmux looks exactly like a server
+    with no sessions. A test that patches ``sessions.get`` to raise is testing
+    a stub of the dependency, not the dependency: it passes either way. This
+    one fails the listing where libtmux actually performs it, which is the
+    shape a real outage has, and the answer must be unknown - the audit closes
+    topics and prunes state on a confirmed empty listing.
+    """
+    import libtmux.server
+
+    mgr._server = libtmux.server.Server()
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("tmux unavailable")
+
+    with (
+        patch("libtmux.server.fetch_objs", _boom),
+        patch("ccgram.multiplexer.tmux.fetch_objs", _boom),
+    ):
+        assert await mgr.list_windows_for_reconciliation() is None
+
     assert mgr._server is None
 
 


### PR DESCRIPTION
`libtmux`'s `Server.sessions` wraps its listing in `except Exception: pass` and returns an empty `QueryList`. So `sessions.get(...)` answers `None` for a broken or unreachable tmux exactly as it does for a server that genuinely has no such session, and `list_windows_for_reconciliation` returned `[]`.

`[]` is a *confirmed* empty listing, and callers act on it: the audit closes topics, `prune_stale_state` and `prune_session_map` delete records. `None`, the "I could not ask" answer that method exists to provide, could never be produced on the default backend.

## Reproduction

Against a real `libtmux.server.Server` with `fetch_objs` raising `OSError`:

| | `list_windows_for_reconciliation()` |
|---|---|
| before | `[]` |
| after | `None` |

## The change

The session lookup goes through `fetch_objs` directly, where a failure stays visible. A listing that *succeeds* without the configured session still answers `[]`, because that is a real answer.

## On the test

The existing test patched `Server.sessions.get` to raise. That is a stub of the dependency standing in for the dependency, so it passed against both the defect and the fix. The replacement fails the call where libtmux actually makes it, and fails against the previous implementation.

**Independent.** This is the only PR in the #212 series that stands entirely on its own: it touches `multiplexer/tmux.py` alone, shares no code with #214-#217, and is not in their history. Merge it in any order relative to them.