### PR TITLE
Separate the selection listing from the one that answers what exists

### DIFF
--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -40,6 +40,7 @@ from .handlers.topics.topic_orchestration import (
 )
 from .handlers.topics.topic_orchestration import (
     handle_new_window as _handle_new_window,
+    still_adoptable as _still_adoptable,
 )
 from .handlers.topics.topic_orchestration import (
     is_pending_creation as _is_pending_creation,
@@ -267,6 +268,12 @@ async def start_session_monitor(application: Application) -> SessionMonitor:
     )
 
     async def new_window_callback(event: NewWindowEvent) -> None:
+        # The automatic sink, so eligibility is re-read per window. The monitor
+        # emits a batch and awaits each creation in turn, so without this the
+        # last window in a batch is judged on a listing taken before the first
+        # one's topic existed. Explicit binds do not come through here.
+        if not await _still_adoptable(event.window_id):
+            return
         await _handle_new_window(event, client)
 
     monitor.set_new_window_callback(new_window_callback)

--- a/src/ccgram/handlers/sessions_dashboard.py
+++ b/src/ccgram/handlers/sessions_dashboard.py
@@ -27,6 +27,7 @@ from ..config import config
 from ..telegram_client import PTBTelegramClient, TelegramClient
 from ..thread_router import thread_router
 from ..multiplexer import multiplexer as tmux_manager
+from ..multiplexer.reconciliation import list_windows_for_reconciliation
 from ..window_query import view_window
 from .callback_data import (
     CB_SESSIONS_KILL,
@@ -52,6 +53,9 @@ _REFRESH_BTN = InlineKeyboardButton(
 )
 _NEW_BTN = InlineKeyboardButton("\u2795 New Session", callback_data=CB_SESSIONS_NEW)
 
+# Green running, black stopped, white when the multiplexer could not be asked.
+_LIVENESS_MARKER = {True: "\U0001f7e2", False: "\u26ab", None: "\u26aa"}
+
 
 async def _build_dashboard(user_id: int) -> tuple[str, InlineKeyboardMarkup]:
     """Build dashboard text and keyboard for a user's sessions."""
@@ -64,16 +68,20 @@ async def _build_dashboard(user_id: int) -> tuple[str, InlineKeyboardMarkup]:
             keyboard,
         )
 
-    all_windows = await tmux_manager.list_windows()
-    live_ids = {w.window_id for w in all_windows}
+    # The complete listing, not the adoption-filtered one: every id here is
+    # already bound, and a live window a backend merely will not auto-adopt
+    # would otherwise show as stopped. None means the backend could not be
+    # asked, which is not the same as every session being stopped.
+    all_windows = await list_windows_for_reconciliation()
+    live_ids = None if all_windows is None else {w.window_id for w in all_windows}
 
     lines: list[str] = []
     action_rows: list[list[InlineKeyboardButton]] = []
     for _thread_id, window_id in sorted(bindings.items()):
         display_name = thread_router.get_display_name(window_id)
         view = view_window(window_id)
-        alive = window_id in live_ids
-        status = "\U0001f7e2" if alive else "\u26ab"
+        alive = None if live_ids is None else window_id in live_ids
+        status = _LIVENESS_MARKER[alive]
 
         # Session line with provider + mode tags and cwd detail
         provider_tag = f" [{view.provider_name}]" if view and view.provider_name else ""
@@ -191,9 +199,8 @@ async def handle_sessions_kill_confirm(
 
     # Re-render dashboard
     text, keyboard = await _build_dashboard(user_id)
-    await safe_edit(
-        query, f"\U0001f5d1 Killed '{display}'\n\n{text}", reply_markup=keyboard
-    )
+    headline = "\U0001f5d1 Killed"
+    await safe_edit(query, f"{headline} '{display}'\n\n{text}", reply_markup=keyboard)
 
 
 @register(

--- a/src/ccgram/handlers/sync_command.py
+++ b/src/ccgram/handlers/sync_command.py
@@ -73,12 +73,25 @@ _RETIRED_OUTCOME_LABELS = {
 }
 
 
-async def _run_audit() -> AuditResult:
-    """Fetch live multiplexer state and run audit."""
-    all_windows = await tmux_manager.list_windows()
+async def _run_audit() -> AuditResult | None:
+    """Fetch live multiplexer state and run audit.
+
+    Liveness comes from the reconciliation listing, never from
+    ``list_windows``: that one is the UI listing and a backend legitimately
+    omits what it will not adopt, so using it here reports a live bound
+    session as a fixable ghost the moment it becomes excluded. Adoptability is
+    the ``topic_eligible`` subset of the same listing.
+
+    Returns None when no listing is available. The caller must not treat that
+    as "nothing is live", which would classify every binding as dead.
+    """
+    all_windows = await list_windows_for_reconciliation(tmux_manager)
+    if all_windows is None:
+        return None
     live_ids = {w.window_id for w in all_windows}
     live_pairs = [(w.window_id, w.window_name) for w in all_windows]
-    return session_manager.audit_state(live_ids, live_pairs)
+    adoptable = {w.window_id for w in all_windows if w.topic_eligible}
+    return session_manager.audit_state(live_ids, live_pairs, adoptable)
 
 
 def _issue_summary_lines(audit: AuditResult) -> list[str]:
@@ -370,7 +383,20 @@ async def _close_ghost_topics(
 async def _adopt_orphaned_windows(
     client: TelegramClient, issues: list[AuditIssue]
 ) -> None:
-    """Create Telegram topics for unbound multiplexer windows."""
+    """Create Telegram topics for unbound multiplexer windows.
+
+    The verdict on the issues handed in is as old as the listing the audit ran
+    against, and /sync Fix probes every bound topic over the network before
+    reaching here — seconds, with many topics. So eligibility is re-read at the
+    point of use: a window that has since gone away, or moved out of scope,
+    must not get a topic. An unavailable listing adopts nothing; adoption is
+    the one step here that is safe to skip and retry.
+
+    The re-read is per candidate, not once for the batch. Creating a topic is
+    itself several Telegram round-trips, so with a batch-wide snapshot the
+    second orphan is judged on a listing taken before the first one's topic was
+    created — the same staleness one level down.
+    """
     # Lazy: bidirectional cycle — topic_orchestration.adopt_unbound_windows
     # also lazy-imports _adopt_orphaned_windows from this module.  Either
     # side must remain lazy until one is split into a third module.
@@ -380,6 +406,9 @@ async def _adopt_orphaned_windows(
     # Lazy: session_monitor / topic_orchestration cycle through window-creation flow
     from .topics.topic_orchestration import handle_new_window as _handle_new_window
 
+    # Lazy: same bidirectional cycle as handle_new_window above.
+    from .topics.topic_orchestration import still_adoptable as _still_adoptable
+
     for issue in issues:
         if issue.category != "orphaned_window":
             continue
@@ -387,6 +416,8 @@ async def _adopt_orphaned_windows(
         if not match:
             continue
         window_id = match.group(1)
+        if not await _still_adoptable(window_id):
+            continue
         view = window_query.view_window(window_id)
         name = (view.window_name if view else "") or thread_router.get_display_name(
             window_id
@@ -536,6 +567,14 @@ async def sync_command(update: Update, _context: ContextTypes.DEFAULT_TYPE) -> N
     status_msg = await safe_reply(update.message, "🔍 State audit…")
     client = PTBTelegramClient(update.get_bot())
     audit = await _run_audit()
+    if audit is None:
+        if status_msg is not None:
+            await safe_edit(
+                status_msg,
+                "⚠ Multiplexer unavailable. Cannot audit state right now.",
+                reply_markup=None,
+            )
+        return
     logger.info(
         "Local state audit completed",
         issue_count=len(audit.issues),
@@ -591,10 +630,14 @@ async def handle_sync_fix(query: CallbackQuery) -> None:
 
     live_ids = {w.window_id for w in all_windows}
     live_pairs = [(w.window_id, w.window_name) for w in all_windows]
+    # Fix adopts the orphans this audit reports, so the adoption question takes
+    # the backend's verdict. The live set stays complete: it drives the pruning
+    # below, and narrowing it would make a live excluded binding a fixable ghost.
+    adoptable_ids = {w.window_id for w in all_windows if w.topic_eligible}
 
     # Audit before fixing to count fixable issues
     client = PTBTelegramClient(query.get_bot())
-    pre_audit = session_manager.audit_state(live_ids, live_pairs)
+    pre_audit = session_manager.audit_state(live_ids, live_pairs, adoptable_ids)
     dead_issues = await _probe_dead_topics(client)
     pre_audit.issues.extend(dead_issues)
     pre_audit.issues.extend(_retired_topic_issues())
@@ -628,6 +671,16 @@ async def handle_sync_fix(query: CallbackQuery) -> None:
     # one is unbound and won't be probed), while failed ones restore the old
     # binding and must be re-probed to avoid inflating actual_fixed.
     post_audit = await _run_audit()
+    if post_audit is None:
+        # The repairs already ran; only the after-picture is missing, and
+        # reporting every binding as dead would be worse than saying so.
+        await safe_edit(
+            query,
+            "✅ Fixes applied. The multiplexer went away before the "
+            "after-audit, so the summary below is unavailable.",
+            reply_markup=None,
+        )
+        return
     post_dead = await _probe_dead_topics(client)
     post_audit.issues.extend(post_dead)
     post_audit.issues.extend(_retired_topic_issues())

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -408,14 +408,18 @@ async def create_topic_in_chat(
         return False
 
 
-async def _rebind_existing_topic_by_name(
-    event: NewWindowEvent, client: TelegramClient, topic_name: str
-) -> bool:
-    """Bind a stale same-name topic to a newly discovered manual window."""
-    clean_topic_name = strip_emoji_prefix(topic_name)
+async def _stale_same_name_bindings(
+    event: NewWindowEvent, clean_topic_name: str
+) -> list[tuple[int, int, str, int]] | None:
+    """Bindings with this topic name whose window is confirmed gone.
+
+    ``None`` when any candidate's liveness could not be confirmed: the caller
+    would hand that topic to a different window, and find_window_by_id answers
+    None both for a window that is gone and for a backend that could not be
+    reached. There is no rush to rebind, so unknown abandons the decision.
+    """
     matches: list[tuple[int, int, str, int]] = []
-    bindings = list(thread_router.iter_thread_bindings())
-    for user_id, thread_id, old_window_id in bindings:
+    for user_id, thread_id, old_window_id in list(thread_router.iter_thread_bindings()):
         if old_window_id == event.window_id:
             continue
         display_name = strip_emoji_prefix(thread_router.get_display_name(old_window_id))
@@ -425,6 +429,17 @@ async def _rebind_existing_topic_by_name(
             continue
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
         matches.append((user_id, thread_id, old_window_id, chat_id))
+    return matches
+
+
+async def _rebind_existing_topic_by_name(
+    event: NewWindowEvent, client: TelegramClient, topic_name: str
+) -> bool:
+    """Bind a stale same-name topic to a newly discovered manual window."""
+    clean_topic_name = strip_emoji_prefix(topic_name)
+    matches = await _stale_same_name_bindings(event, clean_topic_name)
+    if matches is None:
+        return False
 
     if len(matches) != 1:
         if len(matches) > 1:
@@ -541,12 +556,55 @@ async def _handle_new_window_locked(
     return any(results)
 
 
+async def still_adoptable(window_id: str) -> bool:
+    """Confirm, right now, that discovery may adopt this window.
+
+    Read immediately before each automatic adoption, never once for a batch:
+    creating a topic is several Telegram round-trips, so the second window in
+    a batch would otherwise be judged on a listing taken before the first
+    one's topic existed. It has had time to go away, leave the configured
+    workspace scope, or stop being an agent.
+
+    Automatic adoption only. A picker selection is an explicit bind and may
+    name a window discovery would not have taken on its own.
+
+    An unconfirmed listing answers False: skipping costs a retry on the next
+    cycle, while adopting a window that has gone creates a topic nothing will
+    ever drive.
+    """
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ...multiplexer.reconciliation import list_windows_for_reconciliation
+
+    windows = await list_windows_for_reconciliation(tmux_manager)
+    if windows is None:
+        logger.warning(
+            "Skipping adoption: no confirmed window listing", window_id=window_id
+        )
+        return False
+    if not any(w.window_id == window_id and w.topic_eligible for w in windows):
+        logger.info(
+            "Skipping adoption: window no longer adoptable", window_id=window_id
+        )
+        return False
+    return True
+
+
 async def adopt_unbound_windows(client: TelegramClient) -> None:
     """Auto-adopt known-but-unbound windows (post-restart recovery)."""
-    all_windows = await tmux_manager.list_windows()
+    # Orphan repair creates topics, so the adoption question takes the
+    # backend's verdict; liveness comes from the complete listing, or a
+    # present-but-excluded window becomes a ghost instead of being ignored.
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ...multiplexer.reconciliation import list_windows_for_reconciliation
+
+    all_windows = await list_windows_for_reconciliation(tmux_manager)
+    if all_windows is None:
+        logger.warning("Skipping unbound-window adoption: no confirmed listing")
+        return
     live_ids = {w.window_id for w in all_windows}
     live_pairs = [(w.window_id, w.window_name) for w in all_windows]
-    audit = session_manager.audit_state(live_ids, live_pairs)
+    adoptable_ids = {w.window_id for w in all_windows if w.topic_eligible}
+    audit = session_manager.audit_state(live_ids, live_pairs, adoptable_ids)
     orphaned = [i for i in audit.issues if i.category == "orphaned_window"]
     if orphaned:
         # Lazy: bidirectional cycle with sync_command (see

--- a/src/ccgram/multiplexer/agterm.py
+++ b/src/ccgram/multiplexer/agterm.py
@@ -168,6 +168,26 @@ def _validated_work_dir(work_dir: str) -> tuple[Path | None, str]:
     return path, ""
 
 
+def _runs_a_known_agent(foreground: object) -> bool:
+    """Whether this session's foreground argv is an agent ccgram can drive.
+
+    Classified from the whole argv, never from its first token: agterm reports
+    what is actually running, so codex arrives as ``["node", ".../codex", …]``
+    and a check on ``argv[0]`` would reject it while accepting ``vim``, ``less``
+    or a build. ``classify_provider_from_argv`` is the codebase's own
+    wrapper-skipping matcher. A shell is not an adopted agent, and an absent
+    foreground is an idle prompt.
+    """
+    if not isinstance(foreground, list) or not foreground:
+        return False
+    # Lazy: providers reach back into the multiplexer seam, so a module-level
+    # import here would close the loop.
+    from ..providers.process_detection import classify_provider_from_argv
+
+    provider = classify_provider_from_argv([str(part) for part in foreground])
+    return bool(provider) and provider != "shell"
+
+
 def _key_to_bytes(token: str) -> str | None:
     """Translate one tmux key name to pty bytes, or None when unrecognised.
 
@@ -345,6 +365,20 @@ class AgtermManager:
         Fails closed. A failure anywhere returns None, never a partial tree,
         because a partial answer here is indistinguishable from sessions
         having gone away.
+
+        The sweep is a sequence of RPCs, so in principle a session could evade
+        it by moving between windows between two reads. It cannot: agterm has
+        no operation that moves a session across windows. Both relocation
+        paths refuse (``session move <workspace>`` answers "no such workspace"
+        for a workspace in another window, and ``move --after <anchor>``
+        answers "no such session" for an anchor in one), because session and
+        workspace addressing is window-scoped. A session is created in a window
+        and stays there until it closes. What can still appear mid-sweep is a
+        newly opened window, whose sessions are new and therefore cannot be
+        ones ccgram is already bound to.
+
+        ``window_exists`` covers the remainder for the destructive paths, which
+        ask about one target rather than trusting this listing.
         """
         window_ids = await self._open_window_ids()
         if window_ids is None:
@@ -376,8 +410,7 @@ class AgtermManager:
                     pairs.append((workspace, session))
         return pairs
 
-    @staticmethod
-    def _to_window(session: dict) -> WindowRef:
+    def _to_window(self, session: dict, workspace: dict | None = None) -> WindowRef:
         """Map one agterm session node onto the neutral ``WindowRef``."""
         foreground = session.get("foreground")
         command = ""
@@ -393,6 +426,11 @@ class AgtermManager:
             pane_tty="",
             pane_width=0,
             pane_height=0,
+            # Discovery consumes the reconciliation listing, which stays
+            # complete on purpose, so adoptability travels on the window.
+            topic_eligible=self._is_adoptable(session)
+            and (workspace is None or self._in_scope(workspace))
+            and _runs_a_known_agent(foreground),
         )
 
     async def _find_session(self, window_id: str) -> dict | None:
@@ -457,17 +495,21 @@ class AgtermManager:
             )
 
     async def list_windows(self) -> list[WindowRef]:
-        """List the sessions discovery may adopt (best-effort, [] on failure).
+        """List the sessions offered for explicit selection ([] on failure).
 
-        Narrower than ``list_windows_for_reconciliation`` on purpose: this is
-        the listing discovery turns into topics, so it carries the workspace
-        scope and the self/hidden exclusions.
+        The pickers. Narrower than ``list_windows_for_reconciliation``, which
+        returns every session so cleanup can tell absent from excluded, but
+        narrowed only by *visibility*: the workspace scope, ccgram's own
+        session and the ``_`` prefix. Not by adoptability — an in-scope session
+        sitting at a shell is listed here, carrying ``topic_eligible=False``,
+        so a user can bind it by hand while unattended discovery leaves it
+        alone. Discovery reads the reconciliation listing and never this one.
         """
         tree = await self._tree()
         if tree is None:
             return []
         return [
-            self._to_window(session)
+            self._to_window(session, workspace)
             for workspace, session in self._sessions(tree)
             if self._in_scope(workspace) and self._is_adoptable(session)
         ]
@@ -489,7 +531,8 @@ class AgtermManager:
         if tree is None:
             return None
         return [
-            self._to_window(session) for _workspace, session in self._sessions(tree)
+            self._to_window(session, workspace)
+            for workspace, session in self._sessions(tree)
         ]
 
     async def list_workspaces(self) -> list[WorkspaceRef]:
@@ -518,6 +561,8 @@ class AgtermManager:
     async def find_window_by_id(self, window_id: str) -> WindowRef | None:
         """Find a session by its UUID; None when it no longer exists."""
         session = await self._find_session(window_id)
+        # No workspace passed: addressing a known id is not discovery, so an
+        # out-of-scope window is still findable and drivable.
         return None if session is None else self._to_window(session)
 
     async def _read_text(self, window_id: str, *, lines: int | None) -> str | None:
@@ -883,15 +928,20 @@ class AgtermManager:
         agterm reports the argv but no pid, pgid or tty, so those are zero and
         empty.
 
-        None at an idle shell prompt, and that is agterm's answer rather than a
-        failure: it omits ``foreground`` from the node exactly when the pane
-        sits at a prompt. The shell provider needs a shell *name* to install
-        its prompt marker, and agterm reports none, so that provider does not
-        work on this backend. The adapter does not guess one: ``shell_infra``
-        matches ``argv[0]`` against ``KNOWN_SHELLS`` and then sends that
-        shell's syntax, so a wrong guess types zsh into a fish prompt in a
-        terminal somebody is using. Lifting this needs agterm to report the
-        shell on an idle node.
+        None whenever agterm cannot report an argv, which is several states and
+        not one: a shell holds the pane, there is no foreground pid, the
+        foreground group is an unreadable setuid or setgid one such as ``top``
+        or ``sudo``, or a lookup failed. So None means "unknown", never "at a
+        prompt" (confirmed by agterm's author, umputun/agterm#508; their godoc
+        named only the shell case and has been corrected).
+
+        The shell provider does not work on this backend, and a shell name
+        would not fix it. agterm 0.25 adds ``foregroundShell`` for the case
+        where a recognised shell holds the pane, but a shell builtin such as
+        ``read`` or ``vared``, and a shell loop, run inside the shell process,
+        so argv stays the shell's: a pane blocked on input is indistinguishable
+        from one at a prompt and both report the same name. Installing a prompt
+        marker on that signal would type into a running ``read``.
 
         The provider detector classifies this argv directly because agterm cannot
         provide a process-group ID. This preserves provider detection behind

--- a/src/ccgram/multiplexer/base.py
+++ b/src/ccgram/multiplexer/base.py
@@ -20,6 +20,22 @@ from typing import Protocol, runtime_checkable
 # ── Value types ────────────────────────────────────────────────────────
 
 
+def canonical_window_id(window_id: str) -> str:
+    """The comparison form of a window id.
+
+    Window ids are opaque, but they are not all case-stable. agterm reports
+    UUIDs uppercase while a caller may round-trip one lowercased, which is why
+    the backend's own lookup case-folds and why ``WindowRef.matches`` does.
+    Anything comparing a persisted id against a live listing has to agree with
+    them, or the batch sets classify a live session as dead and the audit
+    prunes its state, bindings and offsets.
+
+    Case-folding is safe for every current id form: tmux ``@N`` has no case,
+    herdr's guarded targets are hex digests, agterm's are UUIDs.
+    """
+    return window_id.casefold()
+
+
 @dataclass
 class WindowRef:
     """Neutral representation of a multiplexer window (tmux window / herdr pane).
@@ -35,6 +51,17 @@ class WindowRef:
     pane_tty: str = ""
     pane_width: int = 0
     pane_height: int = 0
+    topic_eligible: bool = True
+    """Whether discovery may adopt this window as a topic.
+
+    Stamped by the backend, because whether a window is ccgram's own, hidden by
+    convention, or outside the configured scope is backend knowledge. Discovery
+    consumes ``list_windows_for_reconciliation``, which stays complete on
+    purpose so cleanup never mistakes a filtered-out window for a dead one, so
+    the adoption decision has to travel on the window itself instead of being
+    applied by omission. Backends with nothing to exclude leave it True.
+    """
+
     alias_window_ids: tuple[str, ...] = ()
     """Superseded canonical identities this same window may be persisted under."""
     legacy_alias_window_ids: tuple[str, ...] = ()

--- a/src/ccgram/multiplexer/base.py
+++ b/src/ccgram/multiplexer/base.py
@@ -210,7 +210,12 @@ class MultiplexerCapabilities:
     """True when ``foreground()`` can return a tty device path (tmux: True)."""
 
     native_agent_status: bool
-    """True when the backend exposes agent status natively (herdr: True)."""
+    """True when the backend exposes agent status natively (herdr, agterm).
+
+    Read only for status. It does not decide which windows become topics: that
+    is ``WindowRef.topic_eligible``, because keying discovery on this flag made
+    every agterm session permanently ineligible once agterm set it.
+    """
 
     read_max_lines: int | None
     """Maximum scrollback lines the backend can return; None = unlimited (tmux)."""
@@ -274,7 +279,38 @@ class Multiplexer(Protocol):
         ...
 
     async def list_windows(self) -> list[WindowRef]:
-        """List all agent windows in the session."""
+        """List the windows the backend presents for explicit selection.
+
+        The pickers. A backend applies its visibility filters here — its own
+        session, hidden names, a configured workspace scope — so this is not a
+        liveness answer; ask ``list_windows_for_reconciliation`` for that.
+
+        It is not the adoption answer either, and unattended discovery never
+        reads it. A window listed here may carry ``topic_eligible=False``:
+        agterm deliberately shows an in-scope session sitting at a shell so a
+        user can bind it by hand. Choosing from a picker is an explicit bind,
+        and the flows behind it do their own existence check.
+        """
+        ...
+
+    async def list_windows_for_reconciliation(self) -> list[WindowRef] | None:
+        """List every live window, or ``None`` when the listing is unconfirmed.
+
+        The complete view, used wherever absence means "this window is gone":
+        state cleanup, the monitor's change detection, ``/sync``, the sessions
+        dashboard, transcript discovery, and the alive column in ``status``. It
+        must include every window ``list_windows`` filters out, so a caller can
+        tell an excluded window from a departed one.
+
+        This is also the listing unattended discovery reads, and the only one
+        it reads. ``WindowRef.topic_eligible`` on these windows is the third
+        question — what may be adopted with nobody asking — kept separate from
+        both the visibility filters above and existence here.
+
+        ``None`` means the backend could not confirm the listing (an
+        unreachable socket, a failed command). It is never an empty listing:
+        treating it as one closes every binding the bot holds.
+        """
         ...
 
     async def list_workspaces(self) -> list[WorkspaceRef]:

--- a/src/ccgram/multiplexer/herdr.py
+++ b/src/ccgram/multiplexer/herdr.py
@@ -329,6 +329,13 @@ def _parse_live_record(record: Mapping[str, object]) -> HerdrLiveRecord | None:
 def _parse_agent_records(
     agents: Sequence[object],
 ) -> tuple[list[HerdrLiveRecord], int]:
+    """Parse the records, counting the ones that leave a gap in the account.
+
+    The count is malformed records only. A record that parses to None is not a
+    gap: a recognised agent without a composite already takes a terminal-derived
+    identity, so what remains is an agent ccgram cannot address at all and never
+    holds a binding to.
+    """
     records: list[HerdrLiveRecord] = []
     malformed = 0
     for agent in agents:
@@ -548,12 +555,39 @@ class HerdrManager:
             )
 
     async def _agent_list_snapshot(self) -> list[HerdrLiveRecord]:
-        """Read and parse one fresh ``agent.list`` snapshot.
+        """The safe records from one fresh ``agent.list`` snapshot.
 
         Known hook-capable agents without a complete session composite use a
         terminal fallback identity. Shells and malformed records remain
         ignored. No focus, title, name, directory, screen, or layout field
         participates in this snapshot.
+
+        Quarantined records are dropped silently, so this subset is safe to
+        address and safe to show, but it is not a complete account of what is
+        live. Anything answering "does this window still exist" must take
+        ``_agent_list_snapshot_checked`` instead.
+        """
+        records, _complete = await self._agent_list_snapshot_checked()
+        return records
+
+    async def _agent_list_snapshot_checked(
+        self,
+    ) -> tuple[list[HerdrLiveRecord], bool]:
+        """The safe records, plus whether they account for every live agent.
+
+        ``False`` when malformed or ambiguous records were quarantined: those
+        panes are live, ccgram may hold bindings to them, and they are absent
+        from the subset returned here. Reporting that subset as complete makes
+        such a binding look like a ghost, which the audit, the polling loop and
+        the destructive guards all act on.
+
+        Completeness means every *addressable* guarded target. A record that
+        merely names a tool is not one: a recognised agent without a composite
+        already gets a terminal-derived identity, and what is left parses to
+        None because ccgram does not recognise the agent at all. Antigravity is
+        the live example, supported here and documented to stay sessionless
+        until its first prompt, so counting it would make reconciliation
+        unknown for every topic while one sits idle.
         """
         result = await self._call_json(["agent", "list"])
         if result is None:
@@ -576,7 +610,8 @@ class HerdrManager:
                 duplicate_target_count=duplicate_targets,
                 duplicate_pane_count=duplicate_panes,
             )
-        return safe
+        complete = not (malformed or duplicate_targets or duplicate_panes)
+        return safe, complete
 
     def target_id_for_live_record(self, record: Mapping[str, object]) -> str | None:
         """Return a guarded opaque target for one ``agent.list`` record.
@@ -610,13 +645,25 @@ class HerdrManager:
         return matches[0]
 
     @staticmethod
-    def _live_ref(record: HerdrLiveRecord, label: str) -> WindowRef:
-        """Project a live record without exposing reusable locator aliases."""
+    def _live_ref(
+        record: HerdrLiveRecord, label: str, *, adoptable: bool = True
+    ) -> WindowRef:
+        """Project a live record without exposing reusable locator aliases.
+
+        ``topic_eligible`` is stamped here because this parser is already the
+        place that decides what counts: it emits a record only for a live agent
+        carrying a guarded target, and a bare shell pane never reaches it. The
+        verdict travels on the window so discovery needs no herdr-shaped check
+        of its own.
+        """
         return WindowRef(
             window_id=record.target_id,
             window_name=label,
             cwd=record.cwd,
             pane_current_command=record.composite.agent,
+            topic_eligible=adoptable
+            and is_herdr_session_target(record.target_id)
+            and bool(record.composite.agent.strip()),
         )
 
     async def _reconciliation_labels(
@@ -674,36 +721,74 @@ class HerdrManager:
             label = labels.get((record.workspace_id, record.tab_id))
             if label is None:
                 if include_unlabeled:
+                    # Kept for liveness and addressing, never for adoption:
+                    # without labels this cannot tell an internal ``__*__``
+                    # workspace or tab from an ordinary one, and adopting
+                    # ccgram's own pane is the failure that guard exists for.
                     refs.append(
                         self._live_ref(
                             record,
                             f"Herdr ▸ {record.target_id[-12:]}",
+                            adoptable=False,
                         )
                     )
                 continue
             workspace_label, tab_label = label
-            if not include_internal and (
+            internal = bool(
                 _INTERNAL_LABEL_RE.match(workspace_label)
                 or _INTERNAL_LABEL_RE.match(tab_label)
-            ):
+            )
+            if internal and not include_internal:
                 continue
             pane = record.pane_id.rsplit(":", 1)[-1]
             refs.append(
                 self._live_ref(
                     record,
                     format_agent_topic_prefix(workspace_label, tab_label, pane),
+                    adoptable=not internal,
                 )
             )
         return refs
 
     async def list_windows(self) -> list[WindowRef]:
-        """Return a best-effort UI listing; reconciliation uses the tri-state API."""
-        return await self.list_windows_for_reconciliation() or []
+        """Return a best-effort UI listing, hiding ccgram's own internal panes.
+
+        Built from the safe subset directly, not from the reconciliation
+        listing: quarantined records make that listing report unknown, and a
+        picker that empties itself because one unrelated record was malformed
+        would be worse than one showing everything it can address. Showing what
+        is addressable is exactly this listing's job.
+        """
+        try:
+            refs = await self._project_live_refs(await self._agent_list_snapshot())
+        except HerdrError:
+            # Best-effort, as before: a failed agent, workspace or tab listing
+            # empties the picker instead of raising through it. Only the
+            # reconciliation listing distinguishes this from "nothing there".
+            return []
+        return [w for w in refs if w.topic_eligible]
 
     async def list_windows_for_reconciliation(self) -> list[WindowRef] | None:
+        """Every live record, including internal ones, marked unadoptable.
+
+        Internal ``__*__`` workspaces and tabs are ccgram's own and must never
+        be adopted, but they have to stay in the listing: a bound session
+        renamed into one would otherwise vanish from liveness, be audited as a
+        ghost binding and have its topic closed. Existence and adoptability are
+        different questions, so this answers the first and stamps the second.
+        """
         try:
+            records, complete = await self._agent_list_snapshot_checked()
+            if not complete:
+                # Quarantined records are live panes missing from this subset,
+                # so it cannot answer what exists. Saying so beats handing back
+                # a listing whose gaps read as dead bindings.
+                logger.warning(
+                    "herdr agent.list incomplete; reporting liveness unknown"
+                )
+                return None
             return await self._project_live_refs(
-                await self._agent_list_snapshot(), include_unlabeled=True
+                records, include_internal=True, include_unlabeled=True
             )
         except HerdrError:
             return None

--- a/src/ccgram/multiplexer/tmux.py
+++ b/src/ccgram/multiplexer/tmux.py
@@ -162,16 +162,24 @@ class TmuxManager:
         return session
 
     @staticmethod
-    def _window_ref_for_reconciliation(window: libtmux.Window) -> TmuxWindow | None:
-        """Build a window ref while treating pane metadata as optional."""
+    def _window_ref_for_reconciliation(window: libtmux.Window) -> TmuxWindow:
+        """Build a window ref while treating pane metadata as optional.
+
+        Every window in the session comes back, including the ones
+        ``list_windows`` hides: the placeholder main window, ccgram's own
+        window, and the ``_``-prefixed hidden ones. Omitting them here made a
+        bound window vanish from liveness the moment it was renamed to start
+        with an underscore, and a window absent from this listing is a ghost
+        binding that /sync Fix offers to close. They come back stamped
+        ``topic_eligible=False`` so discovery still refuses to adopt them.
+        """
         name = window.window_name or ""
         window_id = window.window_id or ""
-        if name == config.tmux_main_window_name:
-            return None
-        if config.own_window_id and window_id == config.own_window_id:
-            return None
-        if name.startswith("_"):
-            return None
+        adoptable = not (
+            name == config.tmux_main_window_name
+            or (config.own_window_id and window_id == config.own_window_id)
+            or name.startswith("_")
+        )
 
         cwd = ""
         pane_cmd = ""
@@ -197,6 +205,7 @@ class TmuxManager:
             pane_tty=pane_tty,
             pane_width=pw,
             pane_height=ph,
+            topic_eligible=bool(adoptable),
         )
 
     async def list_windows(self) -> list[TmuxWindow]:
@@ -267,9 +276,8 @@ class TmuxManager:
                 if session is None:
                     return []
                 windows = [
-                    ref
+                    self._window_ref_for_reconciliation(window)
                     for window in session.windows
-                    if (ref := self._window_ref_for_reconciliation(window)) is not None
                 ]
             except _TmuxError:
                 self._reset_server()
@@ -296,14 +304,21 @@ class TmuxManager:
     async def find_window_by_id(self, window_id: str) -> TmuxWindow | None:
         """Find a window by its tmux window ID (e.g. '@0', '@12').
 
+        Resolves against the complete listing, as agterm and herdr do:
+        addressing a known id is not discovery. Every handler routes an
+        already-bound window through here, so filtering by adoptability made a
+        window unreachable — no text delivered, no screenshot, no toolbar — the
+        moment it was renamed to start with an underscore.
+
         Args:
             window_id: The tmux window ID to match
 
         Returns:
-            TmuxWindow if found, None otherwise
+            TmuxWindow if found, None otherwise (including when tmux could not
+            confirm the listing).
         """
-        windows = await self.list_windows()
-        for window in windows:
+        windows = await self.list_windows_for_reconciliation()
+        for window in windows or []:
             if window.window_id == window_id:
                 return window
         return None

--- a/src/ccgram/multiplexer/topic_mapping.py
+++ b/src/ccgram/multiplexer/topic_mapping.py
@@ -17,7 +17,6 @@ because it is pure logic over the neutral value types.
 
 from __future__ import annotations
 
-from ..herdr_targets import is_herdr_session_target
 from .base import MultiplexerCapabilities, WindowRef
 
 # Separates workspace, tab, and optional pane parts in a Herdr topic title.
@@ -41,17 +40,17 @@ def format_agent_topic_prefix(workspace: str, tab: str, pane: str = "") -> str:
 def is_agent_topic_window(window: WindowRef, caps: MultiplexerCapabilities) -> bool:
     """Return True when a discovered window should surface as its own topic.
 
-    Gated on ``caps.native_agent_status`` — a capability flag, never a backend
-    name (architecture rule: gate on capabilities, not ``name == "herdr"``):
+    The backend decides, in ``WindowRef.topic_eligible``. No capability flag
+    gates discovery: keying it on one is what produced two bugs in a row. It
+    was first keyed on ``native_agent_status``, which made every agterm session
+    permanently ineligible the moment agterm began reporting status natively;
+    keying it on ``native_topic_targets`` instead only moved the overload onto
+    a flag whose documented meaning is which creation flow to use.
 
-    * Backends without native agent status (tmux): every window is eligible,
-      so the historical auto-topic behavior is unchanged.
-    * Backends with native agent status (herdr): every detected agent record
-      qualifies. The adapter exposes each with a versioned opaque target and an
-      agent label; a raw tab/pane locator or bare shell record is rejected.
+    Only the backend can answer this. herdr knows a record carries a guarded
+    target and an agent label, agterm knows its workspace scope and how to read
+    a wrapped argv, tmux excludes nothing. ``caps`` stays in the signature
+    because it is the seam's shape and callers pass it.
     """
-    if not caps.native_agent_status:
-        return True
-    return is_herdr_session_target(window.window_id) and bool(
-        window.pane_current_command.strip()
-    )
+    del caps
+    return window.topic_eligible

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -516,16 +516,29 @@ class SessionManager:
         self,
         live_window_ids: set[str],
         live_windows: list[tuple[str, str]],
+        adoptable_window_ids: set[str] | None = None,
     ) -> AuditResult:
-        """Read-only audit of all state maps against live tmux windows.
+        """Read-only audit of all state maps against live multiplexer windows.
+
+        Liveness and adoptability are different questions and must stay
+        separate here. Ghost detection, cleanup and display-name sync all ask
+        "does this window exist", so they need the complete live set; feeding
+        them a narrowed one turns a live-but-excluded window into a fixable
+        ghost, and ``/sync`` Fix closes those. Only the orphan section asks
+        "may ccgram adopt this", and only it reads the narrowed set.
 
         Args:
-            live_window_ids: Set of currently alive tmux window IDs.
-            live_windows: List of (window_id, window_name) for live windows.
+            live_window_ids: Every window the backend reports as existing.
+            live_windows: (window_id, window_name) for those windows.
+            adoptable_window_ids: The subset discovery may adopt, from
+                ``WindowRef.topic_eligible``. None means every live window,
+                which is what a backend that excludes nothing reports.
 
         Returns:
             AuditResult with discovered issues.
         """
+        if adoptable_window_ids is None:
+            adoptable_window_ids = live_window_ids
         issues: list[AuditIssue] = []
 
         # Collect all bound window IDs
@@ -640,7 +653,7 @@ class SessionManager:
 
         # 7. Orphaned tmux windows (live, known to ccgram, but not bound to any topic)
         known_wids = session_map_wids | set(self.window_states.keys())
-        for wid in live_window_ids:
+        for wid in adoptable_window_ids:
             if wid not in bound_window_ids and wid in known_wids:
                 name = dict(live_windows).get(wid, wid)
                 issues.append(

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -42,6 +42,7 @@ from .providers import get_provider_for_window, registry  # noqa: F401 (used by 
 from .session_map import parse_session_map, read_session_map_raw, session_map_prefix
 from .session_lifecycle import session_lifecycle
 from .multiplexer import multiplexer as tmux_manager
+from .multiplexer.base import canonical_window_id
 from .multiplexer.reconciliation import list_windows_for_reconciliation
 from .multiplexer.window_liveness import note_live_windows
 from .multiplexer.topic_mapping import is_agent_topic_window
@@ -71,6 +72,17 @@ _SKIP_RETRY_MAX_SECONDS = 60.0
 _MSG_PREVIEW_LENGTH = 80
 
 logger = structlog.get_logger()
+
+
+def _adoption_lookup(adoptable_window_ids: set[str]) -> set[str]:
+    """The comparison form of the adoption set, built once per pass.
+
+    Folded, because these keys were written by the hook while the set comes
+    from the backend's listing, and agterm reports UUIDs uppercase while a
+    caller may round-trip one lowercased. The set itself keeps the backend's
+    spelling, since the audit reports orphan ids straight out of it.
+    """
+    return {canonical_window_id(wid) for wid in adoptable_window_ids}
 
 
 class SessionMonitor:
@@ -586,9 +598,20 @@ class SessionMonitor:
             self.state.save_if_dirty()
 
     async def _detect_and_cleanup_changes(
-        self, raw: dict | None = None
+        self,
+        raw: dict | None = None,
+        *,
+        adoptable_window_ids: set[str] | None,
     ) -> dict[str, dict[str, str]]:
-        """Reconcile session_map; clean up replaced/removed sessions; fire new-window events."""
+        """Reconcile session_map; clean up replaced/removed sessions; fire new-window events.
+
+        ``adoptable_window_ids`` is this cycle's verdict, required rather than
+        defaulted: it is per-cycle input with one production caller, so holding
+        it as monitor state let a stale cycle's answer be reused and let the
+        first cycle run with none at all. ``None`` means no listing was
+        available, and then nothing is adopted — a hook entry is not evidence
+        that ccgram may adopt the window it names.
+        """
         if raw is None:
             raw = await read_session_map_raw()
         if raw is None:
@@ -617,6 +640,11 @@ class SessionMonitor:
             # session_manager forms a hard cycle on bootstrap.
             from .session import session_manager as _sm
 
+            adoptable_lookup = (
+                None
+                if adoptable_window_ids is None
+                else _adoption_lookup(adoptable_window_ids)
+            )
             for window_id, details in adoption_windows.items():
                 provider_name = details.get("provider_name", "")
                 if provider_name:
@@ -629,6 +657,15 @@ class SessionMonitor:
                     # the topic it was bound under; announcing it here would
                     # ask for a second topic for the same agent. Both other
                     # discovery paths skip bound windows for the same reason.
+                    continue
+
+                if (
+                    adoptable_lookup is None
+                    or canonical_window_id(window_id) not in adoptable_lookup
+                ):
+                    # A hook entry proves an agent ran there, not that ccgram
+                    # may adopt it. Installed globally, the hook writes entries
+                    # for windows outside the configured scope too.
                     continue
 
                 if self._new_window_callback:
@@ -654,10 +691,13 @@ class SessionMonitor:
         """Fire a NewWindowEvent for each live window not in session_map / bound.
 
         Surfaces windows the hook never registered (no session_map entry) so
-        they can become topics. On backends that expose agent status natively
-        (herdr), only agent panes qualify — a bare shell pane is not a topic;
-        tmux surfaces every window, preserving today's behavior. The gate is the
-        ``native_agent_status`` capability, not a backend name.
+        they can become topics. What qualifies is the backend's own verdict,
+        carried per window in ``WindowRef.topic_eligible``: herdr marks records
+        holding a guarded target and an agent label, agterm marks in-scope
+        sessions running an agent, tmux marks everything except the placeholder
+        main window, its own window and ``_``-prefixed ones, which its complete
+        listing returns ineligible instead of dropping. No capability flag
+        gates this; keying it on one produced two bugs in a row.
         """
         if not self._new_window_callback:
             return
@@ -691,7 +731,7 @@ class SessionMonitor:
     async def _emit_known_unbound_window_events(
         self,
         current_map: dict,
-        live_window_ids: set[str],
+        adoptable_window_ids: set[str],
     ) -> None:
         """Fire a NewWindowEvent for each session_map window that is not bound.
 
@@ -700,9 +740,13 @@ class SessionMonitor:
         poll until it succeeds. ``handle_new_window`` is idempotent — it skips
         windows that are already bound — so this generates no spam for bound tabs.
 
-        ``live_window_ids`` is the set from ``list_windows``. Because ``list_windows``
-        already filters ``__*__`` workspace/tab labels, any such tab is absent from
-        ``live_window_ids`` and is silently skipped here as well.
+        ``adoptable_window_ids`` holds the live windows whose backend marked them
+        ``WindowRef.topic_eligible``. It is NOT the plain live set: the listing
+        this is built from is the complete reconciliation one, because pruning
+        needs every window that exists. Filtering here is what keeps a window
+        the backend excluded — out of scope, ccgram's own, hidden by convention
+        — from being adopted through the session-map path, which reaches this
+        code whenever a globally installed agent hook writes an entry for it.
         """
         if not self._new_window_callback:
             return
@@ -711,9 +755,10 @@ class SessionMonitor:
         from .thread_router import thread_router
 
         bound_window_ids = {wid for _, _, wid in thread_router.iter_thread_bindings()}
+        adoptable_lookup = _adoption_lookup(adoptable_window_ids)
         for window_id, details in current_map.items():
-            if window_id not in live_window_ids:
-                continue  # dead / __*__-filtered — skip
+            if canonical_window_id(window_id) not in adoptable_lookup:
+                continue  # dead, or the backend says it may not be adopted
             if window_id in bound_window_ids:
                 continue  # already has a topic
             event = NewWindowEvent(
@@ -793,6 +838,14 @@ class SessionMonitor:
                 # after a successful fold, re-read the hook file under its
                 # normal parser so the canonical key is what lifecycle sees.
                 all_windows = await list_windows_for_reconciliation(tmux_manager)
+                # Set before the session-map paths run, not after: they consume
+                # it. None while a listing is unavailable, so adoption fails
+                # closed instead of reusing a stale cycle's verdict.
+                adoptable_window_ids = (
+                    None
+                    if all_windows is None
+                    else {w.window_id for w in all_windows if w.topic_eligible}
+                )
                 if all_windows is None:
                     logger.warning(
                         "Multiplexer listing unavailable; skipping window reconciliation"
@@ -820,18 +873,23 @@ class SessionMonitor:
                 await self._read_hook_events()
 
                 await session_map_sync.load_session_map(raw_session_map)
-                current_map = await self._detect_and_cleanup_changes(raw_session_map)
+                current_map = await self._detect_and_cleanup_changes(
+                    raw_session_map, adoptable_window_ids=adoptable_window_ids
+                )
 
                 monitored_map = current_map
                 if all_windows is not None:
                     live_window_ids = {w.window_id for w in all_windows}
                     session_map_sync.prune_session_map(live_window_ids)
+                    # Pruning needs every live window; adoption needs only the
+                    # ones the backend says may be adopted. The listing is
+                    # complete on purpose, so the two sets differ.
                     known_window_ids = set(current_map.keys())
                     await self._emit_unbound_window_events(
                         all_windows, known_window_ids
                     )
                     await self._emit_known_unbound_window_events(
-                        current_map, live_window_ids
+                        current_map, adoptable_window_ids or set()
                     )
                     monitored_map = {
                         window_id: details

--- a/src/ccgram/status_cmd.py
+++ b/src/ccgram/status_cmd.py
@@ -43,38 +43,54 @@ def _active_multiplexer_name() -> str:
     return os.environ.get(_MULTIPLEXER_ENV, _DEFAULT_MULTIPLEXER)
 
 
-def _list_herdr_windows() -> list[dict[str, str]]:
-    """List herdr agent panes via the neutral seam. Returns list of {id, name}.
+def _list_herdr_windows() -> list[dict[str, str]] | None:
+    """List herdr agent panes via the neutral seam, as {id, name}.
 
-    Best-effort like ``_list_tmux_windows``: degrades to an empty list when the
-    herdr socket is unreachable or the backend errors, so ``ccgram status``
-    still prints state-file data.
+    ``None`` when the herdr socket is unreachable or the backend errors, like
+    ``_list_tmux_windows``: not an empty listing, which the caller renders as
+    every binding dead. ``ccgram status`` still prints its state-file data.
     """
-    # Lazy: the registry lazy-imports the backend; defer to keep status startup
-    # light and touch only the neutral seam (never a concrete backend, F1).
-    from .multiplexer import get_multiplexer
-
-    try:
-        windows = asyncio.run(get_multiplexer(_HERDR_BACKEND).list_windows())
-    except Exception:  # noqa: BLE001 — status is best-effort; degrade to empty
-        return []
-    return [{"id": w.window_id, "name": w.window_name} for w in windows]
+    return _live_windows(_HERDR_BACKEND)
 
 
-def _list_backend_windows(mux_name: str) -> list[dict]:
+def _list_backend_windows(mux_name: str) -> list[dict[str, str]] | None:
     """List windows through the seam, for a backend with no bespoke listing.
 
-    Best-effort like the herdr listing above: a failure degrades to empty so
-    status still prints its state-file data.
+    ``None`` when the backend could not be asked, like the herdr listing above:
+    the caller renders an empty listing as every binding dead. Best-effort
+    either way — status still prints its state-file data.
+    """
+    return _live_windows(mux_name)
+
+
+def _live_windows(mux_name: str) -> list[dict[str, str]] | None:
+    """List every live window on ``mux_name``, for the alive/dead column.
+
+    Reads the reconciliation listing, not ``list_windows``: status reports
+    liveness, and the selection listing applies the backend's visibility
+    filters — the agterm workspace scope, a herdr internal workspace, tmux's
+    hidden names. Reporting a bound session dead because it fell outside one
+    of those would be wrong, and dead bindings are what /sync Fix offers to
+    clean up.
+
+    Returns ``None`` when the listing could not be confirmed — a backend
+    error, or the backend's own ``None``. That is distinct from a confirmed
+    empty listing: an outage means every window is unknown, and rendering
+    unknown as ``dead`` is the same false claim this listing exists to
+    prevent. The state-file data is still printed either way.
     """
     # Lazy: the registry lazy-imports the backend; defer to keep status startup
     # light and touch only the neutral seam (never a concrete backend, F1).
     from .multiplexer import get_multiplexer
 
     try:
-        windows = asyncio.run(get_multiplexer(mux_name).list_windows())
-    except Exception:  # noqa: BLE001 — status is best-effort; degrade to empty
-        return []
+        windows = asyncio.run(
+            get_multiplexer(mux_name).list_windows_for_reconciliation()
+        )
+    except Exception:  # noqa: BLE001 — status is best-effort; unknown, not empty
+        return None
+    if windows is None:
+        return None
     return [{"id": w.window_id, "name": w.window_name} for w in windows]
 
 
@@ -86,8 +102,13 @@ def _read_json(path: Path) -> dict:
         return {}
 
 
-def _list_tmux_windows(session_name: str) -> list[dict[str, str]]:
-    """List tmux windows via subprocess. Returns list of {id, name}."""
+def _list_tmux_windows(session_name: str) -> list[dict[str, str]] | None:
+    """List tmux windows via subprocess, or ``None`` if tmux could not answer.
+
+    A missing or unresponsive tmux is not an empty server: reporting it as one
+    labels every binding dead. See ``_live_windows`` for the same distinction
+    on the seam backends.
+    """
     try:
         result = subprocess.run(
             [
@@ -103,7 +124,7 @@ def _list_tmux_windows(session_name: str) -> list[dict[str, str]]:
             timeout=5,
         )
         if result.returncode != 0:
-            return []
+            return None
         windows = []
         for line in result.stdout.strip().splitlines():
             parts = line.split("\t", 1)
@@ -111,7 +132,7 @@ def _list_tmux_windows(session_name: str) -> list[dict[str, str]]:
                 windows.append({"id": parts[0], "name": parts[1]})
         return windows
     except (OSError, subprocess.TimeoutExpired):  # fmt: skip
-        return []
+        return None
 
 
 def _capability_summary() -> tuple[str, str]:
@@ -130,6 +151,13 @@ def _capability_summary() -> tuple[str, str]:
         if flag
     ]
     return caps.name, ", ".join(flags) or "none"
+
+
+def _backend_line(label: str, windows: list[dict[str, str]] | None, unit: str) -> str:
+    """One-line backend summary; an unconfirmed listing says so, not zero."""
+    if windows is None:
+        return f"{label}: unreachable"
+    return f"{label}: {len(windows)} {unit}"
 
 
 def status_main() -> None:
@@ -152,16 +180,20 @@ def status_main() -> None:
     # Get live windows from the active multiplexer backend
     if mux_name == _HERDR_BACKEND:
         live_windows = _list_herdr_windows()
-        backend_line = f"Herdr: {len(live_windows)} pane(s)"
+        backend_line = _backend_line("Herdr", live_windows, "pane(s)")
     elif mux_name != _TMUX_BACKEND:
         # Any other backend answers through the seam; only tmux and herdr have
         # a bespoke listing, and routing a third backend into the tmux branch
         # reports its session count as zero.
         live_windows = _list_backend_windows(mux_name)
-        backend_line = f"{mux_name}: {len(live_windows)} session(s)"
+        backend_line = _backend_line(mux_name, live_windows, "session(s)")
     else:
         live_windows = _list_tmux_windows(session_name)
-        backend_line = f"Tmux session: {session_name} ({len(live_windows)} windows)"
+        backend_line = (
+            f"Tmux session: {session_name} (unreachable)"
+            if live_windows is None
+            else f"Tmux session: {session_name} ({len(live_windows)} windows)"
+        )
 
     # Build binding index: window_id -> (thread_id, user_id)
     thread_bindings = state.get("thread_bindings", {})
@@ -188,7 +220,7 @@ def status_main() -> None:
 
     # Show live windows first
     shown_ids: set[str] = set()
-    for w in live_windows:
+    for w in live_windows or []:
         wid = w["id"]
         name = display_names.get(wid, w["name"])
         shown_ids.add(wid)
@@ -201,10 +233,15 @@ def status_main() -> None:
         else:
             print(f"  {wid:<5} {name:<16}                              (unbound)")
 
-    # Show dead bindings (bound but window gone)
+    # Bound but not in the live listing. Only a confirmed listing makes that
+    # "dead"; an unconfirmed one makes it unknown, and /sync Fix acts on dead.
+    verdict = "unknown" if live_windows is None else "dead"
     for wid, (thread_id, user_id) in bound_windows.items():
         if wid not in shown_ids:
             name = display_names.get(wid, wid)
-            print(f"  {wid:<5} {name:<16} -> topic {thread_id} (user {user_id})   dead")
+            print(
+                f"  {wid:<5} {name:<16} -> topic {thread_id} "
+                f"(user {user_id})   {verdict}"
+            )
 
     sys.exit(0)

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -804,15 +804,21 @@ class TranscriptReader:
             raise
 
     async def _get_active_cwds(self) -> set[str]:
-        """Get normalized cwds of all active tmux windows."""
-        # Lazy: tmux_manager imports providers which transitively imports
-        # transcript_reader through provider format modules.
-        # Lazy: tmux_manager pulls providers eagerly; defer until pane lookup runs
-        from .multiplexer import multiplexer as tmux_manager
+        """Get normalised cwds of every live window.
+
+        Reads the complete listing, not the adoption-filtered one: this set
+        decides which transcripts are discoverable at all, so a live window a
+        backend merely will not auto-adopt (out of the agterm workspace scope,
+        under a herdr internal workspace, tmux-hidden) would have its history
+        silently invisible to /restore and the history pager.
+        """
+        # Lazy: importing the reconciliation seam at module load forms a cycle
+        # through providers, which import transcript_reader for their formats.
+        from .multiplexer.reconciliation import list_windows_for_reconciliation
 
         cwds: set[str] = set()
-        windows = await tmux_manager.list_windows()
-        for w in windows:
+        windows = await list_windows_for_reconciliation()
+        for w in windows or []:
             try:
                 cwds.add(str(Path(w.cwd).resolve()))
             except _PathResolveError:

--- a/tests/ccgram/handlers/test_sessions_dashboard.py
+++ b/tests/ccgram/handlers/test_sessions_dashboard.py
@@ -30,12 +30,16 @@ def deps() -> Iterator[SimpleNamespace]:
         patch("ccgram.handlers.sessions_dashboard.view_window") as view,
         patch("ccgram.handlers.sessions_dashboard.thread_router") as router,
         patch("ccgram.handlers.sessions_dashboard.tmux_manager") as mux,
+        patch(
+            "ccgram.handlers.sessions_dashboard.list_windows_for_reconciliation",
+            new_callable=AsyncMock,
+        ) as listing,
         patch("ccgram.handlers.sessions_dashboard.config") as config,
     ):
         router.get_all_thread_windows.return_value = {}
         router.get_display_name.side_effect = lambda wid: wid
         view.side_effect = lambda wid: WindowState()
-        mux.list_windows = AsyncMock(return_value=[])
+        listing.return_value = []
         config.is_user_allowed.return_value = True
 
         def _sessions(
@@ -44,19 +48,26 @@ def deps() -> Iterator[SimpleNamespace]:
             alive: list[str] | None = None,
             names: dict[str, str] | None = None,
             state: WindowState | None = None,
+            unavailable: bool = False,
         ) -> None:
             router.get_all_thread_windows.return_value = windows
             if names is not None:
                 router.get_display_name.side_effect = lambda wid: names[wid]
             if state is not None:
                 view.side_effect = lambda wid: state
+            if unavailable:
+                listing.return_value = None
+                return
             live = [] if alive is None else alive
-            mux.list_windows = AsyncMock(
-                return_value=[MagicMock(window_id=wid) for wid in live]
-            )
+            listing.return_value = [MagicMock(window_id=wid) for wid in live]
 
         yield SimpleNamespace(
-            view=view, router=router, mux=mux, config=config, sessions=_sessions
+            view=view,
+            router=router,
+            mux=mux,
+            listing=listing,
+            config=config,
+            sessions=_sessions,
         )
 
 
@@ -125,6 +136,32 @@ class TestBuildDashboard:
 
         assert "\U0001f7e2 alive" in text
         assert "⚫ dead" in text
+
+    async def test_liveness_comes_from_the_complete_listing(
+        self, deps: SimpleNamespace
+    ) -> None:
+        """Every id on this dashboard is already bound, so adoptability is
+        beside the point: a live window the backend merely will not auto-adopt
+        must still read as running."""
+        deps.sessions(windows={10: "@0"}, alive=["@0"], names={"@0": "out-of-scope"})
+        deps.mux.list_windows = AsyncMock(return_value=[])
+
+        text, _kb = await _build_dashboard(100)
+
+        assert "\U0001f7e2 out-of-scope" in text
+        assert "⚫" not in text
+
+    async def test_unreachable_multiplexer_is_not_reported_as_stopped(
+        self, deps: SimpleNamespace
+    ) -> None:
+        """A backend that could not be asked is unknown, not stopped."""
+        deps.sessions(windows={10: "@0"}, names={"@0": "proj"}, unavailable=True)
+
+        text, _kb = await _build_dashboard(100)
+
+        assert "⚪ proj" in text
+        assert "⚫" not in text
+        assert "\U0001f7e2" not in text
 
     @pytest.mark.parametrize(
         ("state", "expected_tag", "present"),

--- a/tests/ccgram/handlers/test_sync_command.py
+++ b/tests/ccgram/handlers/test_sync_command.py
@@ -1,9 +1,14 @@
+import contextlib
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from telegram.error import BadRequest, TelegramError
 
+from ccgram.multiplexer.base import WindowRef
+from ccgram.session import SessionManager
+from ccgram.thread_router import thread_router
+from ccgram.handlers.sync_command import _run_audit
 from ccgram.handlers.callback_data import CB_SYNC_DISMISS, CB_SYNC_FIX
 from ccgram.handlers.sync_command import (
     _cleanup_retired_topics,
@@ -32,6 +37,11 @@ def _patch_deps():
         patch(
             "ccgram.handlers.sync_command.list_windows_for_reconciliation"
         ) as mock_listing,
+        # still_adoptable lives in topic_orchestration and reads its own
+        # backend reference, so the same listing has to answer there.
+        patch(
+            "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+        ) as mock_tm_topics,
         patch("ccgram.handlers.sync_command.config") as mock_cfg,
     ):
         mock_sm.audit_state.return_value = AuditResult(
@@ -41,6 +51,7 @@ def _patch_deps():
         mock_sm.window_states = {}
         mock_tm.list_windows = AsyncMock(return_value=[])
         mock_tm.list_windows_for_reconciliation = mock_listing
+        mock_tm_topics.list_windows_for_reconciliation = mock_listing
         mock_listing.return_value = []
         mock_cfg.is_user_allowed.return_value = True
         yield mock_sm, mock_sms, mock_wq, mock_tr, mock_tm, mock_cfg
@@ -778,8 +789,30 @@ class TestSyncFix:
                 100, 42, retirement_reason="remote_removed"
             )
 
+    @staticmethod
+    def _listing(mock_tm, *refs) -> None:
+        """Set the confirmed listing both the audit and adoption read.
+
+        An orphaned_window issue means a live unbound window, so the window
+        must be in the listing: an issue with an empty listing is a state no
+        backend produces.
+        """
+        mock_tm.list_windows_for_reconciliation.return_value = list(refs)
+
+    @staticmethod
+    def _ref(window_id: str, name: str, *, eligible: bool = True):
+        from ccgram.multiplexer.base import WindowRef
+
+        return WindowRef(
+            window_id=window_id,
+            window_name=name,
+            cwd="/tmp",
+            topic_eligible=eligible,
+        )
+
     async def test_fix_adopts_orphaned_windows(self, _patch_deps) -> None:
-        mock_sm, _, mock_wq, _, _, _ = _patch_deps
+        mock_sm, _, mock_wq, _, mock_tm, _ = _patch_deps
+        self._listing(mock_tm, self._ref("w2:t5", "stray-proj"))
         mock_sm.audit_state.side_effect = [
             AuditResult(
                 issues=[
@@ -808,6 +841,146 @@ class TestSyncFix:
             event = mock_handle.call_args[0][0]
             assert event.window_id == "w2:t5"
             assert event.window_name == "stray-proj"
+
+    async def test_fix_does_not_adopt_a_window_that_became_ineligible(
+        self, _patch_deps
+    ) -> None:
+        """The audit's verdict is re-read at the point of adoption.
+
+        /sync Fix probes every bound topic over the network between the audit
+        and the adoption, so the listing behind an orphaned_window issue can be
+        seconds old. A window that moved out of scope, or went away, in that
+        gap must not be handed a topic.
+        """
+        mock_sm, _, mock_wq, _, mock_tm, _ = _patch_deps
+        mock_sm.audit_state.side_effect = [
+            AuditResult(
+                issues=[AuditIssue("orphaned_window", "w2:t5 (stray)", fixable=True)],
+                total_bindings=1,
+                live_binding_count=1,
+            ),
+            AuditResult(issues=[], total_bindings=1, live_binding_count=1),
+        ]
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="stray-proj"
+        )
+        # First read (the audit) sees it adoptable; by the adoption read it has
+        # moved out of scope.
+        mock_tm.list_windows_for_reconciliation.side_effect = [
+            [self._ref("w2:t5", "stray-proj")],
+            [self._ref("w2:t5", "stray-proj", eligible=False)],
+            [self._ref("w2:t5", "stray-proj", eligible=False)],
+        ]
+
+        query = MagicMock()
+
+        with (
+            patch("ccgram.handlers.sync_command.safe_edit"),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+                new_callable=AsyncMock,
+            ) as mock_handle,
+        ):
+            await handle_sync_fix(query)
+
+        mock_handle.assert_not_called()
+
+    async def test_second_orphan_is_judged_after_the_first_is_created(
+        self, _patch_deps
+    ) -> None:
+        """The re-read is per candidate, not once for the batch.
+
+        Creating a topic is several Telegram round-trips on its own, so a
+        batch-wide snapshot judges the second orphan on a listing taken before
+        the first one's topic existed. Here B leaves scope while A is being
+        created, and must not reach handle_new_window.
+        """
+        mock_sm, _, mock_wq, _, mock_tm, _ = _patch_deps
+        mock_sm.audit_state.side_effect = [
+            AuditResult(
+                issues=[
+                    AuditIssue("orphaned_window", "w2:tA (a)", fixable=True),
+                    AuditIssue("orphaned_window", "w2:tB (b)", fixable=True),
+                ],
+                total_bindings=2,
+                live_binding_count=2,
+            ),
+            AuditResult(issues=[], total_bindings=2, live_binding_count=2),
+        ]
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="proj"
+        )
+
+        both_live = [self._ref("w2:tA", "a"), self._ref("w2:tB", "b")]
+        b_left_scope = [
+            self._ref("w2:tA", "a"),
+            self._ref("w2:tB", "b", eligible=False),
+        ]
+
+        # Creating A's topic is what takes B out of scope, so the flip happens
+        # exactly where a batch-wide snapshot would already have been taken.
+        state = {"windows": both_live}
+
+        async def _listing(*_a, **_kw):
+            return state["windows"]
+
+        # Mutate, never rebind: the fixture aliases this attribute to the
+        # module-level helper patch, and replacing it breaks the alias.
+        mock_tm.list_windows_for_reconciliation.side_effect = _listing
+
+        query = MagicMock()
+
+        with (
+            patch("ccgram.handlers.sync_command.safe_edit"),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+                new_callable=AsyncMock,
+            ) as mock_handle,
+        ):
+
+            async def _create(*_a, **_kw):
+                state["windows"] = b_left_scope
+
+            mock_handle.side_effect = _create
+            await handle_sync_fix(query)
+
+        adopted = [call[0][0].window_id for call in mock_handle.call_args_list]
+        assert adopted == ["w2:tA"]
+
+    async def test_fix_adopts_nothing_when_the_listing_goes_away(
+        self, _patch_deps
+    ) -> None:
+        """Adoption is the one step here that is safe to skip and retry."""
+        mock_sm, _, mock_wq, _, mock_tm, _ = _patch_deps
+        mock_sm.audit_state.side_effect = [
+            AuditResult(
+                issues=[AuditIssue("orphaned_window", "w2:t5 (stray)", fixable=True)],
+                total_bindings=1,
+                live_binding_count=1,
+            ),
+            AuditResult(issues=[], total_bindings=1, live_binding_count=1),
+        ]
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="stray-proj"
+        )
+        mock_tm.list_windows_for_reconciliation.side_effect = [
+            [self._ref("w2:t5", "stray-proj")],
+            None,
+            [self._ref("w2:t5", "stray-proj")],
+        ]
+
+        query = MagicMock()
+
+        with (
+            patch("ccgram.handlers.sync_command.safe_edit"),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+                new_callable=AsyncMock,
+            ) as mock_handle,
+        ):
+            await handle_sync_fix(query)
+
+        mock_handle.assert_not_called()
 
 
 class TestDeadTopicDetection:
@@ -899,6 +1072,28 @@ class TestPrivateTopicSyncLifecycle:
 
 
 class TestDeadTopicRecreation:
+    """A dead topic is a live window whose Telegram topic was deleted.
+
+    So the window is present in the listing throughout: recreation is refused
+    unless it is confirmed present, because the repair unbinds the thread
+    before creating the replacement.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _window_is_live(self, _patch_deps):
+        """Whatever window a case binds, report it live."""
+        from ccgram.multiplexer.base import WindowRef
+
+        _, _, _, mock_tr, mock_tm, _ = _patch_deps
+
+        async def _listing(*_a, **_kw):
+            bound = mock_tr.get_window_for_thread.return_value
+            if not isinstance(bound, str):
+                return []
+            return [WindowRef(window_id=bound, window_name="proj", cwd="/tmp/proj")]
+
+        mock_tm.list_windows_for_reconciliation.side_effect = _listing
+
     async def test_skips_stale_issue_after_topic_was_rebound(self, _patch_deps) -> None:
         _mock_sm, _mock_sms, mock_wq, mock_tr, _mock_tm, _mock_cfg = _patch_deps
         mock_wq.view_window.return_value = MagicMock(
@@ -1078,7 +1273,15 @@ class TestDeadTopicRecreation:
 
 class TestSyncFixDeadTopic:
     async def test_fix_recreates_dead_topics(self, _patch_deps) -> None:
-        mock_sm, _, mock_wq, mock_tr, _, _ = _patch_deps
+        from ccgram.multiplexer.base import WindowRef
+
+        mock_sm, _, mock_wq, mock_tr, mock_tm, _ = _patch_deps
+        # The window is live throughout — a dead *topic* is a deleted Telegram
+        # topic, not a dead window — and recreation is refused unless the
+        # window is confirmed present at that point.
+        mock_tm.list_windows_for_reconciliation.return_value = [
+            WindowRef(window_id="@2", window_name="qmd-go", cwd="/tmp")
+        ]
         mock_sm.audit_state.side_effect = [
             AuditResult(issues=[], total_bindings=1, live_binding_count=1),
             AuditResult(issues=[], total_bindings=1, live_binding_count=1),
@@ -1117,3 +1320,179 @@ class TestSyncFixDeadTopic:
             mock_handle.assert_called_once()
             report_text = mock_edit.call_args[0][1]
             assert "Recreated 1 topic" in report_text
+
+
+class TestSyncAuditSeparatesLivenessFromAdoption:
+    """`/sync` Fix adopts the orphans the audit reports, so adoption takes the
+    backend's verdict — but liveness must stay complete, or a live binding to
+    an excluded window becomes a fixable ghost that Fix closes.
+    """
+
+    @staticmethod
+    def _windows() -> list[WindowRef]:
+        return [
+            WindowRef(
+                window_id="REFUSED",
+                window_name="elsewhere",
+                cwd="/other",
+                pane_current_command="claude",
+                topic_eligible=False,
+            ),
+            WindowRef(
+                window_id="ALLOWED",
+                window_name="agent",
+                cwd="/proj",
+                pane_current_command="claude",
+            ),
+        ]
+
+    async def test_audit_gets_every_window_live_and_only_some_adoptable(self):
+        """Backend-shaped: the UI listing omits what the backend refuses.
+
+        Mocking ``list_windows`` to return the refused window described a state
+        real agterm cannot produce, so it could not expose the defect. The
+        audit must take liveness from the reconciliation listing, which keeps
+        the refused window, and adoptability from its ``topic_eligible``.
+        """
+        with (
+            patch("ccgram.handlers.sync_command.tmux_manager") as mock_tmux,
+            patch(
+                "ccgram.handlers.sync_command.list_windows_for_reconciliation",
+                new_callable=AsyncMock,
+                return_value=self._windows(),
+            ),
+            patch("ccgram.handlers.sync_command.session_manager") as mock_sm,
+        ):
+            # what a real backend does: the UI listing hides the refused one
+            mock_tmux.list_windows = AsyncMock(
+                return_value=[w for w in self._windows() if w.topic_eligible]
+            )
+            mock_sm.audit_state.return_value = MagicMock(issues=[])
+
+            await _run_audit()
+
+            live_ids, live_pairs, adoptable = mock_sm.audit_state.call_args[0]
+
+        # liveness is not narrowed: the excluded window still exists
+        assert live_ids == {"REFUSED", "ALLOWED"}
+        assert {wid for wid, _ in live_pairs} == {"REFUSED", "ALLOWED"}
+        # adoption is
+        assert adoptable == {"ALLOWED"}
+
+    async def test_an_unavailable_listing_does_not_declare_everything_dead(self):
+        with (
+            patch(
+                "ccgram.handlers.sync_command.list_windows_for_reconciliation",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("ccgram.handlers.sync_command.session_manager") as mock_sm,
+        ):
+            result = await _run_audit()
+
+        assert result is None
+        mock_sm.audit_state.assert_not_called()
+
+    def test_a_live_but_ineligible_binding_is_not_a_ghost(self):
+        """The regression my first attempt at this introduced.
+
+        Narrowing the live set made an existing topic, whose session merely
+        stopped qualifying for new adoption, look like a fixable ghost.
+        """
+        sm = SessionManager()
+        thread_router.bind_thread(1, 2, "REFUSED", chat_id=-100)
+
+        audit = sm.audit_state(
+            {"REFUSED", "ALLOWED"},
+            [("REFUSED", "elsewhere"), ("ALLOWED", "agent")],
+            {"ALLOWED"},
+        )
+
+        ghosts = [i for i in audit.issues if i.category == "ghost_binding"]
+        assert not ghosts, "a live window is not a ghost merely by being excluded"
+
+    def test_an_ineligible_window_is_not_a_fixable_orphan(self):
+        """Both windows must be orphan *candidates*, or this asserts nothing.
+
+        A window becomes an orphan only when ccgram already knows it (session
+        map or window state) and no topic is bound to it. With a fresh manager
+        that set is empty, no orphans are produced at all, and a check that
+        merely says "no orphan mentions REFUSED" passes without running.
+        """
+        sm = SessionManager()
+        with patch.object(
+            SessionManager,
+            "_get_session_map_window_ids",
+            return_value={"REFUSED", "ALLOWED"},
+        ):
+            audit = sm.audit_state(
+                {"REFUSED", "ALLOWED"},
+                [("REFUSED", "elsewhere"), ("ALLOWED", "agent")],
+                {"ALLOWED"},
+            )
+
+        orphans = [i for i in audit.issues if i.category == "orphaned_window"]
+        # the eligible one is offered for adoption...
+        assert any("ALLOWED" in i.detail for i in orphans), (
+            "the eligible window must be a candidate, or the check below is empty"
+        )
+        # ...and the refused one is not
+        assert not any("REFUSED" in i.detail for i in orphans)
+
+    async def test_handle_sync_fix_passes_both_sets_and_never_adopts_the_refused(
+        self,
+    ):
+        """The mutating path. ``handle_sync_fix`` does not call ``_run_audit``,
+        so testing that function proved nothing about pressing Fix.
+        """
+        query = MagicMock()
+        query.get_bot.return_value = MagicMock()
+
+        with (
+            patch(
+                "ccgram.handlers.sync_command.list_windows_for_reconciliation",
+                new_callable=AsyncMock,
+                return_value=self._windows(),
+            ),
+            patch("ccgram.handlers.sync_command.session_manager") as mock_sm,
+            patch("ccgram.handlers.sync_command.session_map_sync"),
+            patch("ccgram.handlers.sync_command.user_preferences"),
+            patch("ccgram.handlers.sync_command.window_query"),
+            patch("ccgram.handlers.sync_command.safe_edit", new_callable=AsyncMock),
+            patch(
+                "ccgram.handlers.sync_command._probe_dead_topics",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "ccgram.handlers.sync_command._retired_topic_issues", return_value=[]
+            ),
+            patch(
+                "ccgram.handlers.sync_command._sync_live_topic_names",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "ccgram.handlers.sync_command._adopt_orphaned_windows",
+                new_callable=AsyncMock,
+            ) as mock_adopt,
+            patch(
+                "ccgram.handlers.sync_command._close_ghost_topics",
+                new_callable=AsyncMock,
+                return_value=(0, 0),
+            ),
+        ):
+            mock_sm.audit_state.return_value = MagicMock(issues=[])
+            with contextlib.suppress(Exception):
+                await handle_sync_fix(query)
+
+            # The later stages are mocked out and can raise on their mocks; the
+            # claim is about the audit call the fix path makes.
+            audits = [c for c in mock_sm.audit_state.call_args_list if len(c[0]) == 3]
+            assert audits, "handle_sync_fix must pass both sets to audit_state"
+            live_ids, live_pairs, adoptable = audits[0][0]
+
+        assert live_ids == {"REFUSED", "ALLOWED"}, "pruning needs every window"
+        assert adoptable == {"ALLOWED"}
+        for call in mock_adopt.call_args_list:
+            for issue in call[0][1]:
+                assert "REFUSED" not in getattr(issue, "detail", "")

--- a/tests/ccgram/handlers/topics/test_new_window_sync.py
+++ b/tests/ccgram/handlers/topics/test_new_window_sync.py
@@ -73,6 +73,9 @@ def _wire_orchestration(
 
 
 async def _detect(monitor: SessionMonitor, session_map: dict) -> None:
+    # Adoption is gated on the backend's verdict from the current listing, which
+    # the monitor loop derives before reaching this call. These windows are live
+    # and on tmux every live window is adoptable, so mirror that here.
     with patch.object(
         monitor,
         "_load_current_session_map",
@@ -80,7 +83,7 @@ async def _detect(monitor: SessionMonitor, session_map: dict) -> None:
         new_callable=AsyncMock,
         return_value=session_map,
     ):
-        await monitor._detect_and_cleanup_changes()
+        await monitor._detect_and_cleanup_changes(adoptable_window_ids=set(session_map))
 
 
 class TestNewWindowSyncWithBindings:

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from telegram.error import BadRequest, RetryAfter, TelegramError, TimedOut
 
+from ccgram.multiplexer.base import WindowRef
 from ccgram.handlers.topics.topic_orchestration import (
     collect_target_chats,
     _is_window_already_bound,
@@ -33,6 +34,10 @@ def _mock_tmux():
     mock_window.pane_current_command = ""
     with patch("ccgram.handlers.topics.topic_orchestration.tmux_manager") as mock_tmux:
         mock_tmux.find_window_by_id = AsyncMock(return_value=mock_window)
+        # still_present reads this listing, and a confirmed empty one means
+        # "that window is gone" — the default the rebind tests below want. A
+        # test that needs the old window alive supplies it explicitly.
+        mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
         yield mock_tmux
 
 
@@ -554,6 +559,8 @@ class TestHandleNewWindow:
             mock_tr.get_display_name.return_value = "🟡 reflex-gh"
             mock_tr.resolve_chat_id.return_value = -100200
             mock_tmux.find_window_by_id = AsyncMock(return_value=None)
+            # Confirmed empty: the old window really is gone, not unreachable.
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
 
             await handle_new_window(event, bot)
 
@@ -587,6 +594,10 @@ class TestHandleNewWindow:
         ):
             mock_tmux.capabilities.supports_display_name_rebind = False
             mock_tmux.find_window_by_id = AsyncMock(return_value=None)
+            # Confirmed empty: the old window really is gone, not unreachable.
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
+            # Confirmed empty: the old window really is gone, not unreachable.
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
             mock_tr.has_window.return_value = False
             mock_tr.iter_thread_bindings.return_value = iter([(100, 120014, "old")])
             mock_tr.resolve_chat_id.return_value = -100200
@@ -626,6 +637,8 @@ class TestHandleNewWindow:
             mock_tr.get_display_name.return_value = "reflex-gh"
             mock_tr.resolve_chat_id.return_value = -100200
             mock_tmux.find_window_by_id = AsyncMock(return_value=None)
+            # Confirmed empty: the old window really is gone, not unreachable.
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
             mock_tr.group_chat_ids = {"100:120014": -100200}
             mock_config.group_id = None
             mock_config.allowed_users = {100}
@@ -716,7 +729,9 @@ class TestAdoptUnboundWindows:
                 new_callable=AsyncMock,
             ) as mock_adopt,
         ):
-            mock_tmux.list_windows = AsyncMock(return_value=[mock_window])
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(
+                return_value=[mock_window]
+            )
             mock_sm.audit_state.return_value = self._audit("orphaned_window")
 
             await adopt_unbound_windows(bot)
@@ -738,9 +753,123 @@ class TestAdoptUnboundWindows:
                 new_callable=AsyncMock,
             ) as mock_adopt,
         ):
-            mock_tmux.list_windows = AsyncMock(return_value=[])
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
             mock_sm.audit_state.return_value = self._audit()
 
             await adopt_unbound_windows(bot)
 
         mock_adopt.assert_not_called()
+
+
+class TestAdoptUnboundWindowsRespectsEligibility:
+    """Startup orphan repair creates topics, so it takes the backend's verdict.
+
+    Adoption narrows, liveness does not: narrowing the live set would turn a
+    present-but-excluded window into a fixable ghost, which is what the first
+    attempt at this did.
+    """
+
+    async def test_an_ineligible_window_is_live_but_not_adoptable(self):
+        bot = AsyncMock()
+        refused = WindowRef(
+            window_id="OUT-OF-SCOPE",
+            window_name="elsewhere",
+            cwd="/other",
+            pane_current_command="claude",
+            topic_eligible=False,
+        )
+        allowed = WindowRef(
+            window_id="IN-SCOPE",
+            window_name="agent",
+            cwd="/proj",
+            pane_current_command="claude",
+        )
+
+        with (
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.session_manager"
+            ) as mock_sm,
+            patch(
+                "ccgram.handlers.sync_command._adopt_orphaned_windows",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(
+                return_value=[refused, allowed]
+            )
+            audit = MagicMock()
+            audit.issues = []
+            mock_sm.audit_state.return_value = audit
+
+            await adopt_unbound_windows(bot)
+
+            live_ids, live_pairs, adoptable = mock_sm.audit_state.call_args[0]
+
+        # Liveness stays complete: a present-but-excluded window is not a ghost.
+        assert live_ids == {"OUT-OF-SCOPE", "IN-SCOPE"}
+        assert {wid for wid, _ in live_pairs} == {"OUT-OF-SCOPE", "IN-SCOPE"}
+        # Only adoption is narrowed.
+        assert adoptable == {"IN-SCOPE"}
+
+
+class TestAdoptUnboundWindowsNeedsAConfirmedListing:
+    """Startup repair creates topics; it must not run on a guess."""
+
+    async def test_unavailable_listing_adopts_nothing(self):
+        bot = AsyncMock()
+
+        with (
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.session_manager"
+            ) as mock_sm,
+            patch(
+                "ccgram.handlers.sync_command._adopt_orphaned_windows",
+                new_callable=AsyncMock,
+            ) as mock_adopt,
+        ):
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=None)
+
+            await adopt_unbound_windows(bot)
+
+        mock_adopt.assert_not_called()
+        mock_sm.audit_state.assert_not_called()
+
+
+class TestStillAdoptable:
+    """The point-of-use check behind every automatic adoption."""
+
+    @staticmethod
+    def _ref(window_id: str, *, eligible: bool):
+        return WindowRef(
+            window_id=window_id,
+            window_name="proj",
+            cwd="/proj",
+            topic_eligible=eligible,
+        )
+
+    async def _verdict(self, windows) -> bool:
+        from ccgram.handlers.topics.topic_orchestration import still_adoptable
+
+        with patch(
+            "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+        ) as mock_tmux:
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=windows)
+            return await still_adoptable("@5")
+
+    async def test_eligible_window_passes(self):
+        assert await self._verdict([self._ref("@5", eligible=True)]) is True
+
+    async def test_window_that_left_scope_is_refused(self):
+        assert await self._verdict([self._ref("@5", eligible=False)]) is False
+
+    async def test_window_that_went_away_is_refused(self):
+        assert await self._verdict([self._ref("@9", eligible=True)]) is False
+
+    async def test_unconfirmed_listing_is_refused(self):
+        assert await self._verdict(None) is False

--- a/tests/ccgram/providers/test_autodetect.py
+++ b/tests/ccgram/providers/test_autodetect.py
@@ -307,7 +307,7 @@ class TestSessionMonitorProviderFromMap:
             ),
             patch("ccgram.session.session_manager") as mock_sm,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=None)
             mock_sm.set_window_provider.assert_called_once_with("@5", "codex")
 
     async def test_skips_provider_when_not_in_map(self, tmp_path) -> None:
@@ -335,5 +335,5 @@ class TestSessionMonitorProviderFromMap:
             ),
             patch("ccgram.session.session_manager") as mock_sm,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=None)
             mock_sm.set_window_provider.assert_not_called()

--- a/tests/ccgram/test_agterm_backend.py
+++ b/tests/ccgram/test_agterm_backend.py
@@ -896,18 +896,32 @@ async def test_create_window_falls_back_to_the_cwd_basename(tmp_path) -> None:
 
 
 async def test_listings_exclude_the_session_ccgram_itself_runs_in() -> None:
-    """Every listed window is one discovery can auto-adopt.
+    """ccgram's own session is never offered, in either listing.
 
     The tmux backend skips ``config.own_window_id`` for this reason; without
-    the equivalent the bot binds a topic to its own terminal.
+    the equivalent the bot binds a topic to its own terminal. This exclusion is
+    not the ``topic_eligible`` verdict, which governs unattended adoption only:
+    a picker selection is an explicit bind and may name a window this listing
+    would not auto-adopt. Binding the bot's own session is wrong either way.
     """
     fake = (
         FakeAgtermctl()
         .on("window", "list", out=_windows())
         .on("tree", out=_tree(_session(SESSION_A), _session(SESSION_B, name="blog")))
     )
-    windows = await _manager(fake, own=SESSION_A).list_windows()
-    assert [w.window_id for w in windows] == [SESSION_B]
+    manager = _manager(fake, own=SESSION_A)
+
+    # Gone from the selection listing: the picker must never offer it.
+    assert [w.window_id for w in await manager.list_windows()] == [SESSION_B]
+
+    # Present in the complete listing, because it exists — but refused for
+    # adoption there, which is what keeps discovery off it.
+    complete = await manager.list_windows_for_reconciliation()
+    assert complete is not None
+    assert {w.window_id: w.topic_eligible for w in complete} == {
+        SESSION_A: False,
+        SESSION_B: True,
+    }
 
 
 async def test_own_session_exclusion_is_case_insensitive() -> None:
@@ -1205,3 +1219,180 @@ async def test_reconciliation_ignores_the_workspace_scope() -> None:
     ).list_windows_for_reconciliation()
     assert windows is not None
     assert sorted(w.window_id for w in windows) == sorted([SESSION_A, SESSION_B])
+
+
+# ── adoption travels on the window ─────────────────────────────────────
+
+
+async def test_reconciliation_listing_marks_what_discovery_may_not_adopt() -> None:
+    """The listing stays complete, but each window carries its verdict.
+
+    session_monitor hands the reconciliation listing straight to discovery, so
+    a filter that lives only in list_windows never runs for discovery at all.
+    """
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on(
+            "tree",
+            out=_multi_tree(
+                {
+                    "code": [_session(SESSION_A, name="agent")],
+                    "personal": [_session(SESSION_B, name="elsewhere")],
+                }
+            ),
+        )
+    )
+    windows = await _manager(
+        fake, workspaces=("code",)
+    ).list_windows_for_reconciliation()
+    assert windows is not None
+    by_name = {w.window_name: w.topic_eligible for w in windows}
+    # both present, so cleanup still sees everything that exists
+    assert set(by_name) == {"agent", "elsewhere"}
+    # but only the in-scope one may be adopted
+    assert by_name == {"agent": True, "elsewhere": False}
+
+
+async def test_own_session_is_marked_ineligible_in_the_reconciliation_listing() -> None:
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on("tree", out=_tree(_session(SESSION_A), _session(SESSION_B, name="other")))
+    )
+    windows = await _manager(
+        fake, own=SESSION_A, workspaces=None
+    ).list_windows_for_reconciliation()
+    assert windows is not None
+    assert {w.window_id: w.topic_eligible for w in windows} == {
+        SESSION_A: False,
+        SESSION_B: True,
+    }
+
+
+async def test_underscore_named_sessions_are_marked_ineligible() -> None:
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on("tree", out=_tree(_session(SESSION_A, name="_scratch")))
+    )
+    windows = await _manager(fake, workspaces=None).list_windows_for_reconciliation()
+    assert windows is not None
+    assert windows[0].topic_eligible is False
+
+
+async def test_find_window_by_id_is_not_gated_by_eligibility() -> None:
+    """Addressing a known id is not discovery: an out-of-scope window stays drivable."""
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on("tree", out=_multi_tree({"personal": [_session(SESSION_A)]}))
+    )
+    found = await _manager(fake, workspaces=("code",)).find_window_by_id(SESSION_A)
+    assert found is not None
+    assert found.window_id == SESSION_A
+
+
+async def test_a_non_agent_session_in_scope_is_present_but_ineligible() -> None:
+    """Present for cleanup, refused for adoption.
+
+    agterm reports whatever holds the pane, so an in-scope session running an
+    editor or a build must not be adopted, while still existing as far as
+    reconciliation is concerned.
+    """
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on(
+            "tree",
+            out=_tree(
+                _session(SESSION_A, name="editing", foreground=["vim", "notes.md"]),
+                _session(SESSION_B, name="agent", foreground=["claude"]),
+            ),
+        )
+    )
+    windows = await _manager(fake).list_windows_for_reconciliation()
+    assert windows is not None
+    assert {w.window_name: w.topic_eligible for w in windows} == {
+        "editing": False,
+        "agent": True,
+    }
+
+
+async def test_a_non_agent_session_in_scope_is_still_offered_for_explicit_binding() -> (
+    None
+):
+    """The selection listing narrows by visibility, never by adoptability.
+
+    This is the case the three-question contract rests on: `list_windows`
+    keeps an in-scope session running an editor, carrying
+    ``topic_eligible=False``, so a user can bind it from the picker while
+    unattended discovery — which reads the reconciliation listing and this
+    verdict — leaves it alone. Filtering it out here would silently remove a
+    session the user can see in agterm from the picker.
+    """
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on(
+            "tree",
+            out=_tree(
+                _session(SESSION_A, name="editing", foreground=["vim", "notes.md"]),
+                _session(SESSION_B, name="agent", foreground=["claude"]),
+            ),
+        )
+    )
+
+    windows = await _manager(fake).list_windows()
+
+    assert {w.window_name: w.topic_eligible for w in windows} == {
+        "editing": False,
+        "agent": True,
+    }
+
+
+async def test_a_wrapped_agent_is_eligible() -> None:
+    """codex runs as ``node .../codex``; argv[0] alone would reject it."""
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on(
+            "tree",
+            out=_tree(
+                _session(
+                    SESSION_A,
+                    name="codex-session",
+                    foreground=["node", "/opt/homebrew/bin/codex", "--yolo"],
+                )
+            ),
+        )
+    )
+    windows = await _manager(fake).list_windows_for_reconciliation()
+    assert windows is not None
+    assert windows[0].topic_eligible is True
+
+
+async def test_a_build_running_under_node_is_not_an_agent() -> None:
+    """The wrapper skip must not turn every node process into an agent."""
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on(
+            "tree",
+            out=_tree(_session(SESSION_A, foreground=["node", "server.js"])),
+        )
+    )
+    windows = await _manager(fake).list_windows_for_reconciliation()
+    assert windows is not None
+    assert windows[0].topic_eligible is False
+
+
+async def test_an_idle_shell_session_is_ineligible() -> None:
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on("tree", out=_tree(_session(SESSION_A, foreground=None)))
+    )
+    windows = await _manager(fake).list_windows_for_reconciliation()
+    assert windows is not None
+    assert windows[0].topic_eligible is False

--- a/tests/ccgram/test_bootstrap.py
+++ b/tests/ccgram/test_bootstrap.py
@@ -390,3 +390,55 @@ class TestVerifyHooksInstalled:
 
         logger.info.assert_not_called()
         logger.warning.assert_not_called()
+
+
+class TestNewWindowCallbackChecksEligibility:
+    """The monitor's automatic creation sink re-reads the verdict per window.
+
+    Discovery emits a batch and this callback awaits each topic creation in
+    turn, so without a fresh read the last window in a batch is judged on a
+    listing taken before the first one's topic existed. Explicit binds go
+    straight to handle_new_window and are not affected.
+    """
+
+    @staticmethod
+    async def _callback(app):
+        with patch("ccgram.bootstrap.SessionMonitor") as monitor_cls:
+            instance = MagicMock()
+            instance.start = MagicMock()
+            monitor_cls.return_value = instance
+            await bootstrap.start_session_monitor(app)
+        return instance.set_new_window_callback.call_args[0][0]
+
+    async def _run(self, *, adoptable: bool):
+        from ccgram.session_monitor import NewWindowEvent
+
+        app = _make_app()
+        bootstrap.wire_runtime_callbacks()
+        callback = await self._callback(app)
+
+        with (
+            patch(
+                "ccgram.bootstrap._still_adoptable",
+                new_callable=AsyncMock,
+                return_value=adoptable,
+            ),
+            patch(
+                "ccgram.bootstrap._handle_new_window",
+                new_callable=AsyncMock,
+            ) as handle,
+        ):
+            await callback(
+                NewWindowEvent(
+                    window_id="@5", session_id="s", window_name="proj", cwd="/proj"
+                )
+            )
+        return handle
+
+    async def test_adoptable_window_gets_a_topic(self):
+        handle = await self._run(adoptable=True)
+        handle.assert_awaited_once()
+
+    async def test_window_that_is_no_longer_adoptable_gets_none(self):
+        handle = await self._run(adoptable=False)
+        handle.assert_not_awaited()

--- a/tests/ccgram/test_herdr_backend.py
+++ b/tests/ccgram/test_herdr_backend.py
@@ -1163,14 +1163,21 @@ async def test_implicit_workspace_is_closed_for_tab_and_session_failures(
 
 
 async def test_duplicate_live_targets_are_quarantined_without_hiding_others() -> None:
+    """Quarantined records stay unaddressable, and liveness becomes unknown.
+
+    The duplicate panes are live and ccgram may hold bindings to them, so a
+    listing that silently omits them is not an account of what exists. Handing
+    that partial subset back as complete makes those bindings look like ghosts,
+    which the audit, the polling loop and the destructive guards act on.
+    Addressing is a different question and still refuses the ambiguous target.
+    """
     duplicate = _agent(pane_id="w9:p1", tab_id="w9:t1", value="same")
     unrelated = _agent(pane_id="w9:p2", tab_id="w9:t2", value="other")
     fake = _live_fake(duplicate, duplicate, unrelated)
 
     manager = _manager(fake)
-    windows = await manager.list_windows_for_reconciliation()
-    assert windows is not None
-    assert [window.window_id for window in windows] == [_target("other")]
+
+    assert await manager.list_windows_for_reconciliation() is None
     assert await manager.find_window_by_id(_target("same")) is None
     assert await manager.find_window_by_id(_target("other")) is not None
 
@@ -1181,10 +1188,7 @@ async def test_distinct_targets_on_one_pane_are_quarantined() -> None:
     unrelated = _agent(pane_id="w9:p2", tab_id="w9:t1", value="other")
     fake = _live_fake(first, second, unrelated)
 
-    windows = await _manager(fake).list_windows_for_reconciliation()
-
-    assert windows is not None
-    assert [window.window_id for window in windows] == [_target("other")]
+    assert await _manager(fake).list_windows_for_reconciliation() is None
     assert await _manager(fake).find_window_by_id(_target("first")) is None
     assert await _manager(fake).find_window_by_id(_target("second")) is None
     assert await _manager(fake).capture_pane(_target("first")) is None
@@ -1448,7 +1452,9 @@ async def test_agent_status_and_workspace_list_fail_closed_on_malformed_fields()
     assert await _manager(malformed_workspaces).list_workspaces() == []
 
 
-async def test_reconciliation_filters_internal_workspace_and_tab_labels() -> None:
+async def test_reconciliation_keeps_internal_records_but_marks_them_unadoptable() -> (
+    None
+):
     visible = _agent(value="visible")
     internal_workspace = _agent(
         value="workspace-internal", workspace_id="internal", pane_id="w2:p2"
@@ -1478,9 +1484,21 @@ async def test_reconciliation_filters_internal_workspace_and_tab_labels() -> Non
             ),
         )
     )
-    windows = await _manager(fake).list_windows_for_reconciliation()
+    manager = _manager(fake)
+
+    # Reconciliation answers "what exists". Dropping internal records here made
+    # a bound session renamed into an internal workspace look dead, so the
+    # audit called its binding a fixable ghost and Fix closed the topic.
+    windows = await manager.list_windows_for_reconciliation()
     assert windows is not None
-    assert [(window.window_id, window.window_name) for window in windows] == [
+    assert {w.window_id: w.topic_eligible for w in windows} == {
+        _target("visible"): True,
+        _target("workspace-internal"): False,
+        _target("tab-internal"): False,
+    }
+
+    # The UI listing still hides ccgram's own panes.
+    assert [(w.window_id, w.window_name) for w in await manager.list_windows()] == [
         (_target("visible"), "workspace ▸ tab ▸ p1")
     ]
 
@@ -1520,6 +1538,15 @@ async def test_missing_label_uses_fallback_without_hiding_other_sessions() -> No
     found = await _manager(fake).find_window_by_id(_target("missing"))
     assert found is not None
     assert found.window_name.startswith("Herdr ▸ ")
+
+    # An unlabeled record cannot be shown to be non-internal, so it is kept for
+    # liveness and addressing but never offered for adoption.
+    by_id = {w.window_id: w for w in windows}
+    assert by_id[_target("missing")].topic_eligible is False
+    assert by_id[_target("visible")].topic_eligible is True
+    assert _target("missing") not in {
+        w.window_id for w in await _manager(fake).list_windows()
+    }
 
 
 async def test_malformed_prefixed_target_never_reads_agent_list() -> None:
@@ -1804,3 +1831,119 @@ async def test_list_windows_cwd_empty_when_agent_record_has_no_cwd_key() -> None
     windows = await _manager(_live_fake(agent)).list_windows()
     assert len(windows) == 1
     assert windows[0].cwd == ""
+
+
+async def test_live_records_are_stamped_adoptable() -> None:
+    """The herdr topic rules live here now, not in ``is_agent_topic_window``.
+
+    Keying that gate on a capability flag broke twice: once on
+    ``native_agent_status`` when agterm began reporting status natively, once
+    on ``native_topic_targets``, whose documented meaning is which creation
+    flow to use. Whether a record carries a guarded target and an agent label
+    is herdr's own knowledge, so herdr answers it.
+    """
+    fake = _live_fake(_agent(pane_id="w9:p1", tab_id="w9:t1", value="one"))
+
+    windows = await _manager(fake).list_windows_for_reconciliation()
+
+    assert windows is not None
+    assert [w.window_id for w in windows] == [_target("one")]
+    assert windows[0].topic_eligible is True
+    assert windows[0].window_id.startswith("herdr-session-v1-")
+
+
+async def test_a_pane_without_an_agent_is_not_listed_or_adoptable() -> None:
+    """A bare shell pane was never a herdr topic; that must not have changed."""
+    fake = _live_fake(_agent(pane_id="w9:p1", tab_id="w9:t1", value="one", agent=""))
+
+    # An agent_session present but incomplete is a malformed record, not a
+    # bare pane: herdr published something that cannot be parsed, so this
+    # snapshot cannot account for what is live and says so.
+    assert await _manager(fake).list_windows_for_reconciliation() is None
+
+
+async def test_a_pane_with_no_agent_session_keeps_the_listing_complete() -> None:
+    """A genuinely agent-less pane is not a gap in the account.
+
+    herdr publishes no agent_session for a plain shell pane. That pane was
+    never a topic and never will be, so it is skipped without making liveness
+    unknown. Treating it as a gap would make the listing unknown whenever the
+    user has an ordinary pane open, which is to say always, and nothing would
+    ever be cleaned up again.
+    """
+    bare = {
+        "terminal_id": "term-a",
+        "pane_id": "w9:p1",
+        "tab_id": "w9:t1",
+        "workspace_id": "w9",
+    }
+    live = _agent(pane_id="w9:p2", tab_id="w9:t2", value="two")
+
+    windows = await _manager(_live_fake(bare, live)).list_windows_for_reconciliation()
+
+    assert windows is not None
+    assert [window.window_id for window in windows] == [_target("two")]
+
+
+async def test_ui_listing_is_best_effort_when_agent_list_fails() -> None:
+    """The picker empties rather than raising through the handler.
+
+    Only ``list_windows_for_reconciliation`` distinguishes this from an empty
+    herdr; the selection listing has always degraded, and it must keep doing so
+    now that it no longer routes through the guarded reconciliation path.
+    """
+    fake = FakeHerdr().on("agent", "list", rc=1)
+
+    assert await _manager(fake).list_windows() == []
+    assert await _manager(fake).list_windows_for_reconciliation() is None
+
+
+async def test_ui_listing_is_best_effort_when_label_lookup_fails() -> None:
+    """Same for the workspace and tab label listings the projection needs."""
+    fake = (
+        FakeHerdr()
+        .on("agent", "list", out=_agents(_agent(value="one")))
+        .on("workspace", "list", rc=1)
+    )
+
+    assert await _manager(fake).list_windows() == []
+
+
+async def test_a_recognised_sessionless_agent_keeps_the_listing_complete() -> None:
+    """It has a terminal-derived identity, so it is addressable, so it is no gap.
+
+    Completeness means every addressable guarded target. A recognised agent
+    that has not published its composite still gets one, so the seconds after
+    every /new must not read as an incomplete account.
+    """
+    manager = _manager(_live_fake(_sessionless("term-b")))
+
+    windows = await manager.list_windows_for_reconciliation()
+
+    assert windows is not None
+    assert [w.window_id for w in windows] == [_sessionless_target("term-b")]
+
+
+async def test_an_unrecognised_sessionless_agent_does_not_blank_the_listing() -> None:
+    """Antigravity is the live case, and it is not a transient.
+
+    It is a supported provider, excluded from the terminal-fallback set, and
+    documented to stay sessionless until its first prompt creates a
+    conversation. Counting it as a gap would make reconciliation unknown for
+    every topic while one sits idle, which never resolves on its own.
+    """
+    idle_antigravity = {
+        "terminal_id": "term-x",
+        "pane_id": "w9:p9",
+        "tab_id": "w9:t9",
+        "workspace_id": "w9",
+        "agent": "antigravity",
+    }
+    bound = _agent(pane_id="w2:p1", tab_id="w2:t1", value="session-a")
+
+    windows = await _manager(
+        _live_fake(idle_antigravity, bound)
+    ).list_windows_for_reconciliation()
+
+    assert windows is not None, "an unaddressable agent is not an unaccountable gap"
+    assert [w.window_id for w in windows] == [_target("session-a")]

--- a/tests/ccgram/test_multiplexer_tmux.py
+++ b/tests/ccgram/test_multiplexer_tmux.py
@@ -22,6 +22,7 @@ from ccgram.multiplexer.base import (
     PaneDims,
     WindowRef,
 )
+from ccgram.config import config
 from ccgram.multiplexer.tmux import TmuxManager
 
 
@@ -50,6 +51,16 @@ def test_capabilities_full_snapshot(mgr: TmuxManager) -> None:
         "supports_workspace_selection": False,
         "native_topic_targets": False,
     }
+
+
+class _FakeWindow:
+    def __init__(self, window_id: str, window_name: str) -> None:
+        self.window_id = window_id
+        self.window_name = window_name
+
+    @property
+    def active_pane(self):
+        return None
 
 
 # ── Protocol conformance ───────────────────────────────────────────────
@@ -84,6 +95,32 @@ async def test_reconciliation_listing_returns_none_without_session(
     assert mgr._server is None
 
 
+async def test_reconciliation_listing_is_complete(mgr: TmuxManager) -> None:
+    """Every window in the session is listed, adoptable or not.
+
+    The listing answers "which windows exist", and absence from it is what
+    marks a binding a ghost for /sync Fix to close. The UI listing narrows to
+    what discovery may adopt; this one must not, or renaming a bound window to
+    the hidden ``_`` form silently makes it a closure candidate.
+    """
+    session = MagicMock()
+    session.windows = [
+        _FakeWindow("@0", config.tmux_main_window_name),
+        _FakeWindow("@4", "_paused"),
+        _FakeWindow("@5", "my-project"),
+    ]
+
+    server = MagicMock()
+    server.sessions.get.return_value = session
+    mgr._server = server
+
+    windows = await mgr.list_windows_for_reconciliation()
+
+    assert windows is not None
+    assert [w.window_id for w in windows] == ["@0", "@4", "@5"]
+    assert [w.topic_eligible for w in windows] == [False, False, True]
+
+
 def test_reconciliation_window_keeps_identity_when_pane_query_fails() -> None:
     class FailedPaneWindow:
         window_id = "@7"
@@ -100,17 +137,88 @@ def test_reconciliation_window_keeps_identity_when_pane_query_fails() -> None:
     assert window.cwd == ""
 
 
+@pytest.mark.parametrize(
+    ("window_name", "window_id"),
+    [
+        ("_paused", "@4"),
+        (config.tmux_main_window_name, "@0"),
+    ],
+)
+def test_reconciliation_keeps_windows_list_windows_hides(
+    window_name: str, window_id: str
+) -> None:
+    """A window the UI listing hides is still live, and must still be listed.
+
+    Dropping it made a bound window vanish from liveness the moment it was
+    renamed to the hidden form — and a binding whose window is absent from
+    this listing is a ghost that /sync Fix offers to close. It comes back
+    ineligible so discovery still refuses it.
+    """
+    window = TmuxManager._window_ref_for_reconciliation(  # type: ignore[arg-type]
+        _FakeWindow(window_id, window_name)
+    )
+
+    assert window.window_id == window_id
+    assert window.topic_eligible is False
+
+
+def test_reconciliation_keeps_ccgram_own_window() -> None:
+    with patch.object(config, "own_window_id", "@9"):
+        window = TmuxManager._window_ref_for_reconciliation(  # type: ignore[arg-type]
+            _FakeWindow("@9", "ccgram")
+        )
+
+    assert window.window_id == "@9"
+    assert window.topic_eligible is False
+
+
+def test_reconciliation_marks_an_ordinary_window_adoptable() -> None:
+    window = TmuxManager._window_ref_for_reconciliation(  # type: ignore[arg-type]
+        _FakeWindow("@5", "my-project")
+    )
+
+    assert window.topic_eligible is True
+
+
 async def test_find_window_by_id_returns_windowref(mgr: TmuxManager) -> None:
     win = WindowRef(window_id="@3", window_name="proj", cwd="/tmp")
-    mgr.list_windows = AsyncMock(return_value=[win])  # type: ignore[method-assign]
+    mgr.list_windows_for_reconciliation = AsyncMock(return_value=[win])  # type: ignore[method-assign]
     result = await mgr.find_window_by_id("@3")
     assert result is win
     assert isinstance(result, WindowRef)
 
 
 async def test_find_window_by_id_missing_returns_none(mgr: TmuxManager) -> None:
-    mgr.list_windows = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    mgr.list_windows_for_reconciliation = AsyncMock(return_value=[])  # type: ignore[method-assign]
     assert await mgr.find_window_by_id("@99") is None
+
+
+async def test_find_window_by_id_resolves_a_window_list_windows_hides(
+    mgr: TmuxManager,
+) -> None:
+    """Addressing a known id is not discovery.
+
+    Every handler resolves an already-bound window through here. When this
+    read the adoption-filtered listing, renaming a bound window to the hidden
+    ``_`` form made it unreachable: no text delivered, no screenshot, no
+    toolbar, and nothing in the logs pointing at the rename.
+    """
+    hidden = WindowRef(
+        window_id="@3", window_name="_paused", cwd="/tmp", topic_eligible=False
+    )
+    mgr.list_windows = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    mgr.list_windows_for_reconciliation = AsyncMock(return_value=[hidden])  # type: ignore[method-assign]
+
+    assert await mgr.find_window_by_id("@3") is hidden
+
+
+async def test_find_window_by_id_none_listing_is_not_a_match(
+    mgr: TmuxManager,
+) -> None:
+    """An unconfirmed listing is not proof the window is gone, but it is also
+    not a window to drive: callers get None and retry on the next tick."""
+    mgr.list_windows_for_reconciliation = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    assert await mgr.find_window_by_id("@3") is None
 
 
 async def test_capture_pane_plain_returns_text(mgr: TmuxManager) -> None:

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -1869,3 +1869,47 @@ class TestAdoptionIdentityFoldsCaseInTheMonitor:
 
         assert canonical_window_id("9f1c2d3e-4a5b") in lookup
         assert canonical_window_id("other-id") not in lookup
+
+
+class TestActiveCwdsUseTheCompleteListing:
+    """Transcript discovery is gated on the live cwd set.
+
+    A window missing from that set has no discoverable history at all, so it
+    must be built from every live window, not only the ones a backend would
+    auto-adopt. On agterm that means a session outside CCGRAM_AGTERM_WORKSPACES
+    keeps its /restore and history pager working.
+    """
+
+    @staticmethod
+    def _reader():
+        from ccgram.transcript_reader import TranscriptReader
+
+        return TranscriptReader.__new__(TranscriptReader)
+
+    async def test_includes_a_window_the_ui_listing_hides(self, monkeypatch) -> None:
+        from ccgram.multiplexer.base import WindowRef
+
+        excluded = WindowRef(
+            window_id="@4", window_name="_paused", cwd="/repo", topic_eligible=False
+        )
+
+        async def _complete():
+            return [excluded]
+
+        monkeypatch.setattr(
+            "ccgram.multiplexer.reconciliation.list_windows_for_reconciliation",
+            _complete,
+        )
+
+        assert await self._reader()._get_active_cwds() == {"/repo"}
+
+    async def test_unconfirmed_listing_yields_no_cwds(self, monkeypatch) -> None:
+        async def _unavailable():
+            return None
+
+        monkeypatch.setattr(
+            "ccgram.multiplexer.reconciliation.list_windows_for_reconciliation",
+            _unavailable,
+        )
+
+        assert await self._reader()._get_active_cwds() == set()

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -575,7 +575,7 @@ class TestSessionMapReadFailures:
             ),
             patch("ccgram.session_monitor.session_lifecycle") as lifecycle,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=set())
         lifecycle.reconcile.assert_not_called()
 
 
@@ -621,7 +621,7 @@ class TestPendingToolsCleanup:
             new_callable=AsyncMock,
             return_value=new_map,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=set(new_map))
 
         assert old_sid not in monitor._pending_tools
 
@@ -631,6 +631,8 @@ class TestNewWindowDetection:
         cb = AsyncMock(spec=lambda event: None)
         monitor.set_new_window_callback(cb)
         monitor._last_session_map = {}
+        # Adoption is gated on the backend's verdict from the current listing;
+        # the loop sets this before reaching here.
 
         new_map = {"@5": {"session_id": "s1", "cwd": "/proj", "window_name": "proj"}}
         with patch.object(
@@ -640,7 +642,7 @@ class TestNewWindowDetection:
             new_callable=AsyncMock,
             return_value=new_map,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=set(new_map))
 
         cb.assert_called_once()
         event = cb.call_args[0][0]
@@ -665,7 +667,9 @@ class TestNewWindowDetection:
             new_callable=AsyncMock,
             return_value=initial_map,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(
+                adoptable_window_ids=set(initial_map)
+            )
 
         cb.assert_not_called()
 
@@ -682,7 +686,7 @@ class TestNewWindowDetection:
             new_callable=AsyncMock,
             return_value=new_map,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=set(new_map))
 
         cb.assert_called_once()
 
@@ -706,15 +710,26 @@ _HERDR_CAPS = MultiplexerCapabilities(
     self_identify_env="HERDR_PANE_ID",
     supports_event_stream=True,
     native_worktrees=True,
+    # Production herdr sets this; without it these tests take the agterm
+    # branch and guarded-target validation regresses unnoticed.
+    native_topic_targets=True,
 )
 
 
-def _winref(window_id: str, command: str) -> WindowRef:
+def _winref(window_id: str, command: str, *, eligible: bool | None = None) -> WindowRef:
+    """A window as a backend would hand it over.
+
+    ``topic_eligible`` is the backend's verdict, so these fixtures mirror what
+    a real adapter stamps: a record with an agent is adoptable, a bare shell
+    pane is not. Passing ``eligible`` overrides that for the cases that are
+    about the flag itself.
+    """
     return WindowRef(
         window_id=window_id,
         window_name=window_id,
         cwd="/proj",
         pane_current_command=command,
+        topic_eligible=bool(command.strip()) if eligible is None else eligible,
     )
 
 
@@ -1713,3 +1728,144 @@ def _make_gemini_provider():
     from ccgram.providers.gemini import GeminiProvider
 
     return GeminiProvider()
+
+
+class TestAdoptionRespectsBackendEligibility:
+    """Every path that can create a topic honours the backend's verdict.
+
+    Three sites fire ``NewWindowEvent``: discovery, the session-map delta and
+    the known-unbound self-heal. Only the first consults
+    ``is_agent_topic_window``, so a window the backend excluded could still be
+    adopted through the other two the moment a globally installed agent hook
+    wrote a session_map entry for it.
+    """
+
+    @pytest.fixture
+    def wired(self, monkeypatch) -> None:
+        monkeypatch.setattr(SessionManager, "_save_state", lambda self: None)
+        SessionManager()
+
+    async def test_known_unbound_path_skips_an_ineligible_window(
+        self, monitor: SessionMonitor, wired
+    ) -> None:
+        cb = AsyncMock(spec=lambda event: None)
+        monitor.set_new_window_callback(cb)
+        current_map = {
+            "OUT-OF-SCOPE": {"session_id": "S1", "cwd": "/repo", "window_name": "x"}
+        }
+
+        await monitor._emit_known_unbound_window_events(current_map, set())
+
+        cb.assert_not_called()
+
+    async def test_known_unbound_path_still_surfaces_an_eligible_window(
+        self, monitor: SessionMonitor, wired
+    ) -> None:
+        cb = AsyncMock(spec=lambda event: None)
+        monitor.set_new_window_callback(cb)
+        current_map = {
+            "IN-SCOPE": {"session_id": "S1", "cwd": "/repo", "window_name": "x"}
+        }
+
+        await monitor._emit_known_unbound_window_events(current_map, {"IN-SCOPE"})
+
+        cb.assert_called_once()
+
+    async def test_delta_path_refuses_an_out_of_scope_hook_entry(
+        self, monitor: SessionMonitor, wired
+    ) -> None:
+        """Hooks are installed globally, so an agent started in any workspace
+        writes an entry. A hook entry is not permission to adopt."""
+        cb = AsyncMock(spec=lambda event: None)
+        monitor.set_new_window_callback(cb)
+        raw = {
+            "agterm:OUT-OF-SCOPE": {
+                "session_id": "S1",
+                "cwd": "/repo",
+                "window_name": "elsewhere",
+            }
+        }
+
+        await monitor._detect_and_cleanup_changes(raw, adoptable_window_ids=set())
+
+        cb.assert_not_called()
+
+    async def test_delta_path_adopts_nothing_when_no_listing_was_available(
+        self, monitor: SessionMonitor, wired
+    ) -> None:
+        """None is not "no restriction": it means ccgram has no verdict.
+
+        Inferring one from the hook entry is what the fail-open cache did.
+        """
+        cb = AsyncMock(spec=lambda event: None)
+        monitor.set_new_window_callback(cb)
+        raw = {"agterm:ANY": {"session_id": "S1", "cwd": "/repo", "window_name": "x"}}
+
+        await monitor._detect_and_cleanup_changes(raw, adoptable_window_ids=None)
+
+        cb.assert_not_called()
+
+
+class TestTheLoopPassesTheEligibleSubset:
+    """Behavioural, not source inspection.
+
+    The unit tests above prove the delta path obeys whatever verdict it is
+    given. This proves the loop gives it the *eligible* subset rather than
+    every live window, which is the mistake the parameter exists to prevent:
+    handing over the complete listing would adopt exactly the windows the
+    backend refused.
+    """
+
+    async def test_the_delta_path_receives_only_eligible_windows(
+        self, monitor: SessionMonitor, monkeypatch
+    ) -> None:
+        received: list[set[str] | None] = []
+
+        async def spy(raw=None, *, adoptable_window_ids):
+            received.append(adoptable_window_ids)
+            monitor._running = False  # one cycle is enough
+            return {}
+
+        monkeypatch.setattr(
+            "ccgram.session_monitor.list_windows_for_reconciliation",
+            AsyncMock(
+                return_value=[
+                    _winref("KEEP", "claude"),
+                    _winref("REFUSED", "claude", eligible=False),
+                ]
+            ),
+        )
+        monkeypatch.setattr(
+            "ccgram.session_monitor.read_session_map_raw", AsyncMock(return_value={})
+        )
+        monkeypatch.setattr(monitor, "_read_hook_events", AsyncMock())
+        monkeypatch.setattr(monitor, "_cleanup_all_stale_sessions", AsyncMock())
+        monkeypatch.setattr(monitor, "_detect_and_cleanup_changes", spy)
+        monitor._running = True
+
+        await monitor._monitor_loop()
+
+        assert received == [{"KEEP"}], (
+            "the loop must hand over the eligible subset, not every live window"
+        )
+
+
+class TestAdoptionIdentityFoldsCaseInTheMonitor:
+    """Session-map keys are written by the hook; the adoption set comes from
+    the backend's listing. On agterm those can spell one UUID differently, and
+    comparing raw means the window is never adopted on any cycle.
+    """
+
+    def test_the_lookup_folds_case(self) -> None:
+        from ccgram.session_monitor import _adoption_lookup
+
+        assert _adoption_lookup({"9F1C2D3E-4A5B"}) == {"9f1c2d3e-4a5b"}
+
+    def test_a_case_variant_key_is_adoptable(self) -> None:
+        from ccgram.multiplexer.base import canonical_window_id
+        from ccgram.session_monitor import _adoption_lookup
+
+        lookup = _adoption_lookup({"9F1C2D3E-4A5B"})
+
+        assert canonical_window_id("9f1c2d3e-4a5b") in lookup
+        assert canonical_window_id("other-id") not in lookup

--- a/tests/ccgram/test_status_cmd.py
+++ b/tests/ccgram/test_status_cmd.py
@@ -202,15 +202,159 @@ class TestStatusMainHerdr:
         assert "Tmux session" not in captured.out
         assert "Monitored sessions: 1" in captured.out
 
-    def test_herdr_listing_degrades_to_empty_on_backend_error(
-        self, monkeypatch
-    ) -> None:
-        # Socket unreachable / backend error must degrade to [] (best-effort),
-        # not crash `ccgram status`.
+    def test_herdr_listing_reports_unknown_on_backend_error(self, monkeypatch) -> None:
+        # Socket unreachable / backend error must not crash `ccgram status`,
+        # and must not answer []: an unreachable herdr is not an empty one, and
+        # the caller renders an empty listing as every binding dead.
         from ccgram.status_cmd import _list_herdr_windows
 
         def _boom(_name):
             raise RuntimeError("socket down")
 
         monkeypatch.setattr("ccgram.multiplexer.get_multiplexer", _boom)
-        assert _list_herdr_windows() == []
+        assert _list_herdr_windows() is None
+
+
+class TestLiveWindowsListing:
+    """The alive/dead column must read liveness, not adoptability.
+
+    Backends narrow ``list_windows`` to what discovery may auto-adopt: agterm
+    drops out-of-scope workspaces and sessions sitting at a shell, herdr drops
+    internal workspaces. A bound session that becomes merely ineligible is
+    still live, and printing it dead points /sync Fix at a healthy binding.
+    """
+
+    @staticmethod
+    def _fake_backend(monkeypatch, *, ui: list, reconciliation) -> None:
+        from ccgram.multiplexer.base import WindowRef
+
+        class _Backend:
+            async def list_windows(self) -> list[WindowRef]:
+                return ui
+
+            async def list_windows_for_reconciliation(self) -> list[WindowRef] | None:
+                return reconciliation
+
+        monkeypatch.setattr(
+            "ccgram.multiplexer.get_multiplexer", lambda _name: _Backend()
+        )
+
+    def test_live_but_ineligible_window_is_listed(self, monkeypatch) -> None:
+        from ccgram.multiplexer.base import WindowRef
+        from ccgram.status_cmd import _live_windows
+
+        excluded = WindowRef(
+            window_id="AAAA",
+            window_name="out-of-scope",
+            cwd="/repo",
+            topic_eligible=False,
+        )
+        self._fake_backend(monkeypatch, ui=[], reconciliation=[excluded])
+
+        assert _live_windows("agterm") == [{"id": "AAAA", "name": "out-of-scope"}]
+
+    def test_unconfirmed_listing_is_unknown_not_empty(self, monkeypatch) -> None:
+        from ccgram.status_cmd import _live_windows
+
+        self._fake_backend(monkeypatch, ui=[], reconciliation=None)
+
+        assert _live_windows("agterm") is None
+
+
+class TestUnreachableBackendNeverPrintsDead:
+    """An outage means every window is unknown, not that every window is gone.
+
+    ``dead`` is what /sync Fix offers to clean up, so printing it for a
+    binding whose backend simply could not be reached invites closing live
+    sessions. A *confirmed* empty listing still says dead.
+    """
+
+    @staticmethod
+    def _bound(tmp_path, monkeypatch, mux: str) -> None:
+        monkeypatch.setenv("CCGRAM_DIR", str(tmp_path))
+        monkeypatch.setenv("CCGRAM_MULTIPLEXER", mux)
+        monkeypatch.setenv("TMUX_SESSION_NAME", "ccgram")
+        state = {
+            "thread_bindings": {"12345": {"42": "@5"}},
+            "window_display_names": {"@5": "my-project"},
+        }
+        (tmp_path / "state.json").write_text(json.dumps(state))
+
+    @staticmethod
+    def _run(capsys) -> str:
+        with contextlib.suppress(SystemExit):
+            status_main()
+        return capsys.readouterr().out
+
+    def test_seam_backend_returning_none(self, tmp_path, monkeypatch, capsys) -> None:
+        self._bound(tmp_path, monkeypatch, "agterm")
+        monkeypatch.setattr("ccgram.status_cmd._list_backend_windows", lambda _: None)
+
+        out = self._run(capsys)
+
+        assert "dead" not in out
+        assert "unknown" in out
+        assert "my-project" in out
+        assert "unreachable" in out
+
+    def test_tmux_listing_failure(self, tmp_path, monkeypatch, capsys) -> None:
+        self._bound(tmp_path, monkeypatch, "tmux")
+        monkeypatch.setattr("ccgram.status_cmd._list_tmux_windows", lambda _: None)
+
+        out = self._run(capsys)
+
+        assert "dead" not in out
+        assert "unknown" in out
+        assert "my-project" in out
+
+    def test_confirmed_empty_listing_still_says_dead(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        self._bound(tmp_path, monkeypatch, "tmux")
+        monkeypatch.setattr("ccgram.status_cmd._list_tmux_windows", lambda _: [])
+
+        out = self._run(capsys)
+
+        assert "dead" in out
+        assert "unknown" not in out
+
+
+class TestTmuxListingIsUnknownOnFailure:
+    """The rendered tests stub _list_tmux_windows, so its own contract is here.
+
+    Both failure shapes must answer None: the caller renders [] as every
+    binding dead, and a tmux that is missing or wedged is not an empty server.
+    """
+
+    def test_nonzero_exit(self, monkeypatch) -> None:
+        import subprocess
+
+        from ccgram.status_cmd import _list_tmux_windows
+
+        def _failed(*_a, **_kw):
+            return subprocess.CompletedProcess([], returncode=1, stdout="", stderr="")
+
+        monkeypatch.setattr("ccgram.status_cmd.subprocess.run", _failed)
+        assert _list_tmux_windows("ccgram") is None
+
+    def test_tmux_not_installed(self, monkeypatch) -> None:
+        from ccgram.status_cmd import _list_tmux_windows
+
+        def _boom(*_a, **_kw):
+            raise FileNotFoundError("tmux")
+
+        monkeypatch.setattr("ccgram.status_cmd.subprocess.run", _boom)
+        assert _list_tmux_windows("ccgram") is None
+
+    def test_healthy_listing_is_parsed(self, monkeypatch) -> None:
+        import subprocess
+
+        from ccgram.status_cmd import _list_tmux_windows
+
+        def _ok(*_a, **_kw):
+            return subprocess.CompletedProcess(
+                [], returncode=0, stdout="@5\tmy-project\n", stderr=""
+            )
+
+        monkeypatch.setattr("ccgram.status_cmd.subprocess.run", _ok)
+        assert _list_tmux_windows("ccgram") == [{"id": "@5", "name": "my-project"}]

--- a/tests/ccgram/test_topic_mapping.py
+++ b/tests/ccgram/test_topic_mapping.py
@@ -1,7 +1,7 @@
 """Tests for the backend-neutral topic-mapping projection (Task 10).
 
 Covers:
-* ``is_agent_topic_window`` — the capability-gated discovery filter that decides
+* ``is_agent_topic_window`` — the discovery filter that decides
   whether a multiplexer window surfaces as its own Telegram topic.
 * per-session inbound routing and opaque target binding for herdr, where
   ``window_id`` is an opaque durable session target ("topic = agent session").
@@ -45,7 +45,25 @@ HERDR_CAPS = MultiplexerCapabilities(
     self_identify_env="HERDR_PANE_ID",
     supports_event_stream=True,
     native_worktrees=True,
+    native_topic_targets=True,
 )
+
+# agterm: reports agent state natively, but addresses windows by their own
+# session UUID rather than a guarded target.
+AGTERM_CAPS = MultiplexerCapabilities(
+    name="agterm",
+    ids_stable_across_restart=True,
+    exposes_pane_tty=False,
+    native_agent_status=True,
+    read_max_lines=None,
+    self_identify_env="AGTERM_SESSION_ID",
+    supports_event_stream=False,
+    native_worktrees=False,
+    supports_workspace_selection=True,
+    native_topic_targets=False,
+)
+
+AGTERM_SESSION_UUID = "157B4C8C-EFAE-40C2-BA54-9A5D7FD8B5E4"
 
 
 def _win(window_id: str, command: str = "") -> WindowRef:
@@ -69,24 +87,39 @@ class TestIsAgentTopicWindow:
     def test_tmux_surfaces_every_window(self, command: str) -> None:
         assert is_agent_topic_window(_win("@1", command), TMUX_CAPS) is True
 
-    @pytest.mark.parametrize(
-        ("command", "expected"),
-        [
-            ("claude", True),  # an agent pane is a topic
-            ("codex", True),
-            ("", False),  # a bare shell pane is NOT a topic on herdr
-            ("   ", False),  # whitespace-only label is not an agent
-        ],
-    )
-    def test_herdr_only_agent_panes(self, command: str, expected: bool) -> None:
-        assert (
-            is_agent_topic_window(_win(HERDR_TARGET, command), HERDR_CAPS) is expected
-        )
+    def test_herdr_agent_pane_is_a_topic(self) -> None:
+        """The herdr rules themselves now live in the adapter's ``_live_ref``.
 
-    def test_herdr_rejects_malformed_prefixed_target(self) -> None:
-        assert not is_agent_topic_window(
-            _win("herdr-session-v1-not-a-sha256", "claude"), HERDR_CAPS
+        Only the backend can apply them: whether a record carries a guarded
+        target and an agent label is herdr's own knowledge, and asking that
+        question here is what let it be keyed on the wrong capability twice.
+        Verified against the adapter in ``test_herdr_backend.py``.
+        """
+        assert is_agent_topic_window(_win(HERDR_TARGET, "claude"), HERDR_CAPS)
+
+    def test_a_window_the_backend_refused_is_not_a_topic(self) -> None:
+        window = WindowRef(
+            window_id=HERDR_TARGET,
+            window_name="",
+            cwd="/proj",
+            pane_current_command="claude",
+            topic_eligible=False,
         )
+        assert is_agent_topic_window(window, HERDR_CAPS) is False
+
+    def test_agterm_session_qualifies_without_a_herdr_target(self) -> None:
+        """Keying the opaque-target check on ``native_agent_status`` made every
+        agterm session permanently ineligible: a UUID never matches a target.
+
+        Whether the session is running an agent is the backend's call, carried
+        in ``topic_eligible``, because only it can read its own foreground.
+        """
+        assert is_agent_topic_window(_win(AGTERM_SESSION_UUID, "claude"), AGTERM_CAPS)
+
+    def test_agterm_session_uuid_is_not_required_to_look_like_a_herdr_target(
+        self,
+    ) -> None:
+        assert is_agent_topic_window(_win(AGTERM_SESSION_UUID, "claude"), AGTERM_CAPS)
 
 
 class TestFormatAgentTopicPrefix:
@@ -158,3 +191,37 @@ class TestHerdrSessionRouting:
         assert thread_router.get_window_for_thread(100, 12) == target_b
         assert thread_router.get_thread_for_window(100, target_a) == 11
         assert thread_router.get_thread_for_window(100, target_b) == 12
+
+
+class TestTopicEligibleFlag:
+    """Discovery consumes the reconciliation listing, not ``list_windows``.
+
+    ``session_monitor`` calls ``list_windows_for_reconciliation`` and hands that
+    same list to ``_emit_unbound_window_events``; it never calls
+    ``list_windows``. So a backend's adoption filters cannot live only in
+    ``list_windows`` — they have to travel on the window.
+    """
+
+    def test_an_ineligible_window_is_never_a_topic(self) -> None:
+        window = WindowRef(
+            window_id=AGTERM_SESSION_UUID,
+            window_name="",
+            cwd="/proj",
+            pane_current_command="claude",
+            topic_eligible=False,
+        )
+        assert is_agent_topic_window(window, AGTERM_CAPS) is False
+
+    def test_the_flag_overrides_tmux_blanket_eligibility(self) -> None:
+        window = WindowRef(
+            window_id="@1",
+            window_name="",
+            cwd="/proj",
+            pane_current_command="claude",
+            topic_eligible=False,
+        )
+        assert is_agent_topic_window(window, TMUX_CAPS) is False
+
+    def test_windows_default_to_eligible(self) -> None:
+        """Backends with nothing to exclude say nothing and stay unaffected."""
+        assert WindowRef(window_id="@1", window_name="", cwd="/p").topic_eligible

--- a/tests/integration/test_monitor_flow.py
+++ b/tests/integration/test_monitor_flow.py
@@ -229,7 +229,8 @@ async def test_nested_session_start_does_not_steal_forwarding(
 
     _append_jsonl(parent_transcript, [_make_assistant_entry("parent new")])
     _bump_mtime(parent_transcript)
-    current = await monitor._detect_and_cleanup_changes()
+    # tmux: every live window is adoptable, which the loop derives per cycle.
+    current = await monitor._detect_and_cleanup_changes(adoptable_window_ids={"@0"})
     new_messages = await monitor.check_for_updates(current)
 
     assert current["@0"]["session_id"] == parent_id
@@ -277,7 +278,7 @@ async def test_session_change_cleanup(
     (state_dir / "session_map.json").write_text(
         json.dumps({"ccgram:@0": new_map["@0"]})
     )
-    await monitor._detect_and_cleanup_changes()
+    await monitor._detect_and_cleanup_changes(adoptable_window_ids={"@0"})
 
     assert monitor.state.get_session(TEST_SESSION_ID) is None
     assert get_claude_task_snapshot("@0") is None


### PR DESCRIPTION
Two different questions were being read off one listing, which is what let the eligibility bug in #214 happen at all.

| listing | question | shape |
|---|---|---|
| `list_windows` | what does the backend present for explicit selection | filtered by visibility; a row may be `topic_eligible=False` |
| `list_windows_for_reconciliation` | what exists | complete, tri-state; `None` means "could not ask" |

agterm deliberately lists an in-scope session sitting at a shell, so a user can bind it by hand, while unattended discovery leaves it alone. Absence from the *second* listing is what marks a binding a ghost, and `/sync` Fix closes those.

## Consumers were asking the wrong one

- **herdr** dropped internal-workspace records and **tmux** dropped the main window, ccgram's own, and every `_`-prefixed one — so renaming a bound window to the hidden form made it a closure candidate.
- **tmux's `find_window_by_id`** filtered too, so such a window went unreachable with nothing in the logs naming the cause. Addressing a known id is not discovery; agterm and herdr already bypass the filter.
- **The sessions dashboard, `ccgram status` and transcript discovery** each read liveness off the filtered listing. The last decides whether a session's history is discoverable at all.

## herdr's complete listing was not complete

`_agent_list_snapshot` quarantines malformed and ambiguous records and returned only the safe subset, so a duplicate target, a pane holding two, or an agent whose session composite is not yet published vanished and read as a *confirmed dead* binding. It now reports whether it accounts for every live agent, and reconciliation answers `None` when it does not.

A pane naming no agent is not a gap — it was never a topic, and counting it would make liveness unknown whenever an ordinary shell is open. The picker keeps the safe subset, still best-effort.

`None` is never flattened where it would be reported as fact or acted on destructively: status and the dashboard render unknown; the read-only readers degrade for a cycle.

Stacked on #214, which is stacked on #213. Third of the series splitting #212. The tri-state point-of-use guards follow.