### PR TITLE
Read existence as a tri-state, at the point each caller acts on it

### DIFF
--- a/src/ccgram/bootstrap.py
+++ b/src/ccgram/bootstrap.py
@@ -40,6 +40,7 @@ from .handlers.topics.topic_orchestration import (
 )
 from .handlers.topics.topic_orchestration import (
     handle_new_window as _handle_new_window,
+    still_adoptable as _still_adoptable,
 )
 from .handlers.topics.topic_orchestration import (
     is_pending_creation as _is_pending_creation,
@@ -267,6 +268,12 @@ async def start_session_monitor(application: Application) -> SessionMonitor:
     )
 
     async def new_window_callback(event: NewWindowEvent) -> None:
+        # The automatic sink, so eligibility is re-read per window. The monitor
+        # emits a batch and awaits each creation in turn, so without this the
+        # last window in a batch is judged on a listing taken before the first
+        # one's topic existed. Explicit binds do not come through here.
+        if not await _still_adoptable(event.window_id):
+            return
         await _handle_new_window(event, client)
 
     monitor.set_new_window_callback(new_window_callback)

--- a/src/ccgram/handlers/agent_command.py
+++ b/src/ccgram/handlers/agent_command.py
@@ -139,7 +139,13 @@ async def _apply_switch(
     """
     current = identity_state.get_provider_name(window_id) or ""
     if chosen == "auto":
-        target = await _redetect_provider(window_id)
+        detected = await _redetect_provider(window_id)
+        if detected is None:
+            return current or "unknown", (
+                "\u26a0 Could not reach the multiplexer, so the agent was left "
+                "as it is. Try again in a moment."
+            )
+        target = detected
         manual = False
         reply_intro = f"Auto-detected: **{target}**."
     else:
@@ -180,8 +186,14 @@ async def _apply_switch(
     return target, reply
 
 
-async def _redetect_provider(window_id: str) -> str:
-    """Re-run auto-detection for ``/agent auto``; return resolved provider."""
+async def _redetect_provider(window_id: str) -> str | None:
+    """Re-run auto-detection for ``/agent auto``; return resolved provider.
+
+    ``None`` when the multiplexer could not be reached: a lookup failure is
+    indistinguishable from a window that is gone, and the caller persists the
+    result and clears transcript bookkeeping, so an outage would otherwise
+    rewrite a working session to ``shell``.
+    """
     # Lazy: detect_provider_from_pane pulls the providers package — only
     # needed when the user actually requests re-detection via /agent auto.
     from ..providers import detect_provider_from_pane
@@ -189,9 +201,20 @@ async def _redetect_provider(window_id: str) -> str:
     # Lazy: tmux_manager imports providers; same cycle-break as above.
     from ..multiplexer import multiplexer as tmux_manager
 
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ..multiplexer.reconciliation import window_presence
+
+    if await window_presence(window_id, tmux_manager) is None:
+        return None
+
     w = await tmux_manager.find_window_by_id(window_id)
+    if w is None:
+        # Either the window went in the meantime or this second read failed;
+        # neither is a confirmed "not an agent", and the caller persists what
+        # comes back. Report unknown instead of resolving to shell.
+        return None
     detected = ""
-    if w and w.pane_current_command:
+    if w.pane_current_command:
         detected = await detect_provider_from_pane(
             w.pane_current_command, window_id=window_id
         )

--- a/src/ccgram/handlers/recovery/recovery_banner.py
+++ b/src/ccgram/handlers/recovery/recovery_banner.py
@@ -230,6 +230,43 @@ def build_recovery_keyboard(window_id: str) -> InlineKeyboardMarkup:
     )
 
 
+async def _stale_recovery_offer(old_window_id: str) -> str | None:
+    """Why this recovery offer must not be acted on, or None to proceed.
+
+    Every Fresh / Continue / Resume route converges on the replacement below,
+    and the banner offering them may have been drawn from an ambiguous lookup
+    minutes ago. The replacement unbinds before it creates, so a stale offer
+    leaves the old terminal running with its routing handed to a new window.
+
+    One confirmed read answers both questions — does it exist, and is what
+    holds it still an agent — because a presence check followed by a second
+    lookup is a second chance to fail.
+    """
+    if not old_window_id:
+        return None
+
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ...multiplexer.reconciliation import window_snapshot
+
+    # Lazy: same cycle through provider/session initialization.
+    from ..telegram_origin import agent_origin_returned_to_shell
+
+    confirmed, window = await window_snapshot(old_window_id)
+    if not confirmed:
+        return (
+            "\u26a0 Could not reach the multiplexer, so nothing was changed. "
+            "Try again in a moment."
+        )
+    if window is None:
+        # Confirmed gone: recovery is exactly right.
+        return None
+    if await agent_origin_returned_to_shell(old_window_id, window):
+        # Alive, but the agent exited and left a shell — the case the text
+        # handler deliberately offers recovery for.
+        return None
+    return "That session is running again, so it was left alone."
+
+
 async def _create_and_bind_window(
     query: CallbackQuery,
     user_id: int,
@@ -251,6 +288,17 @@ async def _create_and_bind_window(
 
     Returns True on success, False on failure.
     """
+    # Every Fresh / Continue / Resume route converges here, and the banner
+    # offering them may have been drawn from an ambiguous lookup minutes ago.
+    # This unbinds before creating the replacement, so a stale offer would
+    # leave the old terminal running with its routing handed to a new window.
+    # One confirmed read answers both questions: does it exist, and is what
+    # holds it still an agent.
+    refusal = await _stale_recovery_offer(old_window_id)
+    if refusal is not None:
+        await safe_edit(query, refusal, reply_markup=None)
+        return False
+
     thread_router.unbind_thread(
         user_id,
         thread_id,

--- a/src/ccgram/handlers/sessions_dashboard.py
+++ b/src/ccgram/handlers/sessions_dashboard.py
@@ -27,7 +27,11 @@ from ..config import config
 from ..telegram_client import PTBTelegramClient, TelegramClient
 from ..thread_router import thread_router
 from ..multiplexer import multiplexer as tmux_manager
-from ..multiplexer.reconciliation import list_windows_for_reconciliation
+from ..multiplexer.base import canonical_window_id
+from ..multiplexer.reconciliation import (
+    list_windows_for_reconciliation,
+    window_presence,
+)
 from ..window_query import view_window
 from .callback_data import (
     CB_SESSIONS_KILL,
@@ -73,14 +77,21 @@ async def _build_dashboard(user_id: int) -> tuple[str, InlineKeyboardMarkup]:
     # would otherwise show as stopped. None means the backend could not be
     # asked, which is not the same as every session being stopped.
     all_windows = await list_windows_for_reconciliation()
-    live_ids = None if all_windows is None else {w.window_id for w in all_windows}
+    # Folded on both sides: a binding persisted in different case from the
+    # live listing is the same window, and showing it stopped also strips
+    # its Esc, Screenshot and Kill controls.
+    live_ids = (
+        None
+        if all_windows is None
+        else {canonical_window_id(w.window_id) for w in all_windows}
+    )
 
     lines: list[str] = []
     action_rows: list[list[InlineKeyboardButton]] = []
     for _thread_id, window_id in sorted(bindings.items()):
         display_name = thread_router.get_display_name(window_id)
         view = view_window(window_id)
-        alive = None if live_ids is None else window_id in live_ids
+        alive = None if live_ids is None else canonical_window_id(window_id) in live_ids
         status = _LIVENESS_MARKER[alive]
 
         # Session line with provider + mode tags and cwd detail
@@ -174,9 +185,29 @@ async def handle_sessions_kill_confirm(
     """Second tap — kill the tmux window, unbind all users, refresh dashboard."""
     display = thread_router.get_display_name(window_id)
 
-    w = await tmux_manager.find_window_by_id(window_id)
-    if w:
-        await tmux_manager.kill_window(w.window_id)
+    # find_window_by_id answers None both for a window that is gone and for a
+    # backend that could not be reached, and everything below deletes the
+    # routing to this session. Unknown changes nothing: the session would
+    # survive the outage with no way left to reach it.
+    presence = await window_presence(window_id, tmux_manager)
+    if presence is None:
+        await safe_edit(
+            query,
+            f"\u26a0 Could not reach the multiplexer, so '{display}' was left "
+            "alone. Nothing was killed or unbound.",
+            reply_markup=None,
+        )
+        return
+
+    if presence and not await tmux_manager.kill_window(window_id):
+        # The window was there a moment ago and the kill did not succeed, so
+        # it may still be running. Clearing the bindings now would strand it.
+        await safe_edit(
+            query,
+            f"\u26a0 Could not kill '{display}'. Nothing was unbound.",
+            reply_markup=None,
+        )
+        return
 
     # Clean up BEFORE unbind — resolve_chat_id needs group_chat_ids
     # which unbind_thread deletes
@@ -199,7 +230,7 @@ async def handle_sessions_kill_confirm(
 
     # Re-render dashboard
     text, keyboard = await _build_dashboard(user_id)
-    headline = "\U0001f5d1 Killed"
+    headline = "\U0001f5d1 Killed" if presence else "\U0001f5d1 Was already gone:"
     await safe_edit(query, f"{headline} '{display}'\n\n{text}", reply_markup=keyboard)
 
 

--- a/src/ccgram/handlers/sessions_dashboard.py
+++ b/src/ccgram/handlers/sessions_dashboard.py
@@ -27,6 +27,7 @@ from ..config import config
 from ..telegram_client import PTBTelegramClient, TelegramClient
 from ..thread_router import thread_router
 from ..multiplexer import multiplexer as tmux_manager
+from ..multiplexer.reconciliation import list_windows_for_reconciliation
 from ..window_query import view_window
 from .callback_data import (
     CB_SESSIONS_KILL,
@@ -52,6 +53,9 @@ _REFRESH_BTN = InlineKeyboardButton(
 )
 _NEW_BTN = InlineKeyboardButton("\u2795 New Session", callback_data=CB_SESSIONS_NEW)
 
+# Green running, black stopped, white when the multiplexer could not be asked.
+_LIVENESS_MARKER = {True: "\U0001f7e2", False: "\u26ab", None: "\u26aa"}
+
 
 async def _build_dashboard(user_id: int) -> tuple[str, InlineKeyboardMarkup]:
     """Build dashboard text and keyboard for a user's sessions."""
@@ -64,16 +68,20 @@ async def _build_dashboard(user_id: int) -> tuple[str, InlineKeyboardMarkup]:
             keyboard,
         )
 
-    all_windows = await tmux_manager.list_windows()
-    live_ids = {w.window_id for w in all_windows}
+    # The complete listing, not the adoption-filtered one: every id here is
+    # already bound, and a live window a backend merely will not auto-adopt
+    # would otherwise show as stopped. None means the backend could not be
+    # asked, which is not the same as every session being stopped.
+    all_windows = await list_windows_for_reconciliation()
+    live_ids = None if all_windows is None else {w.window_id for w in all_windows}
 
     lines: list[str] = []
     action_rows: list[list[InlineKeyboardButton]] = []
     for _thread_id, window_id in sorted(bindings.items()):
         display_name = thread_router.get_display_name(window_id)
         view = view_window(window_id)
-        alive = window_id in live_ids
-        status = "\U0001f7e2" if alive else "\u26ab"
+        alive = None if live_ids is None else window_id in live_ids
+        status = _LIVENESS_MARKER[alive]
 
         # Session line with provider + mode tags and cwd detail
         provider_tag = f" [{view.provider_name}]" if view and view.provider_name else ""
@@ -191,9 +199,8 @@ async def handle_sessions_kill_confirm(
 
     # Re-render dashboard
     text, keyboard = await _build_dashboard(user_id)
-    await safe_edit(
-        query, f"\U0001f5d1 Killed '{display}'\n\n{text}", reply_markup=keyboard
-    )
+    headline = "\U0001f5d1 Killed"
+    await safe_edit(query, f"{headline} '{display}'\n\n{text}", reply_markup=keyboard)
 
 
 @register(

--- a/src/ccgram/handlers/sync_command.py
+++ b/src/ccgram/handlers/sync_command.py
@@ -73,12 +73,25 @@ _RETIRED_OUTCOME_LABELS = {
 }
 
 
-async def _run_audit() -> AuditResult:
-    """Fetch live multiplexer state and run audit."""
-    all_windows = await tmux_manager.list_windows()
+async def _run_audit() -> AuditResult | None:
+    """Fetch live multiplexer state and run audit.
+
+    Liveness comes from the reconciliation listing, never from
+    ``list_windows``: that one is the UI listing and a backend legitimately
+    omits what it will not adopt, so using it here reports a live bound
+    session as a fixable ghost the moment it becomes excluded. Adoptability is
+    the ``topic_eligible`` subset of the same listing.
+
+    Returns None when no listing is available. The caller must not treat that
+    as "nothing is live", which would classify every binding as dead.
+    """
+    all_windows = await list_windows_for_reconciliation(tmux_manager)
+    if all_windows is None:
+        return None
     live_ids = {w.window_id for w in all_windows}
     live_pairs = [(w.window_id, w.window_name) for w in all_windows]
-    return session_manager.audit_state(live_ids, live_pairs)
+    adoptable = {w.window_id for w in all_windows if w.topic_eligible}
+    return session_manager.audit_state(live_ids, live_pairs, adoptable)
 
 
 def _issue_summary_lines(audit: AuditResult) -> list[str]:
@@ -370,7 +383,20 @@ async def _close_ghost_topics(
 async def _adopt_orphaned_windows(
     client: TelegramClient, issues: list[AuditIssue]
 ) -> None:
-    """Create Telegram topics for unbound multiplexer windows."""
+    """Create Telegram topics for unbound multiplexer windows.
+
+    The verdict on the issues handed in is as old as the listing the audit ran
+    against, and /sync Fix probes every bound topic over the network before
+    reaching here — seconds, with many topics. So eligibility is re-read at the
+    point of use: a window that has since gone away, or moved out of scope,
+    must not get a topic. An unavailable listing adopts nothing; adoption is
+    the one step here that is safe to skip and retry.
+
+    The re-read is per candidate, not once for the batch. Creating a topic is
+    itself several Telegram round-trips, so with a batch-wide snapshot the
+    second orphan is judged on a listing taken before the first one's topic was
+    created — the same staleness one level down.
+    """
     # Lazy: bidirectional cycle — topic_orchestration.adopt_unbound_windows
     # also lazy-imports _adopt_orphaned_windows from this module.  Either
     # side must remain lazy until one is split into a third module.
@@ -380,6 +406,9 @@ async def _adopt_orphaned_windows(
     # Lazy: session_monitor / topic_orchestration cycle through window-creation flow
     from .topics.topic_orchestration import handle_new_window as _handle_new_window
 
+    # Lazy: same bidirectional cycle as handle_new_window above.
+    from .topics.topic_orchestration import still_adoptable as _still_adoptable
+
     for issue in issues:
         if issue.category != "orphaned_window":
             continue
@@ -387,6 +416,8 @@ async def _adopt_orphaned_windows(
         if not match:
             continue
         window_id = match.group(1)
+        if not await _still_adoptable(window_id):
+            continue
         view = window_query.view_window(window_id)
         name = (view.window_name if view else "") or thread_router.get_display_name(
             window_id
@@ -536,6 +567,14 @@ async def sync_command(update: Update, _context: ContextTypes.DEFAULT_TYPE) -> N
     status_msg = await safe_reply(update.message, "🔍 State audit…")
     client = PTBTelegramClient(update.get_bot())
     audit = await _run_audit()
+    if audit is None:
+        if status_msg is not None:
+            await safe_edit(
+                status_msg,
+                "⚠ Multiplexer unavailable. Cannot audit state right now.",
+                reply_markup=None,
+            )
+        return
     logger.info(
         "Local state audit completed",
         issue_count=len(audit.issues),
@@ -591,10 +630,14 @@ async def handle_sync_fix(query: CallbackQuery) -> None:
 
     live_ids = {w.window_id for w in all_windows}
     live_pairs = [(w.window_id, w.window_name) for w in all_windows]
+    # Fix adopts the orphans this audit reports, so the adoption question takes
+    # the backend's verdict. The live set stays complete: it drives the pruning
+    # below, and narrowing it would make a live excluded binding a fixable ghost.
+    adoptable_ids = {w.window_id for w in all_windows if w.topic_eligible}
 
     # Audit before fixing to count fixable issues
     client = PTBTelegramClient(query.get_bot())
-    pre_audit = session_manager.audit_state(live_ids, live_pairs)
+    pre_audit = session_manager.audit_state(live_ids, live_pairs, adoptable_ids)
     dead_issues = await _probe_dead_topics(client)
     pre_audit.issues.extend(dead_issues)
     pre_audit.issues.extend(_retired_topic_issues())
@@ -628,6 +671,16 @@ async def handle_sync_fix(query: CallbackQuery) -> None:
     # one is unbound and won't be probed), while failed ones restore the old
     # binding and must be re-probed to avoid inflating actual_fixed.
     post_audit = await _run_audit()
+    if post_audit is None:
+        # The repairs already ran; only the after-picture is missing, and
+        # reporting every binding as dead would be worse than saying so.
+        await safe_edit(
+            query,
+            "✅ Fixes applied. The multiplexer went away before the "
+            "after-audit, so the summary below is unavailable.",
+            reply_markup=None,
+        )
+        return
     post_dead = await _probe_dead_topics(client)
     post_audit.issues.extend(post_dead)
     post_audit.issues.extend(_retired_topic_issues())

--- a/src/ccgram/handlers/sync_command.py
+++ b/src/ccgram/handlers/sync_command.py
@@ -337,6 +337,9 @@ async def _close_ghost_topics(
     missing ``can_manage_topics`` or General topic).  Returns
     ``(closed_count, manual_close_count)``.
     """
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ..multiplexer.reconciliation import window_presence
+
     closed_count = 0
     manual_close_count = 0
     for issue in issues:
@@ -350,6 +353,16 @@ async def _close_ghost_topics(
         window_id = match.group(3)
         current_window_id = thread_router.get_window_for_thread(user_id, thread_id)
         if current_window_id != window_id:
+            continue
+        # Per candidate, and the strictest of the three: this removes the
+        # user's topic. The audit's listing predates several network round
+        # trips, so re-confirm the window is really gone — present means the
+        # ghost verdict is stale, unknown means we cannot claim it at all.
+        if await window_presence(window_id, tmux_manager) is not False:
+            logger.info(
+                "Skipping ghost topic removal: window not confirmed gone",
+                window_id=window_id,
+            )
             continue
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
         topic_removed = await _remove_topic(client, chat_id, thread_id)
@@ -491,6 +504,9 @@ async def _recreate_dead_topics(
     # Lazy: session_monitor / topic_orchestration cycle through window-creation flow
     from .topics.topic_orchestration import handle_new_window as _handle_new_window
 
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ..multiplexer.reconciliation import window_presence
+
     recreated = 0
     for issue in issues:
         if issue.category != "dead_topic":
@@ -503,6 +519,17 @@ async def _recreate_dead_topics(
         window_id = match.group(3)
         current_window_id = thread_router.get_window_for_thread(user_id, thread_id)
         if current_window_id != window_id:
+            continue
+        # Per candidate: the listing this issue came from was taken before the
+        # Telegram probes, the title sync, orphan adoption and ghost cleanup.
+        # Recreating unbinds the thread first, so a window that has since gone
+        # would get a fresh topic pointing at nothing, and an unreachable
+        # backend must change nothing at all.
+        if await window_presence(window_id, tmux_manager) is not True:
+            logger.info(
+                "Skipping dead-topic recreation: window not confirmed present",
+                window_id=window_id,
+            )
             continue
 
         view = window_query.view_window(window_id)

--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -343,10 +343,61 @@ async def _handle_dead_window(
         )
         return True
 
-    w = await tmux_manager.find_window_by_id(window_id)
-    logically_dead = lifecycle_strategy.is_dead_notified(
-        user_id, thread_id, window_id
-    ) or (w is not None and await agent_origin_returned_to_shell(window_id, w))
+    # One confirmed read: find_window_by_id answers None both for a window
+    # that is gone and for a backend that could not be reached, and the branch
+    # below unbinds the topic when the cached cwd has also gone stale.
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ...multiplexer.reconciliation import window_snapshot
+
+    confirmed, w = await window_snapshot(window_id, tmux_manager)
+    if not confirmed:
+        await safe_reply(
+            message,
+            "\u26a0 Could not reach the multiplexer, so nothing was changed. "
+            "Send that again in a moment.",
+        )
+        return True
+
+    # The dead marker is sticky: tick_window returns early once it is set, so
+    # nothing clears it on its own. A window confirmed present and still
+    # running its agent is alive whatever the marker says — an agterm session
+    # comes back under the same UUID after an app restart — and treating it as
+    # dead reaches the unbind below whenever the cached cwd has gone stale too.
+    returned_to_shell = w is not None and await agent_origin_returned_to_shell(
+        window_id, w
+    )
+    if (
+        w is not None
+        and not returned_to_shell
+        and lifecycle_strategy.is_dead_notified(user_id, thread_id, window_id)
+        and not w.pane_current_command
+    ):
+        # Present, marked dead, and nothing says an agent holds the pane. An
+        # empty foreground command is agterm's "unknown", not proof of an
+        # agent: it reports none for a shell holding the pane, an unreadable
+        # process group and a failed lookup alike, and detection maps all three
+        # to "". Clearing the marker here would forward the next message, and
+        # the shared send guard types it into the pane with Return, so a
+        # session restored under the same UUID as a plain shell runs it as a
+        # command. Change nothing, keep the marker and the binding, and return
+        # before the stale-cwd unbind below.
+        await safe_reply(
+            message,
+            "\u26a0 That session is marked as ended and nothing confirms an "
+            "agent is running in it. Send that again in a moment, or use "
+            "/restore to start one.",
+        )
+        return True
+
+    if w is not None and not returned_to_shell:
+        lifecycle_strategy.clear_dead_notification(user_id, thread_id)
+        lifecycle_strategy.clear_autoclose_timer(user_id, thread_id)
+        return False
+
+    logically_dead = (
+        lifecycle_strategy.is_dead_notified(user_id, thread_id, window_id)
+        or returned_to_shell
+    )
     if w and not logically_dead:
         lifecycle_strategy.clear_autoclose_timer(user_id, thread_id)
         return False

--- a/src/ccgram/handlers/topics/__init__.py
+++ b/src/ccgram/handlers/topics/__init__.py
@@ -47,6 +47,7 @@ from .topic_orchestration import (
     collect_target_chats,
     create_topic_in_chat,
     handle_new_window,
+    still_adoptable,
 )
 from .window_callbacks import handle_window_callback
 
@@ -77,6 +78,7 @@ __all__ = [
     "get_favorites",
     "handle_directory_callback",
     "handle_new_window",
+    "still_adoptable",
     "handle_window_callback",
     "new_command",
     "probe_topic_existence",

--- a/src/ccgram/handlers/topics/topic_lifecycle.py
+++ b/src/ccgram/handlers/topics/topic_lifecycle.py
@@ -101,8 +101,23 @@ async def _close_expired_topic(
         else thread_router.get_window_for_thread(user_id, thread_id)
     )
     if state == "dead" and window_id is not None:
-        live_window = await tmux_manager.find_window_by_id(window_id)
-        if live_window is not None:
+        # Tri-state, read here instead of through find_window_by_id: that
+        # answers None both for a window that is gone and for a backend that
+        # could not be reached, and this path closes the user's topic. Present
+        # clears the stale timer, unknown defers to the next expiry.
+        # Lazy: importing the reconciliation seam at module load forms a cycle.
+        from ...multiplexer.reconciliation import window_presence
+
+        present = await window_presence(window_id, tmux_manager)
+        if present is None:
+            logger.warning(
+                "stale_dead_autoclose_deferred",
+                thread_id=thread_id,
+                user_id=user_id,
+                window_id=window_id,
+            )
+            return
+        if present:
             lifecycle_strategy.clear_autoclose_timer(user_id, thread_id)
             logger.info(
                 "stale_dead_autoclose_cleared",

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -408,14 +408,18 @@ async def create_topic_in_chat(
         return False
 
 
-async def _rebind_existing_topic_by_name(
-    event: NewWindowEvent, client: TelegramClient, topic_name: str
-) -> bool:
-    """Bind a stale same-name topic to a newly discovered manual window."""
-    clean_topic_name = strip_emoji_prefix(topic_name)
+async def _stale_same_name_bindings(
+    event: NewWindowEvent, clean_topic_name: str
+) -> list[tuple[int, int, str, int]] | None:
+    """Bindings with this topic name whose window is confirmed gone.
+
+    ``None`` when any candidate's liveness could not be confirmed: the caller
+    would hand that topic to a different window, and find_window_by_id answers
+    None both for a window that is gone and for a backend that could not be
+    reached. There is no rush to rebind, so unknown abandons the decision.
+    """
     matches: list[tuple[int, int, str, int]] = []
-    bindings = list(thread_router.iter_thread_bindings())
-    for user_id, thread_id, old_window_id in bindings:
+    for user_id, thread_id, old_window_id in list(thread_router.iter_thread_bindings()):
         if old_window_id == event.window_id:
             continue
         display_name = strip_emoji_prefix(thread_router.get_display_name(old_window_id))
@@ -425,6 +429,17 @@ async def _rebind_existing_topic_by_name(
             continue
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
         matches.append((user_id, thread_id, old_window_id, chat_id))
+    return matches
+
+
+async def _rebind_existing_topic_by_name(
+    event: NewWindowEvent, client: TelegramClient, topic_name: str
+) -> bool:
+    """Bind a stale same-name topic to a newly discovered manual window."""
+    clean_topic_name = strip_emoji_prefix(topic_name)
+    matches = await _stale_same_name_bindings(event, clean_topic_name)
+    if matches is None:
+        return False
 
     if len(matches) != 1:
         if len(matches) > 1:
@@ -541,12 +556,55 @@ async def _handle_new_window_locked(
     return any(results)
 
 
+async def still_adoptable(window_id: str) -> bool:
+    """Confirm, right now, that discovery may adopt this window.
+
+    Read immediately before each automatic adoption, never once for a batch:
+    creating a topic is several Telegram round-trips, so the second window in
+    a batch would otherwise be judged on a listing taken before the first
+    one's topic existed. It has had time to go away, leave the configured
+    workspace scope, or stop being an agent.
+
+    Automatic adoption only. A picker selection is an explicit bind and may
+    name a window discovery would not have taken on its own.
+
+    An unconfirmed listing answers False: skipping costs a retry on the next
+    cycle, while adopting a window that has gone creates a topic nothing will
+    ever drive.
+    """
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ...multiplexer.reconciliation import list_windows_for_reconciliation
+
+    windows = await list_windows_for_reconciliation(tmux_manager)
+    if windows is None:
+        logger.warning(
+            "Skipping adoption: no confirmed window listing", window_id=window_id
+        )
+        return False
+    if not any(w.window_id == window_id and w.topic_eligible for w in windows):
+        logger.info(
+            "Skipping adoption: window no longer adoptable", window_id=window_id
+        )
+        return False
+    return True
+
+
 async def adopt_unbound_windows(client: TelegramClient) -> None:
     """Auto-adopt known-but-unbound windows (post-restart recovery)."""
-    all_windows = await tmux_manager.list_windows()
+    # Orphan repair creates topics, so the adoption question takes the
+    # backend's verdict; liveness comes from the complete listing, or a
+    # present-but-excluded window becomes a ghost instead of being ignored.
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ...multiplexer.reconciliation import list_windows_for_reconciliation
+
+    all_windows = await list_windows_for_reconciliation(tmux_manager)
+    if all_windows is None:
+        logger.warning("Skipping unbound-window adoption: no confirmed listing")
+        return
     live_ids = {w.window_id for w in all_windows}
     live_pairs = [(w.window_id, w.window_name) for w in all_windows]
-    audit = session_manager.audit_state(live_ids, live_pairs)
+    adoptable_ids = {w.window_id for w in all_windows if w.topic_eligible}
+    audit = session_manager.audit_state(live_ids, live_pairs, adoptable_ids)
     orphaned = [i for i in audit.issues if i.category == "orphaned_window"]
     if orphaned:
         # Lazy: bidirectional cycle with sync_command (see

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -418,6 +418,9 @@ async def _stale_same_name_bindings(
     None both for a window that is gone and for a backend that could not be
     reached. There is no rush to rebind, so unknown abandons the decision.
     """
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ...multiplexer.reconciliation import window_presence
+
     matches: list[tuple[int, int, str, int]] = []
     for user_id, thread_id, old_window_id in list(thread_router.iter_thread_bindings()):
         if old_window_id == event.window_id:
@@ -425,7 +428,15 @@ async def _stale_same_name_bindings(
         display_name = strip_emoji_prefix(thread_router.get_display_name(old_window_id))
         if display_name != clean_topic_name:
             continue
-        if await tmux_manager.find_window_by_id(old_window_id):
+        present = await window_presence(old_window_id, tmux_manager)
+        if present is None:
+            logger.warning(
+                "Cannot confirm window %s is gone; not rebinding %s",
+                old_window_id,
+                event.window_id,
+            )
+            return None
+        if present:
             continue
         chat_id = thread_router.resolve_chat_id(user_id, thread_id)
         matches.append((user_id, thread_id, old_window_id, chat_id))
@@ -465,6 +476,21 @@ async def _rebind_existing_topic_by_name(
             "Could not probe same-name topic thread %d for stale window %s; not rebinding",
             thread_id,
             old_window_id,
+        )
+        return False
+
+    # The topic probe above is a Telegram round trip, and the old window was
+    # judged gone before it. If it came back in that window, this bind would
+    # take its live topic away, so the verdict is re-read immediately before
+    # the write. Unknown refuses too: there is no rush to rebind.
+    # Lazy: importing the reconciliation seam at module load forms a cycle.
+    from ...multiplexer.reconciliation import window_presence
+
+    if await window_presence(old_window_id, tmux_manager) is not False:
+        logger.info(
+            "Old window %s is no longer confirmed gone; not rebinding %s",
+            old_window_id,
+            event.window_id,
         )
         return False
 
@@ -581,7 +607,7 @@ async def still_adoptable(window_id: str) -> bool:
             "Skipping adoption: no confirmed window listing", window_id=window_id
         )
         return False
-    if not any(w.window_id == window_id and w.topic_eligible for w in windows):
+    if not any(w.matches(window_id) and w.topic_eligible for w in windows):
         logger.info(
             "Skipping adoption: window no longer adoptable", window_id=window_id
         )

--- a/src/ccgram/multiplexer/agterm.py
+++ b/src/ccgram/multiplexer/agterm.py
@@ -168,6 +168,26 @@ def _validated_work_dir(work_dir: str) -> tuple[Path | None, str]:
     return path, ""
 
 
+def _runs_a_known_agent(foreground: object) -> bool:
+    """Whether this session's foreground argv is an agent ccgram can drive.
+
+    Classified from the whole argv, never from its first token: agterm reports
+    what is actually running, so codex arrives as ``["node", ".../codex", …]``
+    and a check on ``argv[0]`` would reject it while accepting ``vim``, ``less``
+    or a build. ``classify_provider_from_argv`` is the codebase's own
+    wrapper-skipping matcher. A shell is not an adopted agent, and an absent
+    foreground is an idle prompt.
+    """
+    if not isinstance(foreground, list) or not foreground:
+        return False
+    # Lazy: providers reach back into the multiplexer seam, so a module-level
+    # import here would close the loop.
+    from ..providers.process_detection import classify_provider_from_argv
+
+    provider = classify_provider_from_argv([str(part) for part in foreground])
+    return bool(provider) and provider != "shell"
+
+
 def _key_to_bytes(token: str) -> str | None:
     """Translate one tmux key name to pty bytes, or None when unrecognised.
 
@@ -345,6 +365,20 @@ class AgtermManager:
         Fails closed. A failure anywhere returns None, never a partial tree,
         because a partial answer here is indistinguishable from sessions
         having gone away.
+
+        The sweep is a sequence of RPCs, so in principle a session could evade
+        it by moving between windows between two reads. It cannot: agterm has
+        no operation that moves a session across windows. Both relocation
+        paths refuse (``session move <workspace>`` answers "no such workspace"
+        for a workspace in another window, and ``move --after <anchor>``
+        answers "no such session" for an anchor in one), because session and
+        workspace addressing is window-scoped. A session is created in a window
+        and stays there until it closes. What can still appear mid-sweep is a
+        newly opened window, whose sessions are new and therefore cannot be
+        ones ccgram is already bound to.
+
+        ``window_exists`` covers the remainder for the destructive paths, which
+        ask about one target rather than trusting this listing.
         """
         window_ids = await self._open_window_ids()
         if window_ids is None:
@@ -376,8 +410,7 @@ class AgtermManager:
                     pairs.append((workspace, session))
         return pairs
 
-    @staticmethod
-    def _to_window(session: dict) -> WindowRef:
+    def _to_window(self, session: dict, workspace: dict | None = None) -> WindowRef:
         """Map one agterm session node onto the neutral ``WindowRef``."""
         foreground = session.get("foreground")
         command = ""
@@ -393,6 +426,11 @@ class AgtermManager:
             pane_tty="",
             pane_width=0,
             pane_height=0,
+            # Discovery consumes the reconciliation listing, which stays
+            # complete on purpose, so adoptability travels on the window.
+            topic_eligible=self._is_adoptable(session)
+            and (workspace is None or self._in_scope(workspace))
+            and _runs_a_known_agent(foreground),
         )
 
     async def _find_session(self, window_id: str) -> dict | None:
@@ -457,17 +495,21 @@ class AgtermManager:
             )
 
     async def list_windows(self) -> list[WindowRef]:
-        """List the sessions discovery may adopt (best-effort, [] on failure).
+        """List the sessions offered for explicit selection ([] on failure).
 
-        Narrower than ``list_windows_for_reconciliation`` on purpose: this is
-        the listing discovery turns into topics, so it carries the workspace
-        scope and the self/hidden exclusions.
+        The pickers. Narrower than ``list_windows_for_reconciliation``, which
+        returns every session so cleanup can tell absent from excluded, but
+        narrowed only by *visibility*: the workspace scope, ccgram's own
+        session and the ``_`` prefix. Not by adoptability — an in-scope session
+        sitting at a shell is listed here, carrying ``topic_eligible=False``,
+        so a user can bind it by hand while unattended discovery leaves it
+        alone. Discovery reads the reconciliation listing and never this one.
         """
         tree = await self._tree()
         if tree is None:
             return []
         return [
-            self._to_window(session)
+            self._to_window(session, workspace)
             for workspace, session in self._sessions(tree)
             if self._in_scope(workspace) and self._is_adoptable(session)
         ]
@@ -489,7 +531,8 @@ class AgtermManager:
         if tree is None:
             return None
         return [
-            self._to_window(session) for _workspace, session in self._sessions(tree)
+            self._to_window(session, workspace)
+            for workspace, session in self._sessions(tree)
         ]
 
     async def list_workspaces(self) -> list[WorkspaceRef]:
@@ -518,6 +561,8 @@ class AgtermManager:
     async def find_window_by_id(self, window_id: str) -> WindowRef | None:
         """Find a session by its UUID; None when it no longer exists."""
         session = await self._find_session(window_id)
+        # No workspace passed: addressing a known id is not discovery, so an
+        # out-of-scope window is still findable and drivable.
         return None if session is None else self._to_window(session)
 
     async def _read_text(self, window_id: str, *, lines: int | None) -> str | None:
@@ -883,15 +928,20 @@ class AgtermManager:
         agterm reports the argv but no pid, pgid or tty, so those are zero and
         empty.
 
-        None at an idle shell prompt, and that is agterm's answer rather than a
-        failure: it omits ``foreground`` from the node exactly when the pane
-        sits at a prompt. The shell provider needs a shell *name* to install
-        its prompt marker, and agterm reports none, so that provider does not
-        work on this backend. The adapter does not guess one: ``shell_infra``
-        matches ``argv[0]`` against ``KNOWN_SHELLS`` and then sends that
-        shell's syntax, so a wrong guess types zsh into a fish prompt in a
-        terminal somebody is using. Lifting this needs agterm to report the
-        shell on an idle node.
+        None whenever agterm cannot report an argv, which is several states and
+        not one: a shell holds the pane, there is no foreground pid, the
+        foreground group is an unreadable setuid or setgid one such as ``top``
+        or ``sudo``, or a lookup failed. So None means "unknown", never "at a
+        prompt" (confirmed by agterm's author, umputun/agterm#508; their godoc
+        named only the shell case and has been corrected).
+
+        The shell provider does not work on this backend, and a shell name
+        would not fix it. agterm 0.25 adds ``foregroundShell`` for the case
+        where a recognised shell holds the pane, but a shell builtin such as
+        ``read`` or ``vared``, and a shell loop, run inside the shell process,
+        so argv stays the shell's: a pane blocked on input is indistinguishable
+        from one at a prompt and both report the same name. Installing a prompt
+        marker on that signal would type into a running ``read``.
 
         The provider detector classifies this argv directly because agterm cannot
         provide a process-group ID. This preserves provider detection behind

--- a/src/ccgram/multiplexer/agterm.py
+++ b/src/ccgram/multiplexer/agterm.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import os
 import shutil
 import subprocess
@@ -82,6 +83,12 @@ _RC_NO_BINARY = 127
 # The agent ccgram drives runs in the session's main pane. Passed explicitly on
 # every read and write because agterm's two defaults disagree (see module docs).
 _AGENT_PANE = "left"
+
+# agterm's refusal for a target it does not know. Matched rather than compared
+# so a trailing id or punctuation change does not silently turn a proof of
+# absence into "unknown", which would only make the guards more cautious, and
+# so an unrelated refusal is never read as absence, which would not.
+_NO_SUCH_SESSION_RE = re.compile(r"\bno such session\b", re.IGNORECASE)
 
 # ``C-x``: a control chord is exactly the prefix plus one character.
 _CONTROL_CHORD_LEN = 3
@@ -325,6 +332,57 @@ class AgtermManager:
             return None
         result = payload.get("result")
         return result if isinstance(result, dict) else {}
+
+    async def window_exists(self, window_id: str) -> bool | None:
+        """Ask agterm about one session: True, False, or None if it could not say.
+
+        The authoritative answer, and the only one this backend can give.
+        ``tree`` is per-window, so a merged listing is a sequence of RPCs with
+        no isolation: a session that stays ahead of the sweep is read in no
+        window at all, and two passes can agree on the same incomplete result.
+        No number of passes fixes that, because an atomic snapshot cannot be
+        assembled from non-atomic reads.
+
+        A targeted call can, because agterm answers it differently. An unknown
+        target returns a well-formed ``{"ok": false, "error": "no such session:
+        <id>"}`` envelope, while an unreachable socket fails before any
+        envelope exists. So a parsed refusal naming this session is proof of
+        absence, and everything else is unknown.
+        """
+        rc, out, _err = await self._run(
+            self._with_socket(
+                ["session", "text", "--pane", _AGENT_PANE, "--target", window_id]
+            ),
+            None,
+        )
+        try:
+            payload = json.loads(out)
+        except json.JSONDecodeError, ValueError:
+            # No envelope at all: the CLI could not reach agterm, or answered
+            # something this code does not understand. Not an absence.
+            return None
+        if not isinstance(payload, dict):
+            return None
+        ok = payload.get("ok")
+        if ok is True:
+            return True
+        error = payload.get("error")
+        # Absence needs the whole shape: an explicit refusal, a string reason,
+        # and this session named in it. Anything looser lets a malformed or
+        # unrelated payload authorise a deletion.
+        if (
+            ok is False
+            and isinstance(error, str)
+            and _NO_SUCH_SESSION_RE.search(error)
+            and window_id.casefold() in error.casefold()
+        ):
+            return False
+        # A refusal for some other reason (a busy pane, a schema change) says
+        # nothing about whether the session is there.
+        logger.debug(
+            "agterm refused an existence probe", window_id=window_id, error=error, rc=rc
+        )
+        return None
 
     async def _call_ok(
         self, args: Sequence[str], stdin_text: str | None = None

--- a/src/ccgram/multiplexer/base.py
+++ b/src/ccgram/multiplexer/base.py
@@ -73,6 +73,34 @@ class WindowRef:
     ambiguous and must not be migrated.
     """
 
+    def matches(self, window_id: str) -> bool:
+        """Whether *window_id* names this window, under any identity it has had.
+
+        Case-insensitive, and it consults ``alias_window_ids``.
+
+        The case-folding is what matters today: agterm's UUIDs round-trip
+        through callers that may lowercase them, which is why its own
+        ``_find_session`` case-folds, and a presence check comparing ids
+        directly would report such a window gone and take the destructive
+        branch.
+
+        The alias arm is the value type's contract, not a live behaviour: no
+        backend currently publishes ``alias_window_ids``, and herdr
+        deliberately leaves them empty across a session re-key. Should one
+        start, a window persisted under a superseded id must still read as
+        present. ``legacy_alias_window_ids`` is deliberately excluded: those
+        are declared non-actionable, and this answer feeds callers that drive
+        the window they get back.
+
+        Case-folding is safe for every current id form — tmux ``@N`` has no
+        case, herdr's guarded targets are hex digests, agterm's are UUIDs. A
+        backend whose ids are genuinely case-sensitive must override this.
+        """
+        wanted = canonical_window_id(window_id)
+        return wanted == canonical_window_id(self.window_id) or any(
+            wanted == canonical_window_id(alias) for alias in self.alias_window_ids
+        )
+
 
 @dataclass
 class PaneInfo:

--- a/src/ccgram/multiplexer/base.py
+++ b/src/ccgram/multiplexer/base.py
@@ -20,6 +20,22 @@ from typing import Protocol, runtime_checkable
 # ── Value types ────────────────────────────────────────────────────────
 
 
+def canonical_window_id(window_id: str) -> str:
+    """The comparison form of a window id.
+
+    Window ids are opaque, but they are not all case-stable. agterm reports
+    UUIDs uppercase while a caller may round-trip one lowercased, which is why
+    the backend's own lookup case-folds and why ``WindowRef.matches`` does.
+    Anything comparing a persisted id against a live listing has to agree with
+    them, or the batch sets classify a live session as dead and the audit
+    prunes its state, bindings and offsets.
+
+    Case-folding is safe for every current id form: tmux ``@N`` has no case,
+    herdr's guarded targets are hex digests, agterm's are UUIDs.
+    """
+    return window_id.casefold()
+
+
 @dataclass
 class WindowRef:
     """Neutral representation of a multiplexer window (tmux window / herdr pane).
@@ -35,6 +51,17 @@ class WindowRef:
     pane_tty: str = ""
     pane_width: int = 0
     pane_height: int = 0
+    topic_eligible: bool = True
+    """Whether discovery may adopt this window as a topic.
+
+    Stamped by the backend, because whether a window is ccgram's own, hidden by
+    convention, or outside the configured scope is backend knowledge. Discovery
+    consumes ``list_windows_for_reconciliation``, which stays complete on
+    purpose so cleanup never mistakes a filtered-out window for a dead one, so
+    the adoption decision has to travel on the window itself instead of being
+    applied by omission. Backends with nothing to exclude leave it True.
+    """
+
     alias_window_ids: tuple[str, ...] = ()
     """Superseded canonical identities this same window may be persisted under."""
     legacy_alias_window_ids: tuple[str, ...] = ()

--- a/src/ccgram/multiplexer/base.py
+++ b/src/ccgram/multiplexer/base.py
@@ -210,7 +210,12 @@ class MultiplexerCapabilities:
     """True when ``foreground()`` can return a tty device path (tmux: True)."""
 
     native_agent_status: bool
-    """True when the backend exposes agent status natively (herdr: True)."""
+    """True when the backend exposes agent status natively (herdr, agterm).
+
+    Read only for status. It does not decide which windows become topics: that
+    is ``WindowRef.topic_eligible``, because keying discovery on this flag made
+    every agterm session permanently ineligible once agterm set it.
+    """
 
     read_max_lines: int | None
     """Maximum scrollback lines the backend can return; None = unlimited (tmux)."""
@@ -274,7 +279,38 @@ class Multiplexer(Protocol):
         ...
 
     async def list_windows(self) -> list[WindowRef]:
-        """List all agent windows in the session."""
+        """List the windows the backend presents for explicit selection.
+
+        The pickers. A backend applies its visibility filters here — its own
+        session, hidden names, a configured workspace scope — so this is not a
+        liveness answer; ask ``list_windows_for_reconciliation`` for that.
+
+        It is not the adoption answer either, and unattended discovery never
+        reads it. A window listed here may carry ``topic_eligible=False``:
+        agterm deliberately shows an in-scope session sitting at a shell so a
+        user can bind it by hand. Choosing from a picker is an explicit bind,
+        and the flows behind it do their own existence check.
+        """
+        ...
+
+    async def list_windows_for_reconciliation(self) -> list[WindowRef] | None:
+        """List every live window, or ``None`` when the listing is unconfirmed.
+
+        The complete view, used wherever absence means "this window is gone":
+        state cleanup, the monitor's change detection, ``/sync``, the sessions
+        dashboard, transcript discovery, and the alive column in ``status``. It
+        must include every window ``list_windows`` filters out, so a caller can
+        tell an excluded window from a departed one.
+
+        This is also the listing unattended discovery reads, and the only one
+        it reads. ``WindowRef.topic_eligible`` on these windows is the third
+        question — what may be adopted with nobody asking — kept separate from
+        both the visibility filters above and existence here.
+
+        ``None`` means the backend could not confirm the listing (an
+        unreachable socket, a failed command). It is never an empty listing:
+        treating it as one closes every binding the bot holds.
+        """
         ...
 
     async def list_workspaces(self) -> list[WorkspaceRef]:

--- a/src/ccgram/multiplexer/herdr.py
+++ b/src/ccgram/multiplexer/herdr.py
@@ -329,6 +329,13 @@ def _parse_live_record(record: Mapping[str, object]) -> HerdrLiveRecord | None:
 def _parse_agent_records(
     agents: Sequence[object],
 ) -> tuple[list[HerdrLiveRecord], int]:
+    """Parse the records, counting the ones that leave a gap in the account.
+
+    The count is malformed records only. A record that parses to None is not a
+    gap: a recognised agent without a composite already takes a terminal-derived
+    identity, so what remains is an agent ccgram cannot address at all and never
+    holds a binding to.
+    """
     records: list[HerdrLiveRecord] = []
     malformed = 0
     for agent in agents:
@@ -548,12 +555,39 @@ class HerdrManager:
             )
 
     async def _agent_list_snapshot(self) -> list[HerdrLiveRecord]:
-        """Read and parse one fresh ``agent.list`` snapshot.
+        """The safe records from one fresh ``agent.list`` snapshot.
 
         Known hook-capable agents without a complete session composite use a
         terminal fallback identity. Shells and malformed records remain
         ignored. No focus, title, name, directory, screen, or layout field
         participates in this snapshot.
+
+        Quarantined records are dropped silently, so this subset is safe to
+        address and safe to show, but it is not a complete account of what is
+        live. Anything answering "does this window still exist" must take
+        ``_agent_list_snapshot_checked`` instead.
+        """
+        records, _complete = await self._agent_list_snapshot_checked()
+        return records
+
+    async def _agent_list_snapshot_checked(
+        self,
+    ) -> tuple[list[HerdrLiveRecord], bool]:
+        """The safe records, plus whether they account for every live agent.
+
+        ``False`` when malformed or ambiguous records were quarantined: those
+        panes are live, ccgram may hold bindings to them, and they are absent
+        from the subset returned here. Reporting that subset as complete makes
+        such a binding look like a ghost, which the audit, the polling loop and
+        the destructive guards all act on.
+
+        Completeness means every *addressable* guarded target. A record that
+        merely names a tool is not one: a recognised agent without a composite
+        already gets a terminal-derived identity, and what is left parses to
+        None because ccgram does not recognise the agent at all. Antigravity is
+        the live example, supported here and documented to stay sessionless
+        until its first prompt, so counting it would make reconciliation
+        unknown for every topic while one sits idle.
         """
         result = await self._call_json(["agent", "list"])
         if result is None:
@@ -576,7 +610,8 @@ class HerdrManager:
                 duplicate_target_count=duplicate_targets,
                 duplicate_pane_count=duplicate_panes,
             )
-        return safe
+        complete = not (malformed or duplicate_targets or duplicate_panes)
+        return safe, complete
 
     def target_id_for_live_record(self, record: Mapping[str, object]) -> str | None:
         """Return a guarded opaque target for one ``agent.list`` record.
@@ -610,13 +645,25 @@ class HerdrManager:
         return matches[0]
 
     @staticmethod
-    def _live_ref(record: HerdrLiveRecord, label: str) -> WindowRef:
-        """Project a live record without exposing reusable locator aliases."""
+    def _live_ref(
+        record: HerdrLiveRecord, label: str, *, adoptable: bool = True
+    ) -> WindowRef:
+        """Project a live record without exposing reusable locator aliases.
+
+        ``topic_eligible`` is stamped here because this parser is already the
+        place that decides what counts: it emits a record only for a live agent
+        carrying a guarded target, and a bare shell pane never reaches it. The
+        verdict travels on the window so discovery needs no herdr-shaped check
+        of its own.
+        """
         return WindowRef(
             window_id=record.target_id,
             window_name=label,
             cwd=record.cwd,
             pane_current_command=record.composite.agent,
+            topic_eligible=adoptable
+            and is_herdr_session_target(record.target_id)
+            and bool(record.composite.agent.strip()),
         )
 
     async def _reconciliation_labels(
@@ -674,36 +721,74 @@ class HerdrManager:
             label = labels.get((record.workspace_id, record.tab_id))
             if label is None:
                 if include_unlabeled:
+                    # Kept for liveness and addressing, never for adoption:
+                    # without labels this cannot tell an internal ``__*__``
+                    # workspace or tab from an ordinary one, and adopting
+                    # ccgram's own pane is the failure that guard exists for.
                     refs.append(
                         self._live_ref(
                             record,
                             f"Herdr ▸ {record.target_id[-12:]}",
+                            adoptable=False,
                         )
                     )
                 continue
             workspace_label, tab_label = label
-            if not include_internal and (
+            internal = bool(
                 _INTERNAL_LABEL_RE.match(workspace_label)
                 or _INTERNAL_LABEL_RE.match(tab_label)
-            ):
+            )
+            if internal and not include_internal:
                 continue
             pane = record.pane_id.rsplit(":", 1)[-1]
             refs.append(
                 self._live_ref(
                     record,
                     format_agent_topic_prefix(workspace_label, tab_label, pane),
+                    adoptable=not internal,
                 )
             )
         return refs
 
     async def list_windows(self) -> list[WindowRef]:
-        """Return a best-effort UI listing; reconciliation uses the tri-state API."""
-        return await self.list_windows_for_reconciliation() or []
+        """Return a best-effort UI listing, hiding ccgram's own internal panes.
+
+        Built from the safe subset directly, not from the reconciliation
+        listing: quarantined records make that listing report unknown, and a
+        picker that empties itself because one unrelated record was malformed
+        would be worse than one showing everything it can address. Showing what
+        is addressable is exactly this listing's job.
+        """
+        try:
+            refs = await self._project_live_refs(await self._agent_list_snapshot())
+        except HerdrError:
+            # Best-effort, as before: a failed agent, workspace or tab listing
+            # empties the picker instead of raising through it. Only the
+            # reconciliation listing distinguishes this from "nothing there".
+            return []
+        return [w for w in refs if w.topic_eligible]
 
     async def list_windows_for_reconciliation(self) -> list[WindowRef] | None:
+        """Every live record, including internal ones, marked unadoptable.
+
+        Internal ``__*__`` workspaces and tabs are ccgram's own and must never
+        be adopted, but they have to stay in the listing: a bound session
+        renamed into one would otherwise vanish from liveness, be audited as a
+        ghost binding and have its topic closed. Existence and adoptability are
+        different questions, so this answers the first and stamps the second.
+        """
         try:
+            records, complete = await self._agent_list_snapshot_checked()
+            if not complete:
+                # Quarantined records are live panes missing from this subset,
+                # so it cannot answer what exists. Saying so beats handing back
+                # a listing whose gaps read as dead bindings.
+                logger.warning(
+                    "herdr agent.list incomplete; reporting liveness unknown"
+                )
+                return None
             return await self._project_live_refs(
-                await self._agent_list_snapshot(), include_unlabeled=True
+                records, include_internal=True, include_unlabeled=True
             )
         except HerdrError:
             return None

--- a/src/ccgram/multiplexer/reconciliation.py
+++ b/src/ccgram/multiplexer/reconciliation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import Protocol, cast
 
 from .base import WindowRef
@@ -10,6 +11,11 @@ from .base import WindowRef
 class _ReconciliationWindowLister(Protocol):
     async def list_windows_for_reconciliation(self) -> list[WindowRef] | None:
         """Return None when a reliable window listing is unavailable."""
+
+
+class _TargetedPresenceProbe(Protocol):
+    async def window_exists(self, window_id: str) -> bool | None:
+        """True, False, or None when the backend could not answer."""
 
 
 async def list_windows_for_reconciliation(
@@ -21,11 +27,7 @@ async def list_windows_for_reconciliation(
     State cleanup must call this stronger backend contract so a failed listing
     cannot be treated as proof that every tracked window is gone.
     """
-    if backend is None:
-        # Lazy: importing multiplexer package state at module load forms a cycle.
-        from . import get_active_multiplexer
-
-        backend = get_active_multiplexer()
+    backend = _resolve_backend(backend)
 
     method = getattr(backend, "list_windows_for_reconciliation", None)
     if not callable(method):
@@ -35,3 +37,76 @@ async def list_windows_for_reconciliation(
         )
     lister = cast("_ReconciliationWindowLister", backend)
     return await lister.list_windows_for_reconciliation()
+
+
+def _resolve_backend(backend: object | None) -> object:
+    """The concrete backend behind whatever the caller passed.
+
+    Callers hold the module facade, whose type defines only ``__getattr__``, so
+    a static lookup on it finds no methods at all. Resolving through it first
+    is what lets the targeted-probe check below see the real backend instead of
+    silently deciding it has none.
+    """
+    # Lazy: importing multiplexer package state at module load forms a cycle.
+    from . import _MultiplexerProxy, get_active_multiplexer
+
+    if backend is None or isinstance(backend, _MultiplexerProxy):
+        return get_active_multiplexer()
+    return backend
+
+
+async def window_snapshot(
+    window_id: str, backend: object | None = None
+) -> tuple[bool, WindowRef | None]:
+    """One confirmed read: ``(confirmed, window)``.
+
+    ``confirmed`` is False when the backend could not be asked, and ``window``
+    is then meaningless. When confirmed, ``window`` is the ref or ``None`` if
+    it is genuinely gone.
+
+    Callers that need to inspect the window as well as its existence take this
+    instead of a presence check followed by ``find_window_by_id``: that second
+    lookup is a second chance to fail, and its ``None`` is ambiguous again.
+    """
+    windows = await list_windows_for_reconciliation(backend)
+    if windows is None:
+        return False, None
+    return True, next((w for w in windows if w.matches(window_id)), None)
+
+
+async def window_presence(window_id: str, backend: object | None = None) -> bool | None:
+    """Is this window there? ``True`` yes, ``False`` gone, ``None`` cannot say.
+
+    The tri-state form of the existence question, on the seam because every
+    layer asks it. ``Multiplexer.find_window_by_id`` cannot answer it: it
+    returns ``None`` both for a window that is gone and for a backend that
+    could not be reached, so a caller that closes a topic, unbinds a thread or
+    switches a provider on that answer does so during an outage too.
+
+    Read it immediately before the mutation, per candidate — these loops span
+    Telegram round-trips, so one verdict for a batch is stale by the second
+    item.
+    """
+    backend = _resolve_backend(backend)
+
+    # A backend that can answer about one window directly is authoritative, and
+    # once it declares that, its answer is the only one taken. agterm is such a
+    # backend: its listing is assembled from per-window RPCs and cannot be a
+    # snapshot, while a targeted call distinguishes "no such session" from a
+    # failure to ask. Falling back to the aggregate on a malformed answer would
+    # reach for the listing this probe exists to avoid, so anything that is not
+    # a bool becomes unknown.
+    #
+    # getattr_static, because it reads the type without running __getattr__: a
+    # plain getattr is satisfied by any test double that generates attributes
+    # on demand, which would route real backends through a probe that answers
+    # nothing.
+    if inspect.iscoroutinefunction(
+        inspect.getattr_static(type(backend), "window_exists", None)
+    ):
+        prober = cast("_TargetedPresenceProbe", backend)
+        answer = await prober.window_exists(window_id)
+        return answer if isinstance(answer, bool) else None
+
+    confirmed, window = await window_snapshot(window_id, backend)
+    return window is not None if confirmed else None

--- a/src/ccgram/multiplexer/tmux.py
+++ b/src/ccgram/multiplexer/tmux.py
@@ -162,16 +162,24 @@ class TmuxManager:
         return session
 
     @staticmethod
-    def _window_ref_for_reconciliation(window: libtmux.Window) -> TmuxWindow | None:
-        """Build a window ref while treating pane metadata as optional."""
+    def _window_ref_for_reconciliation(window: libtmux.Window) -> TmuxWindow:
+        """Build a window ref while treating pane metadata as optional.
+
+        Every window in the session comes back, including the ones
+        ``list_windows`` hides: the placeholder main window, ccgram's own
+        window, and the ``_``-prefixed hidden ones. Omitting them here made a
+        bound window vanish from liveness the moment it was renamed to start
+        with an underscore, and a window absent from this listing is a ghost
+        binding that /sync Fix offers to close. They come back stamped
+        ``topic_eligible=False`` so discovery still refuses to adopt them.
+        """
         name = window.window_name or ""
         window_id = window.window_id or ""
-        if name == config.tmux_main_window_name:
-            return None
-        if config.own_window_id and window_id == config.own_window_id:
-            return None
-        if name.startswith("_"):
-            return None
+        adoptable = not (
+            name == config.tmux_main_window_name
+            or (config.own_window_id and window_id == config.own_window_id)
+            or name.startswith("_")
+        )
 
         cwd = ""
         pane_cmd = ""
@@ -197,6 +205,7 @@ class TmuxManager:
             pane_tty=pane_tty,
             pane_width=pw,
             pane_height=ph,
+            topic_eligible=bool(adoptable),
         )
 
     async def list_windows(self) -> list[TmuxWindow]:
@@ -267,9 +276,8 @@ class TmuxManager:
                 if session is None:
                     return []
                 windows = [
-                    ref
+                    self._window_ref_for_reconciliation(window)
                     for window in session.windows
-                    if (ref := self._window_ref_for_reconciliation(window)) is not None
                 ]
             except _TmuxError:
                 self._reset_server()
@@ -296,14 +304,21 @@ class TmuxManager:
     async def find_window_by_id(self, window_id: str) -> TmuxWindow | None:
         """Find a window by its tmux window ID (e.g. '@0', '@12').
 
+        Resolves against the complete listing, as agterm and herdr do:
+        addressing a known id is not discovery. Every handler routes an
+        already-bound window through here, so filtering by adoptability made a
+        window unreachable — no text delivered, no screenshot, no toolbar — the
+        moment it was renamed to start with an underscore.
+
         Args:
             window_id: The tmux window ID to match
 
         Returns:
-            TmuxWindow if found, None otherwise
+            TmuxWindow if found, None otherwise (including when tmux could not
+            confirm the listing).
         """
-        windows = await self.list_windows()
-        for window in windows:
+        windows = await self.list_windows_for_reconciliation()
+        for window in windows or []:
             if window.window_id == window_id:
                 return window
         return None

--- a/src/ccgram/multiplexer/topic_mapping.py
+++ b/src/ccgram/multiplexer/topic_mapping.py
@@ -17,7 +17,6 @@ because it is pure logic over the neutral value types.
 
 from __future__ import annotations
 
-from ..herdr_targets import is_herdr_session_target
 from .base import MultiplexerCapabilities, WindowRef
 
 # Separates workspace, tab, and optional pane parts in a Herdr topic title.
@@ -41,17 +40,17 @@ def format_agent_topic_prefix(workspace: str, tab: str, pane: str = "") -> str:
 def is_agent_topic_window(window: WindowRef, caps: MultiplexerCapabilities) -> bool:
     """Return True when a discovered window should surface as its own topic.
 
-    Gated on ``caps.native_agent_status`` — a capability flag, never a backend
-    name (architecture rule: gate on capabilities, not ``name == "herdr"``):
+    The backend decides, in ``WindowRef.topic_eligible``. No capability flag
+    gates discovery: keying it on one is what produced two bugs in a row. It
+    was first keyed on ``native_agent_status``, which made every agterm session
+    permanently ineligible the moment agterm began reporting status natively;
+    keying it on ``native_topic_targets`` instead only moved the overload onto
+    a flag whose documented meaning is which creation flow to use.
 
-    * Backends without native agent status (tmux): every window is eligible,
-      so the historical auto-topic behavior is unchanged.
-    * Backends with native agent status (herdr): every detected agent record
-      qualifies. The adapter exposes each with a versioned opaque target and an
-      agent label; a raw tab/pane locator or bare shell record is rejected.
+    Only the backend can answer this. herdr knows a record carries a guarded
+    target and an agent label, agterm knows its workspace scope and how to read
+    a wrapped argv, tmux excludes nothing. ``caps`` stays in the signature
+    because it is the seam's shape and callers pass it.
     """
-    if not caps.native_agent_status:
-        return True
-    return is_herdr_session_target(window.window_id) and bool(
-        window.pane_current_command.strip()
-    )
+    del caps
+    return window.topic_eligible

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -516,16 +516,29 @@ class SessionManager:
         self,
         live_window_ids: set[str],
         live_windows: list[tuple[str, str]],
+        adoptable_window_ids: set[str] | None = None,
     ) -> AuditResult:
-        """Read-only audit of all state maps against live tmux windows.
+        """Read-only audit of all state maps against live multiplexer windows.
+
+        Liveness and adoptability are different questions and must stay
+        separate here. Ghost detection, cleanup and display-name sync all ask
+        "does this window exist", so they need the complete live set; feeding
+        them a narrowed one turns a live-but-excluded window into a fixable
+        ghost, and ``/sync`` Fix closes those. Only the orphan section asks
+        "may ccgram adopt this", and only it reads the narrowed set.
 
         Args:
-            live_window_ids: Set of currently alive tmux window IDs.
-            live_windows: List of (window_id, window_name) for live windows.
+            live_window_ids: Every window the backend reports as existing.
+            live_windows: (window_id, window_name) for those windows.
+            adoptable_window_ids: The subset discovery may adopt, from
+                ``WindowRef.topic_eligible``. None means every live window,
+                which is what a backend that excludes nothing reports.
 
         Returns:
             AuditResult with discovered issues.
         """
+        if adoptable_window_ids is None:
+            adoptable_window_ids = live_window_ids
         issues: list[AuditIssue] = []
 
         # Collect all bound window IDs
@@ -640,7 +653,7 @@ class SessionManager:
 
         # 7. Orphaned tmux windows (live, known to ccgram, but not bound to any topic)
         known_wids = session_map_wids | set(self.window_states.keys())
-        for wid in live_window_ids:
+        for wid in adoptable_window_ids:
             if wid not in bound_window_ids and wid in known_wids:
                 name = dict(live_windows).get(wid, wid)
                 issues.append(

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -34,6 +34,7 @@ from .session_map import (
 )
 from .state_persistence import StatePersistence
 from .multiplexer import multiplexer as tmux_manager
+from .multiplexer.base import canonical_window_id
 from .multiplexer.reconciliation import list_windows_for_reconciliation
 from .thread_router import ThreadRouter, install_thread_router, thread_router
 from .user_preferences import (
@@ -435,6 +436,7 @@ class SessionManager:
         When skip_chat_ids=True, group_chat_ids are preserved (used during startup
         so they remain available for post-restart topic creation).
         """
+        live_lookup = {canonical_window_id(w) for w in live_window_ids}
         # Collect window_ids that are "in use" (bound or have window_states)
         in_use = set(self.window_states.keys())
         in_use.update(thread_router.all_bound_window_ids())
@@ -443,7 +445,7 @@ class SessionManager:
         stale_display = [
             wid
             for wid in thread_router.window_display_names
-            if wid not in live_window_ids and wid not in in_use
+            if canonical_window_id(wid) not in live_lookup and wid not in in_use
         ]
 
         # Collect all bound thread keys "user_id:thread_id"
@@ -539,6 +541,13 @@ class SessionManager:
         """
         if adoptable_window_ids is None:
             adoptable_window_ids = live_window_ids
+        # Comparison sets only. The originals stay the reported identity: a
+        # window id is opaque and must reach the user, the session map and the
+        # repair flows exactly as the backend spelled it. Only the membership
+        # tests below fold case, because a persisted id may have round-tripped
+        # in different case from the live listing and would otherwise read as
+        # dead. See canonical_window_id.
+        live_lookup = {canonical_window_id(wid) for wid in live_window_ids}
         issues: list[AuditIssue] = []
 
         # Collect all bound window IDs
@@ -548,7 +557,7 @@ class SessionManager:
         for _uid, _tid, wid in thread_router.iter_thread_bindings():
             total_bindings += 1
             bound_window_ids.add(wid)
-            if wid in live_window_ids:
+            if canonical_window_id(wid) in live_lookup:
                 live_binding_count += 1
 
         session_map_wids = self._get_session_map_window_ids()
@@ -572,7 +581,10 @@ class SessionManager:
 
         # 2. Ghost bindings (thread → dead window) — fixable (close topic)
         for uid, tid, wid in thread_router.iter_thread_bindings():
-            if wid not in live_window_ids and wid not in legacy_bindings:
+            if (
+                canonical_window_id(wid) not in live_lookup
+                and wid not in legacy_bindings
+            ):
                 display = thread_router.get_display_name(wid)
                 issues.append(
                     AuditIssue(
@@ -585,7 +597,7 @@ class SessionManager:
         # 3. Orphaned display names
         in_use = set(self.window_states.keys()) | bound_window_ids
         for wid in thread_router.window_display_names:
-            if wid not in live_window_ids and wid not in in_use:
+            if canonical_window_id(wid) not in live_lookup and wid not in in_use:
                 name = thread_router.get_display_name(wid)
                 issues.append(
                     AuditIssue(
@@ -615,7 +627,7 @@ class SessionManager:
             if (
                 wid not in session_map_wids
                 and wid not in bound_window_ids
-                and wid not in live_window_ids
+                and canonical_window_id(wid) not in live_lookup
             ):
                 display = self.window_states[wid].window_name or wid
                 issues.append(
@@ -652,9 +664,17 @@ class SessionManager:
                 )
 
         # 7. Orphaned tmux windows (live, known to ccgram, but not bound to any topic)
-        known_wids = session_map_wids | set(self.window_states.keys())
+        # Comparison folds case on both sides: an id ccgram persisted may be
+        # spelled differently from the live listing, and an orphan that reads
+        # as unknown here is simply never adopted.
+        known_lookup = {
+            canonical_window_id(wid)
+            for wid in session_map_wids | set(self.window_states.keys())
+        }
+        bound_lookup = {canonical_window_id(wid) for wid in bound_window_ids}
         for wid in adoptable_window_ids:
-            if wid not in bound_window_ids and wid in known_wids:
+            key = canonical_window_id(wid)
+            if key not in bound_lookup and key in known_lookup:
                 name = dict(live_windows).get(wid, wid)
                 issues.append(
                     AuditIssue(
@@ -675,6 +695,7 @@ class SessionManager:
 
         Returns True if any changes were made.
         """
+        live_lookup = {canonical_window_id(w) for w in live_window_ids}
         session_map_wids = self._get_session_map_window_ids()
         bound_window_ids = thread_router.all_bound_window_ids()
 
@@ -684,7 +705,7 @@ class SessionManager:
             if (
                 wid not in session_map_wids
                 and wid not in bound_window_ids
-                and wid not in live_window_ids
+                and canonical_window_id(wid) not in live_lookup
                 and not window_store.is_archived_legacy_herdr(wid)
             )
         ]

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -33,6 +33,7 @@ from typing import Any, cast
 
 import aiofiles
 
+from .multiplexer.base import canonical_window_id
 from .config import config
 from .herdr_targets import is_herdr_session_target
 from .hooks.state_files import StateFileValidationError, parse_session_map_entry
@@ -295,13 +296,21 @@ def _read_session_map_for_pruning() -> dict[str, Any] | None:
 def _dead_session_map_entries(
     raw: dict[str, Any], live_window_ids: set[str]
 ) -> list[tuple[str, str]]:
+    """Entries whose window is absent from the live listing.
+
+    The comparison folds case on both sides. A key written by the hook and a
+    listing from the backend can spell the same agterm UUID differently, and
+    deleting the entry here loses the session's provider, cwd and transcript
+    path for a session that is still running.
+    """
     prefix = session_map_prefix()
+    live = {canonical_window_id(wid) for wid in live_window_ids}
     return [
         (key, window_id)
         for key in raw
         if key.startswith(prefix)
         and is_backend_window_id(window_id := key[len(prefix) :])
-        and window_id not in live_window_ids
+        and canonical_window_id(window_id) not in live
     ]
 
 

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -42,6 +42,7 @@ from .providers import get_provider_for_window, registry  # noqa: F401 (used by 
 from .session_map import parse_session_map, read_session_map_raw, session_map_prefix
 from .session_lifecycle import session_lifecycle
 from .multiplexer import multiplexer as tmux_manager
+from .multiplexer.base import canonical_window_id
 from .multiplexer.reconciliation import list_windows_for_reconciliation
 from .multiplexer.window_liveness import note_live_windows
 from .multiplexer.topic_mapping import is_agent_topic_window
@@ -71,6 +72,17 @@ _SKIP_RETRY_MAX_SECONDS = 60.0
 _MSG_PREVIEW_LENGTH = 80
 
 logger = structlog.get_logger()
+
+
+def _adoption_lookup(adoptable_window_ids: set[str]) -> set[str]:
+    """The comparison form of the adoption set, built once per pass.
+
+    Folded, because these keys were written by the hook while the set comes
+    from the backend's listing, and agterm reports UUIDs uppercase while a
+    caller may round-trip one lowercased. The set itself keeps the backend's
+    spelling, since the audit reports orphan ids straight out of it.
+    """
+    return {canonical_window_id(wid) for wid in adoptable_window_ids}
 
 
 class SessionMonitor:
@@ -586,9 +598,20 @@ class SessionMonitor:
             self.state.save_if_dirty()
 
     async def _detect_and_cleanup_changes(
-        self, raw: dict | None = None
+        self,
+        raw: dict | None = None,
+        *,
+        adoptable_window_ids: set[str] | None,
     ) -> dict[str, dict[str, str]]:
-        """Reconcile session_map; clean up replaced/removed sessions; fire new-window events."""
+        """Reconcile session_map; clean up replaced/removed sessions; fire new-window events.
+
+        ``adoptable_window_ids`` is this cycle's verdict, required rather than
+        defaulted: it is per-cycle input with one production caller, so holding
+        it as monitor state let a stale cycle's answer be reused and let the
+        first cycle run with none at all. ``None`` means no listing was
+        available, and then nothing is adopted — a hook entry is not evidence
+        that ccgram may adopt the window it names.
+        """
         if raw is None:
             raw = await read_session_map_raw()
         if raw is None:
@@ -617,6 +640,11 @@ class SessionMonitor:
             # session_manager forms a hard cycle on bootstrap.
             from .session import session_manager as _sm
 
+            adoptable_lookup = (
+                None
+                if adoptable_window_ids is None
+                else _adoption_lookup(adoptable_window_ids)
+            )
             for window_id, details in adoption_windows.items():
                 provider_name = details.get("provider_name", "")
                 if provider_name:
@@ -629,6 +657,15 @@ class SessionMonitor:
                     # the topic it was bound under; announcing it here would
                     # ask for a second topic for the same agent. Both other
                     # discovery paths skip bound windows for the same reason.
+                    continue
+
+                if (
+                    adoptable_lookup is None
+                    or canonical_window_id(window_id) not in adoptable_lookup
+                ):
+                    # A hook entry proves an agent ran there, not that ccgram
+                    # may adopt it. Installed globally, the hook writes entries
+                    # for windows outside the configured scope too.
                     continue
 
                 if self._new_window_callback:
@@ -654,10 +691,13 @@ class SessionMonitor:
         """Fire a NewWindowEvent for each live window not in session_map / bound.
 
         Surfaces windows the hook never registered (no session_map entry) so
-        they can become topics. On backends that expose agent status natively
-        (herdr), only agent panes qualify — a bare shell pane is not a topic;
-        tmux surfaces every window, preserving today's behavior. The gate is the
-        ``native_agent_status`` capability, not a backend name.
+        they can become topics. What qualifies is the backend's own verdict,
+        carried per window in ``WindowRef.topic_eligible``: herdr marks records
+        holding a guarded target and an agent label, agterm marks in-scope
+        sessions running an agent, tmux marks everything except the placeholder
+        main window, its own window and ``_``-prefixed ones, which its complete
+        listing returns ineligible instead of dropping. No capability flag
+        gates this; keying it on one produced two bugs in a row.
         """
         if not self._new_window_callback:
             return
@@ -691,7 +731,7 @@ class SessionMonitor:
     async def _emit_known_unbound_window_events(
         self,
         current_map: dict,
-        live_window_ids: set[str],
+        adoptable_window_ids: set[str],
     ) -> None:
         """Fire a NewWindowEvent for each session_map window that is not bound.
 
@@ -700,9 +740,13 @@ class SessionMonitor:
         poll until it succeeds. ``handle_new_window`` is idempotent — it skips
         windows that are already bound — so this generates no spam for bound tabs.
 
-        ``live_window_ids`` is the set from ``list_windows``. Because ``list_windows``
-        already filters ``__*__`` workspace/tab labels, any such tab is absent from
-        ``live_window_ids`` and is silently skipped here as well.
+        ``adoptable_window_ids`` holds the live windows whose backend marked them
+        ``WindowRef.topic_eligible``. It is NOT the plain live set: the listing
+        this is built from is the complete reconciliation one, because pruning
+        needs every window that exists. Filtering here is what keeps a window
+        the backend excluded — out of scope, ccgram's own, hidden by convention
+        — from being adopted through the session-map path, which reaches this
+        code whenever a globally installed agent hook writes an entry for it.
         """
         if not self._new_window_callback:
             return
@@ -711,9 +755,10 @@ class SessionMonitor:
         from .thread_router import thread_router
 
         bound_window_ids = {wid for _, _, wid in thread_router.iter_thread_bindings()}
+        adoptable_lookup = _adoption_lookup(adoptable_window_ids)
         for window_id, details in current_map.items():
-            if window_id not in live_window_ids:
-                continue  # dead / __*__-filtered — skip
+            if canonical_window_id(window_id) not in adoptable_lookup:
+                continue  # dead, or the backend says it may not be adopted
             if window_id in bound_window_ids:
                 continue  # already has a topic
             event = NewWindowEvent(
@@ -793,6 +838,14 @@ class SessionMonitor:
                 # after a successful fold, re-read the hook file under its
                 # normal parser so the canonical key is what lifecycle sees.
                 all_windows = await list_windows_for_reconciliation(tmux_manager)
+                # Set before the session-map paths run, not after: they consume
+                # it. None while a listing is unavailable, so adoption fails
+                # closed instead of reusing a stale cycle's verdict.
+                adoptable_window_ids = (
+                    None
+                    if all_windows is None
+                    else {w.window_id for w in all_windows if w.topic_eligible}
+                )
                 if all_windows is None:
                     logger.warning(
                         "Multiplexer listing unavailable; skipping window reconciliation"
@@ -820,18 +873,23 @@ class SessionMonitor:
                 await self._read_hook_events()
 
                 await session_map_sync.load_session_map(raw_session_map)
-                current_map = await self._detect_and_cleanup_changes(raw_session_map)
+                current_map = await self._detect_and_cleanup_changes(
+                    raw_session_map, adoptable_window_ids=adoptable_window_ids
+                )
 
                 monitored_map = current_map
                 if all_windows is not None:
                     live_window_ids = {w.window_id for w in all_windows}
                     session_map_sync.prune_session_map(live_window_ids)
+                    # Pruning needs every live window; adoption needs only the
+                    # ones the backend says may be adopted. The listing is
+                    # complete on purpose, so the two sets differ.
                     known_window_ids = set(current_map.keys())
                     await self._emit_unbound_window_events(
                         all_windows, known_window_ids
                     )
                     await self._emit_known_unbound_window_events(
-                        current_map, live_window_ids
+                        current_map, adoptable_window_ids or set()
                     )
                     monitored_map = {
                         window_id: details

--- a/src/ccgram/status_cmd.py
+++ b/src/ccgram/status_cmd.py
@@ -43,38 +43,54 @@ def _active_multiplexer_name() -> str:
     return os.environ.get(_MULTIPLEXER_ENV, _DEFAULT_MULTIPLEXER)
 
 
-def _list_herdr_windows() -> list[dict[str, str]]:
-    """List herdr agent panes via the neutral seam. Returns list of {id, name}.
+def _list_herdr_windows() -> list[dict[str, str]] | None:
+    """List herdr agent panes via the neutral seam, as {id, name}.
 
-    Best-effort like ``_list_tmux_windows``: degrades to an empty list when the
-    herdr socket is unreachable or the backend errors, so ``ccgram status``
-    still prints state-file data.
+    ``None`` when the herdr socket is unreachable or the backend errors, like
+    ``_list_tmux_windows``: not an empty listing, which the caller renders as
+    every binding dead. ``ccgram status`` still prints its state-file data.
     """
-    # Lazy: the registry lazy-imports the backend; defer to keep status startup
-    # light and touch only the neutral seam (never a concrete backend, F1).
-    from .multiplexer import get_multiplexer
-
-    try:
-        windows = asyncio.run(get_multiplexer(_HERDR_BACKEND).list_windows())
-    except Exception:  # noqa: BLE001 — status is best-effort; degrade to empty
-        return []
-    return [{"id": w.window_id, "name": w.window_name} for w in windows]
+    return _live_windows(_HERDR_BACKEND)
 
 
-def _list_backend_windows(mux_name: str) -> list[dict]:
+def _list_backend_windows(mux_name: str) -> list[dict[str, str]] | None:
     """List windows through the seam, for a backend with no bespoke listing.
 
-    Best-effort like the herdr listing above: a failure degrades to empty so
-    status still prints its state-file data.
+    ``None`` when the backend could not be asked, like the herdr listing above:
+    the caller renders an empty listing as every binding dead. Best-effort
+    either way — status still prints its state-file data.
+    """
+    return _live_windows(mux_name)
+
+
+def _live_windows(mux_name: str) -> list[dict[str, str]] | None:
+    """List every live window on ``mux_name``, for the alive/dead column.
+
+    Reads the reconciliation listing, not ``list_windows``: status reports
+    liveness, and the selection listing applies the backend's visibility
+    filters — the agterm workspace scope, a herdr internal workspace, tmux's
+    hidden names. Reporting a bound session dead because it fell outside one
+    of those would be wrong, and dead bindings are what /sync Fix offers to
+    clean up.
+
+    Returns ``None`` when the listing could not be confirmed — a backend
+    error, or the backend's own ``None``. That is distinct from a confirmed
+    empty listing: an outage means every window is unknown, and rendering
+    unknown as ``dead`` is the same false claim this listing exists to
+    prevent. The state-file data is still printed either way.
     """
     # Lazy: the registry lazy-imports the backend; defer to keep status startup
     # light and touch only the neutral seam (never a concrete backend, F1).
     from .multiplexer import get_multiplexer
 
     try:
-        windows = asyncio.run(get_multiplexer(mux_name).list_windows())
-    except Exception:  # noqa: BLE001 — status is best-effort; degrade to empty
-        return []
+        windows = asyncio.run(
+            get_multiplexer(mux_name).list_windows_for_reconciliation()
+        )
+    except Exception:  # noqa: BLE001 — status is best-effort; unknown, not empty
+        return None
+    if windows is None:
+        return None
     return [{"id": w.window_id, "name": w.window_name} for w in windows]
 
 
@@ -86,8 +102,13 @@ def _read_json(path: Path) -> dict:
         return {}
 
 
-def _list_tmux_windows(session_name: str) -> list[dict[str, str]]:
-    """List tmux windows via subprocess. Returns list of {id, name}."""
+def _list_tmux_windows(session_name: str) -> list[dict[str, str]] | None:
+    """List tmux windows via subprocess, or ``None`` if tmux could not answer.
+
+    A missing or unresponsive tmux is not an empty server: reporting it as one
+    labels every binding dead. See ``_live_windows`` for the same distinction
+    on the seam backends.
+    """
     try:
         result = subprocess.run(
             [
@@ -103,7 +124,7 @@ def _list_tmux_windows(session_name: str) -> list[dict[str, str]]:
             timeout=5,
         )
         if result.returncode != 0:
-            return []
+            return None
         windows = []
         for line in result.stdout.strip().splitlines():
             parts = line.split("\t", 1)
@@ -111,7 +132,7 @@ def _list_tmux_windows(session_name: str) -> list[dict[str, str]]:
                 windows.append({"id": parts[0], "name": parts[1]})
         return windows
     except (OSError, subprocess.TimeoutExpired):  # fmt: skip
-        return []
+        return None
 
 
 def _capability_summary() -> tuple[str, str]:
@@ -130,6 +151,13 @@ def _capability_summary() -> tuple[str, str]:
         if flag
     ]
     return caps.name, ", ".join(flags) or "none"
+
+
+def _backend_line(label: str, windows: list[dict[str, str]] | None, unit: str) -> str:
+    """One-line backend summary; an unconfirmed listing says so, not zero."""
+    if windows is None:
+        return f"{label}: unreachable"
+    return f"{label}: {len(windows)} {unit}"
 
 
 def status_main() -> None:
@@ -152,16 +180,20 @@ def status_main() -> None:
     # Get live windows from the active multiplexer backend
     if mux_name == _HERDR_BACKEND:
         live_windows = _list_herdr_windows()
-        backend_line = f"Herdr: {len(live_windows)} pane(s)"
+        backend_line = _backend_line("Herdr", live_windows, "pane(s)")
     elif mux_name != _TMUX_BACKEND:
         # Any other backend answers through the seam; only tmux and herdr have
         # a bespoke listing, and routing a third backend into the tmux branch
         # reports its session count as zero.
         live_windows = _list_backend_windows(mux_name)
-        backend_line = f"{mux_name}: {len(live_windows)} session(s)"
+        backend_line = _backend_line(mux_name, live_windows, "session(s)")
     else:
         live_windows = _list_tmux_windows(session_name)
-        backend_line = f"Tmux session: {session_name} ({len(live_windows)} windows)"
+        backend_line = (
+            f"Tmux session: {session_name} (unreachable)"
+            if live_windows is None
+            else f"Tmux session: {session_name} ({len(live_windows)} windows)"
+        )
 
     # Build binding index: window_id -> (thread_id, user_id)
     thread_bindings = state.get("thread_bindings", {})
@@ -188,7 +220,7 @@ def status_main() -> None:
 
     # Show live windows first
     shown_ids: set[str] = set()
-    for w in live_windows:
+    for w in live_windows or []:
         wid = w["id"]
         name = display_names.get(wid, w["name"])
         shown_ids.add(wid)
@@ -201,10 +233,15 @@ def status_main() -> None:
         else:
             print(f"  {wid:<5} {name:<16}                              (unbound)")
 
-    # Show dead bindings (bound but window gone)
+    # Bound but not in the live listing. Only a confirmed listing makes that
+    # "dead"; an unconfirmed one makes it unknown, and /sync Fix acts on dead.
+    verdict = "unknown" if live_windows is None else "dead"
     for wid, (thread_id, user_id) in bound_windows.items():
         if wid not in shown_ids:
             name = display_names.get(wid, wid)
-            print(f"  {wid:<5} {name:<16} -> topic {thread_id} (user {user_id})   dead")
+            print(
+                f"  {wid:<5} {name:<16} -> topic {thread_id} "
+                f"(user {user_id})   {verdict}"
+            )
 
     sys.exit(0)

--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -804,15 +804,21 @@ class TranscriptReader:
             raise
 
     async def _get_active_cwds(self) -> set[str]:
-        """Get normalized cwds of all active tmux windows."""
-        # Lazy: tmux_manager imports providers which transitively imports
-        # transcript_reader through provider format modules.
-        # Lazy: tmux_manager pulls providers eagerly; defer until pane lookup runs
-        from .multiplexer import multiplexer as tmux_manager
+        """Get normalised cwds of every live window.
+
+        Reads the complete listing, not the adoption-filtered one: this set
+        decides which transcripts are discoverable at all, so a live window a
+        backend merely will not auto-adopt (out of the agterm workspace scope,
+        under a herdr internal workspace, tmux-hidden) would have its history
+        silently invisible to /restore and the history pager.
+        """
+        # Lazy: importing the reconciliation seam at module load forms a cycle
+        # through providers, which import transcript_reader for their formats.
+        from .multiplexer.reconciliation import list_windows_for_reconciliation
 
         cwds: set[str] = set()
-        windows = await tmux_manager.list_windows()
-        for w in windows:
+        windows = await list_windows_for_reconciliation()
+        for w in windows or []:
             try:
                 cwds.add(str(Path(w.cwd).resolve()))
             except _PathResolveError:

--- a/src/ccgram/user_preferences.py
+++ b/src/ccgram/user_preferences.py
@@ -23,6 +23,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
+from .multiplexer.base import canonical_window_id
+
 logger = structlog.get_logger()
 
 
@@ -143,8 +145,11 @@ class UserPreferences:
         changed = False
         empty_users: list[int] = []
         pruned = 0
+        # Folded on both sides: an offset keyed in different case from the live
+        # listing belongs to the same window, and dropping it replays history.
+        known = {canonical_window_id(wid) for wid in known_window_ids}
         for uid, offsets in self.user_window_offsets.items():
-            stale = [wid for wid in offsets if wid not in known_window_ids]
+            stale = [wid for wid in offsets if canonical_window_id(wid) not in known]
             for wid in stale:
                 logger.debug("Pruning stale offset: user %d, window %s", uid, wid)
                 del offsets[wid]

--- a/tests/ccgram/handlers/polling/test_status_polling.py
+++ b/tests/ccgram/handlers/polling/test_status_polling.py
@@ -103,6 +103,14 @@ class TestAutocloseTimers:
             patch("ccgram.handlers.topics.topic_lifecycle.thread_router") as mock_tr,
             patch("ccgram.handlers.topics.topic_lifecycle.time") as mock_time,
             patch("ccgram.handlers.topics.topic_lifecycle.clear_topic_state"),
+            # The dead case reads liveness before closing: a confirmed empty
+            # listing means the window really is gone. It used to get that for
+            # free from libtmux swallowing its own listing error.
+            patch(
+                "ccgram.multiplexer.reconciliation.list_windows_for_reconciliation",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
         ):
             mock_config.autoclose_done_minutes = 30
             mock_config.autoclose_dead_minutes = minutes

--- a/tests/ccgram/handlers/recovery/test_recovery_banner.py
+++ b/tests/ccgram/handlers/recovery/test_recovery_banner.py
@@ -183,3 +183,59 @@ class TestRecoveryCwdOrReport:
         assert result is None
         assert "Directory no longer exists" in mock_edit.call_args[0][1]
         assert RECOVERY_WINDOW_ID not in ctx.user_data
+
+
+class TestStaleRecoveryOffer:
+    """Fresh, Continue and Resume all converge on one replacement.
+
+    That replacement unbinds the thread before creating its successor, and the
+    banner offering it may have been drawn minutes earlier from a lookup that
+    could not distinguish "gone" from "could not ask". So the decision is
+    re-read here, from one confirmed snapshot.
+    """
+
+    @staticmethod
+    async def _verdict(snapshot, *, returned_to_shell: bool = False):
+        from ccgram.handlers.recovery.recovery_banner import _stale_recovery_offer
+
+        async def _snapshot(*_a, **_kw):
+            return snapshot
+
+        async def _returned(*_a, **_kw):
+            return returned_to_shell
+
+        with (
+            patch("ccgram.multiplexer.reconciliation.window_snapshot", _snapshot),
+            patch(
+                "ccgram.handlers.telegram_origin.agent_origin_returned_to_shell",
+                _returned,
+            ),
+        ):
+            return await _stale_recovery_offer("@5")
+
+    async def test_unavailable_listing_changes_nothing(self) -> None:
+        verdict = await self._verdict((False, None))
+        assert verdict is not None
+        assert "Could not reach" in verdict
+
+    async def test_confirmed_live_agent_changes_nothing(self) -> None:
+        from ccgram.multiplexer.base import WindowRef
+
+        window = WindowRef(window_id="@5", window_name="proj", cwd="/p")
+        verdict = await self._verdict((True, window), returned_to_shell=False)
+        assert verdict is not None
+        assert "running again" in verdict
+
+    async def test_confirmed_missing_proceeds(self) -> None:
+        assert await self._verdict((True, None)) is None
+
+    async def test_confirmed_live_shell_after_agent_exit_proceeds(self) -> None:
+        from ccgram.multiplexer.base import WindowRef
+
+        window = WindowRef(window_id="@5", window_name="proj", cwd="/p")
+        assert await self._verdict((True, window), returned_to_shell=True) is None
+
+    async def test_no_old_window_is_not_a_refusal(self) -> None:
+        from ccgram.handlers.recovery.recovery_banner import _stale_recovery_offer
+
+        assert await _stale_recovery_offer("") is None

--- a/tests/ccgram/handlers/recovery/test_recovery_ui.py
+++ b/tests/ccgram/handlers/recovery/test_recovery_ui.py
@@ -49,8 +49,21 @@ _STALE_TOAST = "Stale recovery (topic mismatch)"
 
 @pytest.fixture(autouse=True)
 def _patch_recovery_session_manager():
-    """Mock session_manager writes (set_window_*) so tests don't hit real state."""
-    with patch(f"{_RC}.session_manager"):
+    """Mock session_manager writes (set_window_*) so tests don't hit real state.
+
+    Also confirms the old window is gone. Recovery replaces a binding, so it
+    refuses to act on a listing it could not obtain; these cases are all "the
+    old window really is dead", which is a confirmed empty listing, not the
+    absent one they used to get for free from libtmux swallowing the error.
+    """
+    with (
+        patch(f"{_RC}.session_manager"),
+        patch(
+            "ccgram.multiplexer.reconciliation.list_windows_for_reconciliation",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
         yield
 
 

--- a/tests/ccgram/handlers/test_agent_command.py
+++ b/tests/ccgram/handlers/test_agent_command.py
@@ -163,6 +163,25 @@ async def test_arg_unknown_is_rejected(reply):
     assert window_store.window_states["@7"].provider_name == "claude"
 
 
+def _confirm_live(monkeypatch, window_id: str) -> None:
+    """Report *window_id* live through the reconciliation seam.
+
+    /agent auto persists what detection returns and clears transcript
+    bookkeeping, so it refuses to resolve at all unless the window is
+    confirmed present.
+    """
+    from ccgram.multiplexer.base import WindowRef
+
+    monkeypatch.setattr(
+        "ccgram.multiplexer.tmux.tmux_manager.list_windows_for_reconciliation",
+        AsyncMock(
+            return_value=[
+                WindowRef(window_id=window_id, window_name="proj", cwd="/proj")
+            ]
+        ),
+    )
+
+
 async def test_auto_clears_override_and_redetects(monkeypatch, reply):
     # Pre-mark as manual override so we can verify it gets cleared.
     identity_state.set_provider_manual_override("@7", value=True)
@@ -174,6 +193,7 @@ async def test_auto_clears_override_and_redetects(monkeypatch, reply):
         "ccgram.multiplexer.tmux.tmux_manager.find_window_by_id",
         AsyncMock(return_value=fake_window),
     )
+    _confirm_live(monkeypatch, "@7")
     monkeypatch.setattr(
         "ccgram.providers.detect_provider_from_pane",
         AsyncMock(return_value="codex"),
@@ -198,6 +218,7 @@ async def test_auto_falls_back_to_shell_and_triggers_ensure_setup(monkeypatch, r
         "ccgram.multiplexer.tmux.tmux_manager.find_window_by_id",
         AsyncMock(return_value=fake_window),
     )
+    _confirm_live(monkeypatch, "@7")
     monkeypatch.setattr(
         "ccgram.providers.detect_provider_from_pane",
         AsyncMock(return_value=""),
@@ -327,6 +348,7 @@ async def test_auto_resolving_to_same_provider_clears_override(
         "ccgram.multiplexer.tmux.tmux_manager.find_window_by_id",
         AsyncMock(return_value=fake_window),
     )
+    _confirm_live(monkeypatch, "@7")
     monkeypatch.setattr(
         "ccgram.providers.detect_provider_from_pane",
         AsyncMock(return_value="claude"),
@@ -386,3 +408,40 @@ async def test_rejected_callbacks_leave_provider_untouched(
 
     update.callback_query.answer.assert_awaited_once_with(expected_answer)
     assert window_store.window_states["@7"].provider_name == "claude"
+
+
+class TestAgentAutoNeedsConfirmedLiveness:
+    """/agent auto persists what it resolves, so an unknown answer must not.
+
+    find_window_by_id returns None both for a window that is gone and for a
+    backend that could not be reached. Resolving that to shell rewrites a
+    working session's provider and clears its transcript bookkeeping.
+    """
+
+    @staticmethod
+    async def _run(monkeypatch, reply, *, listing):
+        identity_state.set_provider_manual_override("@7", value=True)
+        monkeypatch.setattr(
+            "ccgram.multiplexer.tmux.tmux_manager.list_windows_for_reconciliation",
+            AsyncMock(return_value=listing),
+        )
+        monkeypatch.setattr(
+            "ccgram.multiplexer.tmux.tmux_manager.find_window_by_id",
+            AsyncMock(return_value=None),
+        )
+        await ac.agent_command(_make_update("/agent auto"), MagicMock())
+        return window_store.window_states["@7"]
+
+    async def test_unreachable_backend_changes_nothing(self, monkeypatch, reply):
+        state = await self._run(monkeypatch, reply, listing=None)
+
+        assert state.provider_name == "claude"
+        assert state.provider_manual_override is True
+        assert "Could not reach" in _sent_text(reply)
+
+    async def test_confirmed_absence_changes_nothing(self, monkeypatch, reply):
+        state = await self._run(monkeypatch, reply, listing=[])
+
+        assert state.provider_name == "claude"
+        assert state.provider_manual_override is True
+        assert "Could not reach" in _sent_text(reply)

--- a/tests/ccgram/handlers/test_kill_command.py
+++ b/tests/ccgram/handlers/test_kill_command.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from ccgram.multiplexer.base import WindowRef
+
 import pytest
 
 from ccgram.handlers.sessions_dashboard import (
@@ -58,6 +60,9 @@ class TestHandleSessionsKillConfirm:
             (300, 10, "@9"),
         ]
         mock_tm.find_window_by_id = AsyncMock(return_value=MagicMock(window_id="@5"))
+        mock_tm.list_windows_for_reconciliation = AsyncMock(
+            return_value=[WindowRef(window_id="@5", window_name="proj", cwd="/p")]
+        )
         mock_tm.kill_window = AsyncMock()
 
         query = AsyncMock()
@@ -86,6 +91,8 @@ class TestHandleSessionsKillConfirm:
         mock_tr.get_display_name.side_effect = lambda wid: "myproj"
         mock_tr.iter_thread_bindings.return_value = [(100, 42, "@5")]
         mock_tm.find_window_by_id = AsyncMock(return_value=None)
+        # Confirmed gone, not unreachable: the cleanup should still run.
+        mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[])
         mock_tm.kill_window = AsyncMock()
 
         query = AsyncMock()
@@ -106,6 +113,9 @@ class TestHandleSessionsKillConfirm:
         mock_tr.get_display_name.side_effect = lambda wid: "proj"
         mock_tr.iter_thread_bindings.return_value = [(100, 42, "@5")]
         mock_tm.find_window_by_id = AsyncMock(return_value=MagicMock(window_id="@5"))
+        mock_tm.list_windows_for_reconciliation = AsyncMock(
+            return_value=[WindowRef(window_id="@5", window_name="proj", cwd="/p")]
+        )
         mock_tm.kill_window = AsyncMock()
 
         query = AsyncMock()
@@ -115,3 +125,52 @@ class TestHandleSessionsKillConfirm:
             mock_edit.assert_called_once()
             text = mock_edit.call_args[0][1]
             assert "Killed" in text
+
+
+class TestKillNeedsConfirmedLiveness:
+    """Kill deletes every route to a session, so an outage must change nothing.
+
+    find_window_by_id answers None both for a window that is gone and for a
+    backend that could not be reached. Acting on that during an outage leaves
+    the session running with no topic left to reach it from.
+    """
+
+    async def test_unreachable_backend_kills_and_unbinds_nothing(
+        self, _patch_deps
+    ) -> None:
+        _mock_sm, mock_tr, mock_tm, mock_clear = _patch_deps
+        mock_tr.get_display_name.side_effect = lambda wid: "myproj"
+        mock_tr.iter_thread_bindings.return_value = [(100, 42, "@5")]
+        mock_tm.find_window_by_id = AsyncMock(return_value=None)
+        mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=None)
+        mock_tm.kill_window = AsyncMock()
+
+        query = AsyncMock()
+        with patch("ccgram.handlers.sessions_dashboard.safe_edit") as edit:
+            await handle_sessions_kill_confirm(query, 100, "@5", AsyncMock())
+
+        mock_tm.kill_window.assert_not_called()
+        mock_tr.unbind_thread.assert_not_called()
+        mock_clear.assert_not_called()
+        assert "Could not reach" in edit.call_args[0][1]
+
+
+class TestKillRequiresTheKillToSucceed:
+    """A failed kill must not clear the routing to a session still running."""
+
+    async def test_failed_kill_unbinds_nothing(self, _patch_deps) -> None:
+        _mock_sm, mock_tr, mock_tm, mock_clear = _patch_deps
+        mock_tr.get_display_name.side_effect = lambda wid: "myproj"
+        mock_tr.iter_thread_bindings.return_value = [(100, 42, "@5")]
+        mock_tm.list_windows_for_reconciliation = AsyncMock(
+            return_value=[WindowRef(window_id="@5", window_name="proj", cwd="/p")]
+        )
+        mock_tm.kill_window = AsyncMock(return_value=False)
+
+        query = AsyncMock()
+        with patch("ccgram.handlers.sessions_dashboard.safe_edit") as edit:
+            await handle_sessions_kill_confirm(query, 100, "@5", AsyncMock())
+
+        mock_tr.unbind_thread.assert_not_called()
+        mock_clear.assert_not_called()
+        assert "Could not kill" in edit.call_args[0][1]

--- a/tests/ccgram/handlers/test_sessions_dashboard.py
+++ b/tests/ccgram/handlers/test_sessions_dashboard.py
@@ -30,12 +30,16 @@ def deps() -> Iterator[SimpleNamespace]:
         patch("ccgram.handlers.sessions_dashboard.view_window") as view,
         patch("ccgram.handlers.sessions_dashboard.thread_router") as router,
         patch("ccgram.handlers.sessions_dashboard.tmux_manager") as mux,
+        patch(
+            "ccgram.handlers.sessions_dashboard.list_windows_for_reconciliation",
+            new_callable=AsyncMock,
+        ) as listing,
         patch("ccgram.handlers.sessions_dashboard.config") as config,
     ):
         router.get_all_thread_windows.return_value = {}
         router.get_display_name.side_effect = lambda wid: wid
         view.side_effect = lambda wid: WindowState()
-        mux.list_windows = AsyncMock(return_value=[])
+        listing.return_value = []
         config.is_user_allowed.return_value = True
 
         def _sessions(
@@ -44,19 +48,26 @@ def deps() -> Iterator[SimpleNamespace]:
             alive: list[str] | None = None,
             names: dict[str, str] | None = None,
             state: WindowState | None = None,
+            unavailable: bool = False,
         ) -> None:
             router.get_all_thread_windows.return_value = windows
             if names is not None:
                 router.get_display_name.side_effect = lambda wid: names[wid]
             if state is not None:
                 view.side_effect = lambda wid: state
+            if unavailable:
+                listing.return_value = None
+                return
             live = [] if alive is None else alive
-            mux.list_windows = AsyncMock(
-                return_value=[MagicMock(window_id=wid) for wid in live]
-            )
+            listing.return_value = [MagicMock(window_id=wid) for wid in live]
 
         yield SimpleNamespace(
-            view=view, router=router, mux=mux, config=config, sessions=_sessions
+            view=view,
+            router=router,
+            mux=mux,
+            listing=listing,
+            config=config,
+            sessions=_sessions,
         )
 
 
@@ -125,6 +136,32 @@ class TestBuildDashboard:
 
         assert "\U0001f7e2 alive" in text
         assert "⚫ dead" in text
+
+    async def test_liveness_comes_from_the_complete_listing(
+        self, deps: SimpleNamespace
+    ) -> None:
+        """Every id on this dashboard is already bound, so adoptability is
+        beside the point: a live window the backend merely will not auto-adopt
+        must still read as running."""
+        deps.sessions(windows={10: "@0"}, alive=["@0"], names={"@0": "out-of-scope"})
+        deps.mux.list_windows = AsyncMock(return_value=[])
+
+        text, _kb = await _build_dashboard(100)
+
+        assert "\U0001f7e2 out-of-scope" in text
+        assert "⚫" not in text
+
+    async def test_unreachable_multiplexer_is_not_reported_as_stopped(
+        self, deps: SimpleNamespace
+    ) -> None:
+        """A backend that could not be asked is unknown, not stopped."""
+        deps.sessions(windows={10: "@0"}, names={"@0": "proj"}, unavailable=True)
+
+        text, _kb = await _build_dashboard(100)
+
+        assert "⚪ proj" in text
+        assert "⚫" not in text
+        assert "\U0001f7e2" not in text
 
     @pytest.mark.parametrize(
         ("state", "expected_tag", "present"),

--- a/tests/ccgram/handlers/test_sessions_dashboard.py
+++ b/tests/ccgram/handlers/test_sessions_dashboard.py
@@ -292,3 +292,28 @@ class TestSessionsRefresh:
         mock_edit.assert_called_once()
         assert mock_edit.call_args[0][0] is query
         assert "No active sessions" in mock_edit.call_args[0][1]
+
+
+class TestDashboardIdentityFoldsCase:
+    @pytest.mark.parametrize(
+        ("bound", "listed"),
+        [
+            pytest.param("9f1c2d3e-4a5b", "9F1C2D3E-4A5B", id="bound-lower"),
+            pytest.param("9F1C2D3E-4A5B", "9f1c2d3e-4a5b", id="bound-upper"),
+        ],
+    )
+    async def test_a_case_variant_binding_reads_as_running(
+        self, deps: SimpleNamespace, bound: str, listed: str
+    ) -> None:
+        """Raw set membership marked the session stopped and stripped its
+        Esc, Screenshot and Kill controls.
+
+        Both orderings, because the set and the lookup fold independently and
+        one of them alone leaves the other half untested.
+        """
+        deps.sessions(windows={10: bound}, alive=[listed], names={bound: "proj"})
+
+        text, _kb = await _build_dashboard(100)
+
+        assert "\U0001f7e2 proj" in text
+        assert "⚫" not in text

--- a/tests/ccgram/handlers/test_sync_command.py
+++ b/tests/ccgram/handlers/test_sync_command.py
@@ -1,9 +1,14 @@
+import contextlib
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from telegram.error import BadRequest, TelegramError
 
+from ccgram.multiplexer.base import WindowRef
+from ccgram.session import SessionManager
+from ccgram.thread_router import thread_router
+from ccgram.handlers.sync_command import _run_audit
 from ccgram.handlers.callback_data import CB_SYNC_DISMISS, CB_SYNC_FIX
 from ccgram.handlers.sync_command import (
     _cleanup_retired_topics,
@@ -32,6 +37,11 @@ def _patch_deps():
         patch(
             "ccgram.handlers.sync_command.list_windows_for_reconciliation"
         ) as mock_listing,
+        # still_adoptable lives in topic_orchestration and reads its own
+        # backend reference, so the same listing has to answer there.
+        patch(
+            "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+        ) as mock_tm_topics,
         patch("ccgram.handlers.sync_command.config") as mock_cfg,
     ):
         mock_sm.audit_state.return_value = AuditResult(
@@ -41,6 +51,7 @@ def _patch_deps():
         mock_sm.window_states = {}
         mock_tm.list_windows = AsyncMock(return_value=[])
         mock_tm.list_windows_for_reconciliation = mock_listing
+        mock_tm_topics.list_windows_for_reconciliation = mock_listing
         mock_listing.return_value = []
         mock_cfg.is_user_allowed.return_value = True
         yield mock_sm, mock_sms, mock_wq, mock_tr, mock_tm, mock_cfg
@@ -778,8 +789,30 @@ class TestSyncFix:
                 100, 42, retirement_reason="remote_removed"
             )
 
+    @staticmethod
+    def _listing(mock_tm, *refs) -> None:
+        """Set the confirmed listing both the audit and adoption read.
+
+        An orphaned_window issue means a live unbound window, so the window
+        must be in the listing: an issue with an empty listing is a state no
+        backend produces.
+        """
+        mock_tm.list_windows_for_reconciliation.return_value = list(refs)
+
+    @staticmethod
+    def _ref(window_id: str, name: str, *, eligible: bool = True):
+        from ccgram.multiplexer.base import WindowRef
+
+        return WindowRef(
+            window_id=window_id,
+            window_name=name,
+            cwd="/tmp",
+            topic_eligible=eligible,
+        )
+
     async def test_fix_adopts_orphaned_windows(self, _patch_deps) -> None:
-        mock_sm, _, mock_wq, _, _, _ = _patch_deps
+        mock_sm, _, mock_wq, _, mock_tm, _ = _patch_deps
+        self._listing(mock_tm, self._ref("w2:t5", "stray-proj"))
         mock_sm.audit_state.side_effect = [
             AuditResult(
                 issues=[
@@ -808,6 +841,146 @@ class TestSyncFix:
             event = mock_handle.call_args[0][0]
             assert event.window_id == "w2:t5"
             assert event.window_name == "stray-proj"
+
+    async def test_fix_does_not_adopt_a_window_that_became_ineligible(
+        self, _patch_deps
+    ) -> None:
+        """The audit's verdict is re-read at the point of adoption.
+
+        /sync Fix probes every bound topic over the network between the audit
+        and the adoption, so the listing behind an orphaned_window issue can be
+        seconds old. A window that moved out of scope, or went away, in that
+        gap must not be handed a topic.
+        """
+        mock_sm, _, mock_wq, _, mock_tm, _ = _patch_deps
+        mock_sm.audit_state.side_effect = [
+            AuditResult(
+                issues=[AuditIssue("orphaned_window", "w2:t5 (stray)", fixable=True)],
+                total_bindings=1,
+                live_binding_count=1,
+            ),
+            AuditResult(issues=[], total_bindings=1, live_binding_count=1),
+        ]
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="stray-proj"
+        )
+        # First read (the audit) sees it adoptable; by the adoption read it has
+        # moved out of scope.
+        mock_tm.list_windows_for_reconciliation.side_effect = [
+            [self._ref("w2:t5", "stray-proj")],
+            [self._ref("w2:t5", "stray-proj", eligible=False)],
+            [self._ref("w2:t5", "stray-proj", eligible=False)],
+        ]
+
+        query = MagicMock()
+
+        with (
+            patch("ccgram.handlers.sync_command.safe_edit"),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+                new_callable=AsyncMock,
+            ) as mock_handle,
+        ):
+            await handle_sync_fix(query)
+
+        mock_handle.assert_not_called()
+
+    async def test_second_orphan_is_judged_after_the_first_is_created(
+        self, _patch_deps
+    ) -> None:
+        """The re-read is per candidate, not once for the batch.
+
+        Creating a topic is several Telegram round-trips on its own, so a
+        batch-wide snapshot judges the second orphan on a listing taken before
+        the first one's topic existed. Here B leaves scope while A is being
+        created, and must not reach handle_new_window.
+        """
+        mock_sm, _, mock_wq, _, mock_tm, _ = _patch_deps
+        mock_sm.audit_state.side_effect = [
+            AuditResult(
+                issues=[
+                    AuditIssue("orphaned_window", "w2:tA (a)", fixable=True),
+                    AuditIssue("orphaned_window", "w2:tB (b)", fixable=True),
+                ],
+                total_bindings=2,
+                live_binding_count=2,
+            ),
+            AuditResult(issues=[], total_bindings=2, live_binding_count=2),
+        ]
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="proj"
+        )
+
+        both_live = [self._ref("w2:tA", "a"), self._ref("w2:tB", "b")]
+        b_left_scope = [
+            self._ref("w2:tA", "a"),
+            self._ref("w2:tB", "b", eligible=False),
+        ]
+
+        # Creating A's topic is what takes B out of scope, so the flip happens
+        # exactly where a batch-wide snapshot would already have been taken.
+        state = {"windows": both_live}
+
+        async def _listing(*_a, **_kw):
+            return state["windows"]
+
+        # Mutate, never rebind: the fixture aliases this attribute to the
+        # module-level helper patch, and replacing it breaks the alias.
+        mock_tm.list_windows_for_reconciliation.side_effect = _listing
+
+        query = MagicMock()
+
+        with (
+            patch("ccgram.handlers.sync_command.safe_edit"),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+                new_callable=AsyncMock,
+            ) as mock_handle,
+        ):
+
+            async def _create(*_a, **_kw):
+                state["windows"] = b_left_scope
+
+            mock_handle.side_effect = _create
+            await handle_sync_fix(query)
+
+        adopted = [call[0][0].window_id for call in mock_handle.call_args_list]
+        assert adopted == ["w2:tA"]
+
+    async def test_fix_adopts_nothing_when_the_listing_goes_away(
+        self, _patch_deps
+    ) -> None:
+        """Adoption is the one step here that is safe to skip and retry."""
+        mock_sm, _, mock_wq, _, mock_tm, _ = _patch_deps
+        mock_sm.audit_state.side_effect = [
+            AuditResult(
+                issues=[AuditIssue("orphaned_window", "w2:t5 (stray)", fixable=True)],
+                total_bindings=1,
+                live_binding_count=1,
+            ),
+            AuditResult(issues=[], total_bindings=1, live_binding_count=1),
+        ]
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="stray-proj"
+        )
+        mock_tm.list_windows_for_reconciliation.side_effect = [
+            [self._ref("w2:t5", "stray-proj")],
+            None,
+            [self._ref("w2:t5", "stray-proj")],
+        ]
+
+        query = MagicMock()
+
+        with (
+            patch("ccgram.handlers.sync_command.safe_edit"),
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+                new_callable=AsyncMock,
+            ) as mock_handle,
+        ):
+            await handle_sync_fix(query)
+
+        mock_handle.assert_not_called()
 
 
 class TestDeadTopicDetection:
@@ -899,6 +1072,28 @@ class TestPrivateTopicSyncLifecycle:
 
 
 class TestDeadTopicRecreation:
+    """A dead topic is a live window whose Telegram topic was deleted.
+
+    So the window is present in the listing throughout: recreation is refused
+    unless it is confirmed present, because the repair unbinds the thread
+    before creating the replacement.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _window_is_live(self, _patch_deps):
+        """Whatever window a case binds, report it live."""
+        from ccgram.multiplexer.base import WindowRef
+
+        _, _, _, mock_tr, mock_tm, _ = _patch_deps
+
+        async def _listing(*_a, **_kw):
+            bound = mock_tr.get_window_for_thread.return_value
+            if not isinstance(bound, str):
+                return []
+            return [WindowRef(window_id=bound, window_name="proj", cwd="/tmp/proj")]
+
+        mock_tm.list_windows_for_reconciliation.side_effect = _listing
+
     async def test_skips_stale_issue_after_topic_was_rebound(self, _patch_deps) -> None:
         _mock_sm, _mock_sms, mock_wq, mock_tr, _mock_tm, _mock_cfg = _patch_deps
         mock_wq.view_window.return_value = MagicMock(
@@ -1078,7 +1273,15 @@ class TestDeadTopicRecreation:
 
 class TestSyncFixDeadTopic:
     async def test_fix_recreates_dead_topics(self, _patch_deps) -> None:
-        mock_sm, _, mock_wq, mock_tr, _, _ = _patch_deps
+        from ccgram.multiplexer.base import WindowRef
+
+        mock_sm, _, mock_wq, mock_tr, mock_tm, _ = _patch_deps
+        # The window is live throughout — a dead *topic* is a deleted Telegram
+        # topic, not a dead window — and recreation is refused unless the
+        # window is confirmed present at that point.
+        mock_tm.list_windows_for_reconciliation.return_value = [
+            WindowRef(window_id="@2", window_name="qmd-go", cwd="/tmp")
+        ]
         mock_sm.audit_state.side_effect = [
             AuditResult(issues=[], total_bindings=1, live_binding_count=1),
             AuditResult(issues=[], total_bindings=1, live_binding_count=1),
@@ -1117,3 +1320,179 @@ class TestSyncFixDeadTopic:
             mock_handle.assert_called_once()
             report_text = mock_edit.call_args[0][1]
             assert "Recreated 1 topic" in report_text
+
+
+class TestSyncAuditSeparatesLivenessFromAdoption:
+    """`/sync` Fix adopts the orphans the audit reports, so adoption takes the
+    backend's verdict — but liveness must stay complete, or a live binding to
+    an excluded window becomes a fixable ghost that Fix closes.
+    """
+
+    @staticmethod
+    def _windows() -> list[WindowRef]:
+        return [
+            WindowRef(
+                window_id="REFUSED",
+                window_name="elsewhere",
+                cwd="/other",
+                pane_current_command="claude",
+                topic_eligible=False,
+            ),
+            WindowRef(
+                window_id="ALLOWED",
+                window_name="agent",
+                cwd="/proj",
+                pane_current_command="claude",
+            ),
+        ]
+
+    async def test_audit_gets_every_window_live_and_only_some_adoptable(self):
+        """Backend-shaped: the UI listing omits what the backend refuses.
+
+        Mocking ``list_windows`` to return the refused window described a state
+        real agterm cannot produce, so it could not expose the defect. The
+        audit must take liveness from the reconciliation listing, which keeps
+        the refused window, and adoptability from its ``topic_eligible``.
+        """
+        with (
+            patch("ccgram.handlers.sync_command.tmux_manager") as mock_tmux,
+            patch(
+                "ccgram.handlers.sync_command.list_windows_for_reconciliation",
+                new_callable=AsyncMock,
+                return_value=self._windows(),
+            ),
+            patch("ccgram.handlers.sync_command.session_manager") as mock_sm,
+        ):
+            # what a real backend does: the UI listing hides the refused one
+            mock_tmux.list_windows = AsyncMock(
+                return_value=[w for w in self._windows() if w.topic_eligible]
+            )
+            mock_sm.audit_state.return_value = MagicMock(issues=[])
+
+            await _run_audit()
+
+            live_ids, live_pairs, adoptable = mock_sm.audit_state.call_args[0]
+
+        # liveness is not narrowed: the excluded window still exists
+        assert live_ids == {"REFUSED", "ALLOWED"}
+        assert {wid for wid, _ in live_pairs} == {"REFUSED", "ALLOWED"}
+        # adoption is
+        assert adoptable == {"ALLOWED"}
+
+    async def test_an_unavailable_listing_does_not_declare_everything_dead(self):
+        with (
+            patch(
+                "ccgram.handlers.sync_command.list_windows_for_reconciliation",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("ccgram.handlers.sync_command.session_manager") as mock_sm,
+        ):
+            result = await _run_audit()
+
+        assert result is None
+        mock_sm.audit_state.assert_not_called()
+
+    def test_a_live_but_ineligible_binding_is_not_a_ghost(self):
+        """The regression my first attempt at this introduced.
+
+        Narrowing the live set made an existing topic, whose session merely
+        stopped qualifying for new adoption, look like a fixable ghost.
+        """
+        sm = SessionManager()
+        thread_router.bind_thread(1, 2, "REFUSED", chat_id=-100)
+
+        audit = sm.audit_state(
+            {"REFUSED", "ALLOWED"},
+            [("REFUSED", "elsewhere"), ("ALLOWED", "agent")],
+            {"ALLOWED"},
+        )
+
+        ghosts = [i for i in audit.issues if i.category == "ghost_binding"]
+        assert not ghosts, "a live window is not a ghost merely by being excluded"
+
+    def test_an_ineligible_window_is_not_a_fixable_orphan(self):
+        """Both windows must be orphan *candidates*, or this asserts nothing.
+
+        A window becomes an orphan only when ccgram already knows it (session
+        map or window state) and no topic is bound to it. With a fresh manager
+        that set is empty, no orphans are produced at all, and a check that
+        merely says "no orphan mentions REFUSED" passes without running.
+        """
+        sm = SessionManager()
+        with patch.object(
+            SessionManager,
+            "_get_session_map_window_ids",
+            return_value={"REFUSED", "ALLOWED"},
+        ):
+            audit = sm.audit_state(
+                {"REFUSED", "ALLOWED"},
+                [("REFUSED", "elsewhere"), ("ALLOWED", "agent")],
+                {"ALLOWED"},
+            )
+
+        orphans = [i for i in audit.issues if i.category == "orphaned_window"]
+        # the eligible one is offered for adoption...
+        assert any("ALLOWED" in i.detail for i in orphans), (
+            "the eligible window must be a candidate, or the check below is empty"
+        )
+        # ...and the refused one is not
+        assert not any("REFUSED" in i.detail for i in orphans)
+
+    async def test_handle_sync_fix_passes_both_sets_and_never_adopts_the_refused(
+        self,
+    ):
+        """The mutating path. ``handle_sync_fix`` does not call ``_run_audit``,
+        so testing that function proved nothing about pressing Fix.
+        """
+        query = MagicMock()
+        query.get_bot.return_value = MagicMock()
+
+        with (
+            patch(
+                "ccgram.handlers.sync_command.list_windows_for_reconciliation",
+                new_callable=AsyncMock,
+                return_value=self._windows(),
+            ),
+            patch("ccgram.handlers.sync_command.session_manager") as mock_sm,
+            patch("ccgram.handlers.sync_command.session_map_sync"),
+            patch("ccgram.handlers.sync_command.user_preferences"),
+            patch("ccgram.handlers.sync_command.window_query"),
+            patch("ccgram.handlers.sync_command.safe_edit", new_callable=AsyncMock),
+            patch(
+                "ccgram.handlers.sync_command._probe_dead_topics",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "ccgram.handlers.sync_command._retired_topic_issues", return_value=[]
+            ),
+            patch(
+                "ccgram.handlers.sync_command._sync_live_topic_names",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "ccgram.handlers.sync_command._adopt_orphaned_windows",
+                new_callable=AsyncMock,
+            ) as mock_adopt,
+            patch(
+                "ccgram.handlers.sync_command._close_ghost_topics",
+                new_callable=AsyncMock,
+                return_value=(0, 0),
+            ),
+        ):
+            mock_sm.audit_state.return_value = MagicMock(issues=[])
+            with contextlib.suppress(Exception):
+                await handle_sync_fix(query)
+
+            # The later stages are mocked out and can raise on their mocks; the
+            # claim is about the audit call the fix path makes.
+            audits = [c for c in mock_sm.audit_state.call_args_list if len(c[0]) == 3]
+            assert audits, "handle_sync_fix must pass both sets to audit_state"
+            live_ids, live_pairs, adoptable = audits[0][0]
+
+        assert live_ids == {"REFUSED", "ALLOWED"}, "pruning needs every window"
+        assert adoptable == {"ALLOWED"}
+        for call in mock_adopt.call_args_list:
+            for issue in call[0][1]:
+                assert "REFUSED" not in getattr(issue, "detail", "")

--- a/tests/ccgram/handlers/test_sync_command.py
+++ b/tests/ccgram/handlers/test_sync_command.py
@@ -1271,6 +1271,121 @@ class TestDeadTopicRecreation:
             )
 
 
+class TestSyncFixRereadsBeforeDestroying:
+    """Both destructive repairs re-read liveness per candidate.
+
+    handle_sync_fix takes its listing, then probes every bound topic over the
+    network before these run. A ghost verdict can be stale by then, and the
+    repair either removes the user's topic or unbinds a thread to recreate it.
+    """
+
+    @staticmethod
+    def _ghost_issue() -> AuditIssue:
+        return AuditIssue(
+            "ghost_binding", "user:100 thread:42 window:@2 (proj)", fixable=True
+        )
+
+    @staticmethod
+    def _live(window_id: str):
+        from ccgram.multiplexer.base import WindowRef
+
+        return WindowRef(window_id=window_id, window_name="proj", cwd="/tmp")
+
+    async def test_ghost_topic_is_kept_when_the_window_is_back(
+        self, _patch_deps
+    ) -> None:
+        _, _, _, mock_tr, mock_tm, _ = _patch_deps
+        mock_tr.get_window_for_thread.return_value = "@2"
+        mock_tr.resolve_chat_id.return_value = -999
+        mock_tm.list_windows_for_reconciliation.return_value = [self._live("@2")]
+
+        client = AsyncMock()
+        closed, manual = await _close_ghost_topics(client, [self._ghost_issue()])
+
+        assert (closed, manual) == (0, 0)
+        client.delete_forum_topic.assert_not_called()
+        client.close_forum_topic.assert_not_called()
+
+    async def test_ghost_topic_is_kept_when_liveness_is_unknown(
+        self, _patch_deps
+    ) -> None:
+        _, _, _, mock_tr, mock_tm, _ = _patch_deps
+        mock_tr.get_window_for_thread.return_value = "@2"
+        mock_tr.resolve_chat_id.return_value = -999
+        mock_tm.list_windows_for_reconciliation.return_value = None
+
+        client = AsyncMock()
+        closed, manual = await _close_ghost_topics(client, [self._ghost_issue()])
+
+        assert (closed, manual) == (0, 0)
+        client.delete_forum_topic.assert_not_called()
+        client.close_forum_topic.assert_not_called()
+
+    async def test_ghost_topic_is_removed_when_confirmed_gone(
+        self, _patch_deps
+    ) -> None:
+        """The other side of the rule, so the guard cannot pass by refusing all."""
+        _, _, _, mock_tr, mock_tm, _ = _patch_deps
+        mock_tr.get_window_for_thread.return_value = "@2"
+        mock_tr.resolve_chat_id.return_value = -999
+        mock_tm.list_windows_for_reconciliation.return_value = []
+
+        client = AsyncMock()
+        closed, _manual = await _close_ghost_topics(client, [self._ghost_issue()])
+
+        assert closed == 1
+
+    async def test_dead_topic_is_not_recreated_when_the_window_went_away(
+        self, _patch_deps
+    ) -> None:
+        _, _, mock_wq, mock_tr, mock_tm, _ = _patch_deps
+        mock_tr.get_window_for_thread.return_value = "@2"
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="proj"
+        )
+        mock_tm.list_windows_for_reconciliation.return_value = []
+
+        issues = [
+            AuditIssue(
+                "dead_topic", "user:100 thread:42 window:@2 (proj)", fixable=True
+            )
+        ]
+        with patch(
+            "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+            new_callable=AsyncMock,
+        ) as mock_handle:
+            recreated = await _recreate_dead_topics(AsyncMock(), issues)
+
+        assert recreated == 0
+        mock_handle.assert_not_called()
+        mock_tr.unbind_thread.assert_not_called()
+
+    async def test_dead_topic_is_not_recreated_when_liveness_is_unknown(
+        self, _patch_deps
+    ) -> None:
+        _, _, mock_wq, mock_tr, mock_tm, _ = _patch_deps
+        mock_tr.get_window_for_thread.return_value = "@2"
+        mock_wq.view_window.return_value = MagicMock(
+            session_id="s1", cwd="/tmp", window_name="proj"
+        )
+        mock_tm.list_windows_for_reconciliation.return_value = None
+
+        issues = [
+            AuditIssue(
+                "dead_topic", "user:100 thread:42 window:@2 (proj)", fixable=True
+            )
+        ]
+        with patch(
+            "ccgram.handlers.topics.topic_orchestration.handle_new_window",
+            new_callable=AsyncMock,
+        ) as mock_handle:
+            recreated = await _recreate_dead_topics(AsyncMock(), issues)
+
+        assert recreated == 0
+        mock_handle.assert_not_called()
+        mock_tr.unbind_thread.assert_not_called()
+
+
 class TestSyncFixDeadTopic:
     async def test_fix_recreates_dead_topics(self, _patch_deps) -> None:
         from ccgram.multiplexer.base import WindowRef

--- a/tests/ccgram/handlers/text/test_text_handler.py
+++ b/tests/ccgram/handlers/text/test_text_handler.py
@@ -16,6 +16,7 @@ from ccgram.handlers.text.text_handler import (
     handle_text_message,
 )
 from ccgram.handlers.polling.polling_state import lifecycle_strategy
+from ccgram.multiplexer.base import WindowRef
 from ccgram.handlers.topics.directory_browser import (
     STATE_BROWSING_DIRECTORY,
     STATE_KEY,
@@ -152,7 +153,9 @@ class TestHandleUnboundTopic:
 class TestHandleDeadWindow:
     @patch(f"{_TH}.tmux_manager")
     async def test_alive_window_returns_false(self, mock_tm: MagicMock) -> None:
-        mock_tm.find_window_by_id = AsyncMock(return_value=MagicMock())
+        mock_tm.list_windows_for_reconciliation = AsyncMock(
+            return_value=[WindowRef(window_id="@0", window_name="p", cwd="/p")]
+        )
         message = AsyncMock()
 
         result = await _handle_dead_window("@0", 100, 42, "hello", {}, message)
@@ -164,7 +167,9 @@ class TestHandleDeadWindow:
         self, mock_tm: MagicMock
     ) -> None:
         lifecycle_strategy.start_autoclose_timer(100, 42, "dead", 100.0)
-        mock_tm.find_window_by_id = AsyncMock(return_value=MagicMock())
+        mock_tm.list_windows_for_reconciliation = AsyncMock(
+            return_value=[WindowRef(window_id="@0", window_name="p", cwd="/p")]
+        )
         message = AsyncMock()
 
         result = await _handle_dead_window("@0", 100, 42, "hello", {}, message)
@@ -173,7 +178,15 @@ class TestHandleDeadWindow:
         assert lifecycle_strategy.get_state(100, 42).autoclose is None
 
     async def test_live_shell_after_agent_exit_shows_recovery(self) -> None:
-        window = MagicMock(pane_current_command="bash")
+        # A real ref, not a MagicMock: WindowRef.matches compares ids, and a
+        # mock would fail to match and route this through the window-is-gone
+        # branch, passing the assertions below without exercising the case.
+        window = WindowRef(
+            window_id="@0",
+            window_name="project",
+            cwd="/tmp/project",
+            pane_current_command="bash",
+        )
         view = MagicMock(cwd="/tmp/project", provider_name="claude")
         message = AsyncMock()
         message.chat.id = -100
@@ -190,7 +203,7 @@ class TestHandleDeadWindow:
             patch(f"{_TH}.safe_reply", new_callable=AsyncMock) as mock_reply,
             patch(f"{_TH}.Path") as mock_path,
         ):
-            mock_tm.find_window_by_id = AsyncMock(return_value=window)
+            mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[window])
             mock_query.get_window_provider.return_value = "claude"
             mock_query.view_window.return_value = view
             mock_router.get_display_name.return_value = "project"
@@ -214,7 +227,7 @@ class TestHandleDeadWindow:
         mock_render: MagicMock,
         mock_reply: AsyncMock,
     ) -> None:
-        mock_tm.find_window_by_id = AsyncMock(return_value=None)
+        mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[])
         mock_tr.get_display_name.return_value = "project"
         ws = MagicMock()
         ws.cwd = "/tmp/project"
@@ -253,7 +266,7 @@ class TestHandleDeadWindow:
         mock_tm: MagicMock,
         mock_reply: AsyncMock,
     ) -> None:
-        mock_tm.find_window_by_id = AsyncMock(return_value=None)
+        mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[])
         mock_tr.get_display_name.return_value = "project"
         ws = MagicMock()
         ws.cwd = "/tmp/project"
@@ -292,7 +305,7 @@ class TestHandleDeadWindow:
         _mock_reply: AsyncMock,
         cwd: str,
     ) -> None:
-        mock_tm.find_window_by_id = AsyncMock(return_value=None)
+        mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[])
         mock_tr.get_display_name.return_value = "project"
         ws = MagicMock()
         ws.cwd = cwd
@@ -592,3 +605,163 @@ class TestBashCaptureCleanup:
             await task_a  # A's finally runs
 
         assert _bash_capture_tasks.get(key) is sentinel
+
+
+class TestDeadWindowNeedsAConfirmedRead:
+    """An unreachable backend must not unbind a live topic.
+
+    find_window_by_id answers None both for a window that is gone and for a
+    backend that could not be reached. With a stale or invalid cached cwd, the
+    dead branch unbinds the thread as system_replacement and drops the user
+    into the directory browser, so the live session loses its topic.
+    """
+
+    async def test_unreachable_backend_preserves_the_binding(self) -> None:
+        message = AsyncMock()
+        with (
+            patch(f"{_TH}.tmux_manager") as mock_tm,
+            patch(f"{_TH}.window_query") as mock_query,
+            patch(f"{_TH}.thread_router") as mock_router,
+            patch(f"{_TH}.safe_reply", new_callable=AsyncMock) as mock_reply,
+        ):
+            mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=None)
+            mock_query.is_legacy_herdr.return_value = False
+            # An invalid cached cwd: the shape that reaches the unbind.
+            mock_query.view_window.return_value = MagicMock(cwd="/nonexistent")
+
+            result = await _handle_dead_window("@0", 100, 42, "hi", {}, message)
+
+        assert result is True
+        mock_router.unbind_thread.assert_not_called()
+        assert "Could not reach" in mock_reply.await_args[0][1]
+
+
+class TestStaleDeadMarkerDoesNotOutliveTheWindow:
+    """The dead marker is sticky, so a live window must be able to clear it.
+
+    tick_window returns early once the marker is set, so nothing else clears
+    it. An agterm session comes back under the same UUID after an app restart,
+    and with a stale cached cwd the dead branch unbinds the topic.
+    """
+
+    async def test_live_agent_clears_the_marker_instead_of_unbinding(self) -> None:
+        lifecycle_strategy.mark_dead_notified(100, 42, "@0")
+        window = WindowRef(
+            window_id="@0",
+            window_name="project",
+            cwd="/tmp/project",
+            pane_current_command="claude",
+        )
+        message = AsyncMock()
+        with (
+            patch(f"{_TH}.tmux_manager") as mock_tm,
+            patch(f"{_TH}.window_query") as mock_query,
+            patch(f"{_TH}.thread_router") as mock_router,
+            patch(
+                f"{_TH}.agent_origin_returned_to_shell",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[window])
+            mock_query.is_legacy_herdr.return_value = False
+            # Stale cached cwd: the shape that otherwise reaches the unbind.
+            mock_query.view_window.return_value = MagicMock(cwd="/nonexistent")
+
+            result = await _handle_dead_window("@0", 100, 42, "hi", {}, message)
+
+        assert result is False
+        mock_router.unbind_thread.assert_not_called()
+        assert not lifecycle_strategy.is_dead_notified(100, 42, "@0")
+
+    async def test_shell_return_still_shows_recovery(self) -> None:
+        """The marker clearing must not swallow the case recovery exists for."""
+        window = WindowRef(
+            window_id="@0",
+            window_name="project",
+            cwd="/tmp/project",
+            pane_current_command="bash",
+        )
+        message = AsyncMock()
+        message.chat.id = -100
+        with (
+            patch(f"{_TH}.tmux_manager") as mock_tm,
+            patch(f"{_TH}.window_query") as mock_query,
+            patch(f"{_TH}.thread_router") as mock_router,
+            patch(
+                f"{_TH}.agent_origin_returned_to_shell",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(f"{_TH}.render_banner", return_value=("recovery", MagicMock())),
+            patch(f"{_TH}.safe_reply", new_callable=AsyncMock) as mock_reply,
+            patch(f"{_TH}.Path") as mock_path,
+        ):
+            mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[window])
+            mock_query.is_legacy_herdr.return_value = False
+            mock_query.get_window_provider.return_value = "claude"
+            mock_query.view_window.return_value = MagicMock(
+                cwd="/tmp/project", provider_name="claude"
+            )
+            mock_router.get_display_name.return_value = "project"
+            mock_path.return_value.is_dir.return_value = True
+
+            result = await _handle_dead_window("@0", 100, 42, "hi", {}, message)
+
+        assert result is True
+        mock_reply.assert_awaited_once()
+
+
+class TestUnknownAgentStateDoesNotClearTheMarker:
+    """agterm reports no foreground for a shell, an unreadable process group
+    and a failed lookup alike, and detection maps all three to "". Treating
+    that as "an agent is running" clears the dead marker, forwards the next
+    message, and the shared send guard types it into the pane with Return, so
+    a session restored under the same UUID as a plain shell runs it.
+    """
+
+    @staticmethod
+    async def _run(pane_command: str) -> tuple[bool, AsyncMock, AsyncMock]:
+        lifecycle_strategy.mark_dead_notified(100, 42, "@0")
+        window = WindowRef(
+            window_id="@0",
+            window_name="project",
+            cwd="/tmp/project",
+            pane_current_command=pane_command,
+        )
+        message = AsyncMock()
+        with (
+            patch(f"{_TH}.tmux_manager") as mock_tm,
+            patch(f"{_TH}.window_query") as mock_query,
+            patch(f"{_TH}.thread_router") as mock_router,
+            patch(
+                f"{_TH}.agent_origin_returned_to_shell",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(f"{_TH}.safe_reply", new_callable=AsyncMock) as mock_reply,
+        ):
+            mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[window])
+            mock_query.is_legacy_herdr.return_value = False
+            # Stale cached cwd: the shape that reaches the unbind.
+            mock_query.view_window.return_value = MagicMock(cwd="/nonexistent")
+            result = await _handle_dead_window("@0", 100, 42, "hi", {}, message)
+        return result, mock_router, mock_reply
+
+    async def test_an_unknown_foreground_keeps_the_marker_and_forwards_nothing(
+        self,
+    ) -> None:
+        handled, mock_router, mock_reply = await self._run("")
+
+        assert handled is True, "the message must not be forwarded to the pane"
+        assert lifecycle_strategy.is_dead_notified(100, 42, "@0")
+        mock_router.unbind_thread.assert_not_called()
+        assert "nothing confirms an agent" in mock_reply.await_args[0][1]
+
+    async def test_a_named_agent_still_clears_the_marker(self) -> None:
+        """The other side: a confirmed agent is why the clearing exists."""
+        handled, mock_router, _ = await self._run("claude")
+
+        assert handled is False, "a live agent's topic keeps forwarding"
+        assert not lifecycle_strategy.is_dead_notified(100, 42, "@0")
+        mock_router.unbind_thread.assert_not_called()

--- a/tests/ccgram/handlers/topics/test_new_window_sync.py
+++ b/tests/ccgram/handlers/topics/test_new_window_sync.py
@@ -73,6 +73,9 @@ def _wire_orchestration(
 
 
 async def _detect(monitor: SessionMonitor, session_map: dict) -> None:
+    # Adoption is gated on the backend's verdict from the current listing, which
+    # the monitor loop derives before reaching this call. These windows are live
+    # and on tmux every live window is adoptable, so mirror that here.
     with patch.object(
         monitor,
         "_load_current_session_map",
@@ -80,7 +83,7 @@ async def _detect(monitor: SessionMonitor, session_map: dict) -> None:
         new_callable=AsyncMock,
         return_value=session_map,
     ):
-        await monitor._detect_and_cleanup_changes()
+        await monitor._detect_and_cleanup_changes(adoptable_window_ids=set(session_map))
 
 
 class TestNewWindowSyncWithBindings:

--- a/tests/ccgram/handlers/topics/test_topic_lifecycle.py
+++ b/tests/ccgram/handlers/topics/test_topic_lifecycle.py
@@ -6,6 +6,7 @@ import pytest
 from telegram import Bot
 from telegram.error import BadRequest, RetryAfter
 
+from ccgram.multiplexer.base import WindowRef
 from ccgram.window_view import WindowView
 
 from ccgram.handlers.topics.topic_lifecycle import (
@@ -117,6 +118,9 @@ class TestCheckAutocloseTimers:
             mock_config.autoclose_dead_minutes = 10
             mock_router.get_window_for_thread.return_value = "@0"
             mock_tmux.find_window_by_id = AsyncMock(return_value=MagicMock())
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(
+                return_value=[WindowRef(window_id="@1", window_name="p", cwd="/p")]
+            )
             await check_autoclose_timers(bot)
         bot.delete_forum_topic.assert_not_called()
         assert lifecycle_strategy.get_state(user_id, thread_id).autoclose is None
@@ -481,3 +485,37 @@ class TestProbeTopicExistence:
                 bot.unpin_all_forum_topic_messages.assert_not_called()
         finally:
             tl._probe_pin_disabled.discard(wid)
+
+
+class TestAutocloseNeedsConfirmedDeath:
+    """An unreachable backend must not close the user's topic.
+
+    find_window_by_id answers None for a window that is gone and for a backend
+    that could not be reached, and this path closes a forum topic on that
+    answer. Unknown defers to the next expiry.
+    """
+
+    async def test_unreachable_backend_defers_the_close(self) -> None:
+        from ccgram.handlers.topics.topic_lifecycle import _close_expired_topic
+
+        client = AsyncMock()
+        with (
+            patch("ccgram.handlers.topics.topic_lifecycle.tmux_manager") as mock_tmux,
+            patch("ccgram.handlers.topics.topic_lifecycle.thread_router") as mock_tr,
+            patch(
+                "ccgram.handlers.topics.topic_lifecycle.lifecycle_strategy"
+            ) as strategy,
+            patch("ccgram.handlers.topics.topic_lifecycle.window_query") as wq,
+        ):
+            mock_tr.iter_thread_bindings_with_chat.return_value = [
+                (100, -100200, 42, "@1")
+            ]
+            mock_tr.get_window_for_thread.return_value = "@1"
+            wq.view_window.return_value = MagicMock(state="dead")
+            mock_tmux.find_window_by_id = AsyncMock(return_value=None)
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=None)
+
+            await _close_expired_topic(client, 100, 42, "dead")
+
+        client.close_forum_topic.assert_not_called()
+        strategy.clear_autoclose_timer.assert_not_called()

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from telegram.error import BadRequest, RetryAfter, TelegramError, TimedOut
 
+from ccgram.multiplexer.base import WindowRef
 from ccgram.handlers.topics.topic_orchestration import (
     collect_target_chats,
     _is_window_already_bound,
@@ -33,6 +34,10 @@ def _mock_tmux():
     mock_window.pane_current_command = ""
     with patch("ccgram.handlers.topics.topic_orchestration.tmux_manager") as mock_tmux:
         mock_tmux.find_window_by_id = AsyncMock(return_value=mock_window)
+        # still_present reads this listing, and a confirmed empty one means
+        # "that window is gone" — the default the rebind tests below want. A
+        # test that needs the old window alive supplies it explicitly.
+        mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
         yield mock_tmux
 
 
@@ -554,6 +559,8 @@ class TestHandleNewWindow:
             mock_tr.get_display_name.return_value = "🟡 reflex-gh"
             mock_tr.resolve_chat_id.return_value = -100200
             mock_tmux.find_window_by_id = AsyncMock(return_value=None)
+            # Confirmed empty: the old window really is gone, not unreachable.
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
 
             await handle_new_window(event, bot)
 
@@ -587,6 +594,10 @@ class TestHandleNewWindow:
         ):
             mock_tmux.capabilities.supports_display_name_rebind = False
             mock_tmux.find_window_by_id = AsyncMock(return_value=None)
+            # Confirmed empty: the old window really is gone, not unreachable.
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
+            # Confirmed empty: the old window really is gone, not unreachable.
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
             mock_tr.has_window.return_value = False
             mock_tr.iter_thread_bindings.return_value = iter([(100, 120014, "old")])
             mock_tr.resolve_chat_id.return_value = -100200
@@ -626,6 +637,8 @@ class TestHandleNewWindow:
             mock_tr.get_display_name.return_value = "reflex-gh"
             mock_tr.resolve_chat_id.return_value = -100200
             mock_tmux.find_window_by_id = AsyncMock(return_value=None)
+            # Confirmed empty: the old window really is gone, not unreachable.
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
             mock_tr.group_chat_ids = {"100:120014": -100200}
             mock_config.group_id = None
             mock_config.allowed_users = {100}
@@ -716,7 +729,9 @@ class TestAdoptUnboundWindows:
                 new_callable=AsyncMock,
             ) as mock_adopt,
         ):
-            mock_tmux.list_windows = AsyncMock(return_value=[mock_window])
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(
+                return_value=[mock_window]
+            )
             mock_sm.audit_state.return_value = self._audit("orphaned_window")
 
             await adopt_unbound_windows(bot)
@@ -738,9 +753,123 @@ class TestAdoptUnboundWindows:
                 new_callable=AsyncMock,
             ) as mock_adopt,
         ):
-            mock_tmux.list_windows = AsyncMock(return_value=[])
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[])
             mock_sm.audit_state.return_value = self._audit()
 
             await adopt_unbound_windows(bot)
 
         mock_adopt.assert_not_called()
+
+
+class TestAdoptUnboundWindowsRespectsEligibility:
+    """Startup orphan repair creates topics, so it takes the backend's verdict.
+
+    Adoption narrows, liveness does not: narrowing the live set would turn a
+    present-but-excluded window into a fixable ghost, which is what the first
+    attempt at this did.
+    """
+
+    async def test_an_ineligible_window_is_live_but_not_adoptable(self):
+        bot = AsyncMock()
+        refused = WindowRef(
+            window_id="OUT-OF-SCOPE",
+            window_name="elsewhere",
+            cwd="/other",
+            pane_current_command="claude",
+            topic_eligible=False,
+        )
+        allowed = WindowRef(
+            window_id="IN-SCOPE",
+            window_name="agent",
+            cwd="/proj",
+            pane_current_command="claude",
+        )
+
+        with (
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.session_manager"
+            ) as mock_sm,
+            patch(
+                "ccgram.handlers.sync_command._adopt_orphaned_windows",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(
+                return_value=[refused, allowed]
+            )
+            audit = MagicMock()
+            audit.issues = []
+            mock_sm.audit_state.return_value = audit
+
+            await adopt_unbound_windows(bot)
+
+            live_ids, live_pairs, adoptable = mock_sm.audit_state.call_args[0]
+
+        # Liveness stays complete: a present-but-excluded window is not a ghost.
+        assert live_ids == {"OUT-OF-SCOPE", "IN-SCOPE"}
+        assert {wid for wid, _ in live_pairs} == {"OUT-OF-SCOPE", "IN-SCOPE"}
+        # Only adoption is narrowed.
+        assert adoptable == {"IN-SCOPE"}
+
+
+class TestAdoptUnboundWindowsNeedsAConfirmedListing:
+    """Startup repair creates topics; it must not run on a guess."""
+
+    async def test_unavailable_listing_adopts_nothing(self):
+        bot = AsyncMock()
+
+        with (
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+            ) as mock_tmux,
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.session_manager"
+            ) as mock_sm,
+            patch(
+                "ccgram.handlers.sync_command._adopt_orphaned_windows",
+                new_callable=AsyncMock,
+            ) as mock_adopt,
+        ):
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=None)
+
+            await adopt_unbound_windows(bot)
+
+        mock_adopt.assert_not_called()
+        mock_sm.audit_state.assert_not_called()
+
+
+class TestStillAdoptable:
+    """The point-of-use check behind every automatic adoption."""
+
+    @staticmethod
+    def _ref(window_id: str, *, eligible: bool):
+        return WindowRef(
+            window_id=window_id,
+            window_name="proj",
+            cwd="/proj",
+            topic_eligible=eligible,
+        )
+
+    async def _verdict(self, windows) -> bool:
+        from ccgram.handlers.topics.topic_orchestration import still_adoptable
+
+        with patch(
+            "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+        ) as mock_tmux:
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=windows)
+            return await still_adoptable("@5")
+
+    async def test_eligible_window_passes(self):
+        assert await self._verdict([self._ref("@5", eligible=True)]) is True
+
+    async def test_window_that_left_scope_is_refused(self):
+        assert await self._verdict([self._ref("@5", eligible=False)]) is False
+
+    async def test_window_that_went_away_is_refused(self):
+        assert await self._verdict([self._ref("@9", eligible=True)]) is False
+
+    async def test_unconfirmed_listing_is_refused(self):
+        assert await self._verdict(None) is False

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -873,3 +873,105 @@ class TestStillAdoptable:
 
     async def test_unconfirmed_listing_is_refused(self):
         assert await self._verdict(None) is False
+
+
+class TestSameNameRebindNeedsConfirmedDeath:
+    """Rebinding hands a live Telegram topic to a different window.
+
+    The old window is judged gone, then the topic is probed over the network,
+    and only then is the binding overwritten. Both reads must be confirmed:
+    find_window_by_id answers None for a window that is gone and for a backend
+    that could not be reached alike.
+    """
+
+    @staticmethod
+    def _ref(window_id: str):
+        return WindowRef(window_id=window_id, window_name="reflex-gh", cwd="/p")
+
+    async def _run(self, listings):
+        from ccgram.handlers.topics.topic_orchestration import (
+            _rebind_existing_topic_by_name,
+        )
+
+        event = _make_event(window_id="@new", window_name="reflex-gh")
+        with (
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.thread_router"
+            ) as mock_tr,
+            patch("ccgram.handlers.topics.topic_orchestration.tmux_manager") as mock_tm,
+            patch(
+                "ccgram.handlers.topics.topic_orchestration.probe_topic_exists",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            mock_tr.iter_thread_bindings.return_value = [(100, 42, "@old")]
+            mock_tr.get_display_name.return_value = "reflex-gh"
+            mock_tr.resolve_chat_id.return_value = -100200
+            mock_tm.list_windows_for_reconciliation = AsyncMock(side_effect=listings)
+
+            result = await _rebind_existing_topic_by_name(
+                event, AsyncMock(), "reflex-gh"
+            )
+        return result, mock_tr
+
+    async def test_unavailable_listing_does_not_rebind(self) -> None:
+        result, mock_tr = await self._run([None, None])
+
+        assert result is False
+        mock_tr.bind_thread.assert_not_called()
+        mock_tr.unbind_thread.assert_not_called()
+
+    async def test_old_window_reappearing_during_the_probe_does_not_rebind(
+        self,
+    ) -> None:
+        """Gone when the candidate was chosen, back by the time of the write."""
+        result, mock_tr = await self._run([[], [self._ref("@old")]])
+
+        assert result is False
+        mock_tr.bind_thread.assert_not_called()
+        mock_tr.unbind_thread.assert_not_called()
+
+    async def test_confirmed_dead_old_window_still_rebinds(self) -> None:
+        """The other side, so the guard cannot pass by refusing everything."""
+        result, mock_tr = await self._run([[], []])
+
+        assert result is True
+        mock_tr.bind_thread.assert_called_once()
+
+
+class TestAdoptionIdentityFoldsCase:
+    """An orphan issue carries the persisted id, which may differ in case.
+
+    agterm reports UUIDs uppercase while a caller may round-trip one
+    lowercased. Comparing raw meant the refreshed listing looked as though the
+    window had gone, so /sync Fix skipped creating its topic on every attempt.
+    """
+
+    async def test_a_case_variant_id_is_still_adoptable(self) -> None:
+        from ccgram.handlers.topics.topic_orchestration import still_adoptable
+
+        live = WindowRef(
+            window_id="9F1C2D3E-4A5B", window_name="proj", cwd="/p", topic_eligible=True
+        )
+        with patch(
+            "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+        ) as mock_tmux:
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[live])
+            assert await still_adoptable("9f1c2d3e-4a5b") is True
+
+    async def test_an_ineligible_case_variant_is_still_refused(self) -> None:
+        """Folding case must not soften the eligibility half of the check."""
+        from ccgram.handlers.topics.topic_orchestration import still_adoptable
+
+        live = WindowRef(
+            window_id="9F1C2D3E-4A5B",
+            window_name="proj",
+            cwd="/p",
+            topic_eligible=False,
+        )
+        with patch(
+            "ccgram.handlers.topics.topic_orchestration.tmux_manager"
+        ) as mock_tmux:
+            mock_tmux.list_windows_for_reconciliation = AsyncMock(return_value=[live])
+            assert await still_adoptable("9f1c2d3e-4a5b") is False

--- a/tests/ccgram/providers/test_autodetect.py
+++ b/tests/ccgram/providers/test_autodetect.py
@@ -200,6 +200,9 @@ class _NewWindowHarness:
             window = MagicMock()
             window.pane_current_command = pane_command
         self.mux.find_window_by_id = AsyncMock(return_value=window)
+        # still_present reads this; confirmed empty means no stale same-name
+        # binding is alive, which is the state these cases describe.
+        self.mux.list_windows_for_reconciliation = AsyncMock(return_value=[])
         self.mux.get_pane_title = AsyncMock(return_value=pane_title)
 
         event = NewWindowEvent(
@@ -307,7 +310,7 @@ class TestSessionMonitorProviderFromMap:
             ),
             patch("ccgram.session.session_manager") as mock_sm,
         ):
-            await monitor._detect_and_cleanup_changes(adoptable_window_ids=None)
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=set(new_map))
             mock_sm.set_window_provider.assert_called_once_with("@5", "codex")
 
     async def test_skips_provider_when_not_in_map(self, tmp_path) -> None:
@@ -335,5 +338,5 @@ class TestSessionMonitorProviderFromMap:
             ),
             patch("ccgram.session.session_manager") as mock_sm,
         ):
-            await monitor._detect_and_cleanup_changes(adoptable_window_ids=None)
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=set(new_map))
             mock_sm.set_window_provider.assert_not_called()

--- a/tests/ccgram/providers/test_autodetect.py
+++ b/tests/ccgram/providers/test_autodetect.py
@@ -307,7 +307,7 @@ class TestSessionMonitorProviderFromMap:
             ),
             patch("ccgram.session.session_manager") as mock_sm,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=None)
             mock_sm.set_window_provider.assert_called_once_with("@5", "codex")
 
     async def test_skips_provider_when_not_in_map(self, tmp_path) -> None:
@@ -335,5 +335,5 @@ class TestSessionMonitorProviderFromMap:
             ),
             patch("ccgram.session.session_manager") as mock_sm,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=None)
             mock_sm.set_window_provider.assert_not_called()

--- a/tests/ccgram/test_agterm_backend.py
+++ b/tests/ccgram/test_agterm_backend.py
@@ -896,18 +896,32 @@ async def test_create_window_falls_back_to_the_cwd_basename(tmp_path) -> None:
 
 
 async def test_listings_exclude_the_session_ccgram_itself_runs_in() -> None:
-    """Every listed window is one discovery can auto-adopt.
+    """ccgram's own session is never offered, in either listing.
 
     The tmux backend skips ``config.own_window_id`` for this reason; without
-    the equivalent the bot binds a topic to its own terminal.
+    the equivalent the bot binds a topic to its own terminal. This exclusion is
+    not the ``topic_eligible`` verdict, which governs unattended adoption only:
+    a picker selection is an explicit bind and may name a window this listing
+    would not auto-adopt. Binding the bot's own session is wrong either way.
     """
     fake = (
         FakeAgtermctl()
         .on("window", "list", out=_windows())
         .on("tree", out=_tree(_session(SESSION_A), _session(SESSION_B, name="blog")))
     )
-    windows = await _manager(fake, own=SESSION_A).list_windows()
-    assert [w.window_id for w in windows] == [SESSION_B]
+    manager = _manager(fake, own=SESSION_A)
+
+    # Gone from the selection listing: the picker must never offer it.
+    assert [w.window_id for w in await manager.list_windows()] == [SESSION_B]
+
+    # Present in the complete listing, because it exists — but refused for
+    # adoption there, which is what keeps discovery off it.
+    complete = await manager.list_windows_for_reconciliation()
+    assert complete is not None
+    assert {w.window_id: w.topic_eligible for w in complete} == {
+        SESSION_A: False,
+        SESSION_B: True,
+    }
 
 
 async def test_own_session_exclusion_is_case_insensitive() -> None:
@@ -1205,3 +1219,180 @@ async def test_reconciliation_ignores_the_workspace_scope() -> None:
     ).list_windows_for_reconciliation()
     assert windows is not None
     assert sorted(w.window_id for w in windows) == sorted([SESSION_A, SESSION_B])
+
+
+# ── adoption travels on the window ─────────────────────────────────────
+
+
+async def test_reconciliation_listing_marks_what_discovery_may_not_adopt() -> None:
+    """The listing stays complete, but each window carries its verdict.
+
+    session_monitor hands the reconciliation listing straight to discovery, so
+    a filter that lives only in list_windows never runs for discovery at all.
+    """
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on(
+            "tree",
+            out=_multi_tree(
+                {
+                    "code": [_session(SESSION_A, name="agent")],
+                    "personal": [_session(SESSION_B, name="elsewhere")],
+                }
+            ),
+        )
+    )
+    windows = await _manager(
+        fake, workspaces=("code",)
+    ).list_windows_for_reconciliation()
+    assert windows is not None
+    by_name = {w.window_name: w.topic_eligible for w in windows}
+    # both present, so cleanup still sees everything that exists
+    assert set(by_name) == {"agent", "elsewhere"}
+    # but only the in-scope one may be adopted
+    assert by_name == {"agent": True, "elsewhere": False}
+
+
+async def test_own_session_is_marked_ineligible_in_the_reconciliation_listing() -> None:
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on("tree", out=_tree(_session(SESSION_A), _session(SESSION_B, name="other")))
+    )
+    windows = await _manager(
+        fake, own=SESSION_A, workspaces=None
+    ).list_windows_for_reconciliation()
+    assert windows is not None
+    assert {w.window_id: w.topic_eligible for w in windows} == {
+        SESSION_A: False,
+        SESSION_B: True,
+    }
+
+
+async def test_underscore_named_sessions_are_marked_ineligible() -> None:
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on("tree", out=_tree(_session(SESSION_A, name="_scratch")))
+    )
+    windows = await _manager(fake, workspaces=None).list_windows_for_reconciliation()
+    assert windows is not None
+    assert windows[0].topic_eligible is False
+
+
+async def test_find_window_by_id_is_not_gated_by_eligibility() -> None:
+    """Addressing a known id is not discovery: an out-of-scope window stays drivable."""
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on("tree", out=_multi_tree({"personal": [_session(SESSION_A)]}))
+    )
+    found = await _manager(fake, workspaces=("code",)).find_window_by_id(SESSION_A)
+    assert found is not None
+    assert found.window_id == SESSION_A
+
+
+async def test_a_non_agent_session_in_scope_is_present_but_ineligible() -> None:
+    """Present for cleanup, refused for adoption.
+
+    agterm reports whatever holds the pane, so an in-scope session running an
+    editor or a build must not be adopted, while still existing as far as
+    reconciliation is concerned.
+    """
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on(
+            "tree",
+            out=_tree(
+                _session(SESSION_A, name="editing", foreground=["vim", "notes.md"]),
+                _session(SESSION_B, name="agent", foreground=["claude"]),
+            ),
+        )
+    )
+    windows = await _manager(fake).list_windows_for_reconciliation()
+    assert windows is not None
+    assert {w.window_name: w.topic_eligible for w in windows} == {
+        "editing": False,
+        "agent": True,
+    }
+
+
+async def test_a_non_agent_session_in_scope_is_still_offered_for_explicit_binding() -> (
+    None
+):
+    """The selection listing narrows by visibility, never by adoptability.
+
+    This is the case the three-question contract rests on: `list_windows`
+    keeps an in-scope session running an editor, carrying
+    ``topic_eligible=False``, so a user can bind it from the picker while
+    unattended discovery — which reads the reconciliation listing and this
+    verdict — leaves it alone. Filtering it out here would silently remove a
+    session the user can see in agterm from the picker.
+    """
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on(
+            "tree",
+            out=_tree(
+                _session(SESSION_A, name="editing", foreground=["vim", "notes.md"]),
+                _session(SESSION_B, name="agent", foreground=["claude"]),
+            ),
+        )
+    )
+
+    windows = await _manager(fake).list_windows()
+
+    assert {w.window_name: w.topic_eligible for w in windows} == {
+        "editing": False,
+        "agent": True,
+    }
+
+
+async def test_a_wrapped_agent_is_eligible() -> None:
+    """codex runs as ``node .../codex``; argv[0] alone would reject it."""
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on(
+            "tree",
+            out=_tree(
+                _session(
+                    SESSION_A,
+                    name="codex-session",
+                    foreground=["node", "/opt/homebrew/bin/codex", "--yolo"],
+                )
+            ),
+        )
+    )
+    windows = await _manager(fake).list_windows_for_reconciliation()
+    assert windows is not None
+    assert windows[0].topic_eligible is True
+
+
+async def test_a_build_running_under_node_is_not_an_agent() -> None:
+    """The wrapper skip must not turn every node process into an agent."""
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on(
+            "tree",
+            out=_tree(_session(SESSION_A, foreground=["node", "server.js"])),
+        )
+    )
+    windows = await _manager(fake).list_windows_for_reconciliation()
+    assert windows is not None
+    assert windows[0].topic_eligible is False
+
+
+async def test_an_idle_shell_session_is_ineligible() -> None:
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on("tree", out=_tree(_session(SESSION_A, foreground=None)))
+    )
+    windows = await _manager(fake).list_windows_for_reconciliation()
+    assert windows is not None
+    assert windows[0].topic_eligible is False

--- a/tests/ccgram/test_agterm_backend.py
+++ b/tests/ccgram/test_agterm_backend.py
@@ -1396,3 +1396,167 @@ async def test_an_idle_shell_session_is_ineligible() -> None:
     windows = await _manager(fake).list_windows_for_reconciliation()
     assert windows is not None
     assert windows[0].topic_eligible is False
+
+
+# ── targeted existence, because the merged tree cannot be a snapshot ───
+
+
+async def test_a_known_session_is_reported_present() -> None:
+    fake = FakeAgtermctl().ok("session", "text", result={"text": "hi"})
+
+    assert await _manager(fake).window_exists(SESSION_A) is True
+
+
+async def test_no_such_session_is_proof_of_absence() -> None:
+    """The one answer that licenses a destructive repair.
+
+    agterm answers an unknown target with a well-formed refusal, which is why
+    this backend can prove absence at all: its listing is assembled from
+    per-window RPCs with no isolation, so a session staying ahead of the sweep
+    is read in no window, and two identical passes can both omit it. An atomic
+    snapshot cannot be built out of non-atomic reads.
+    """
+    fake = FakeAgtermctl().on(
+        "session",
+        "text",
+        out=json.dumps({"ok": False, "error": f"no such session: {SESSION_A}"}),
+    )
+
+    assert await _manager(fake).window_exists(SESSION_A) is False
+
+
+async def test_an_unreachable_socket_is_not_absence() -> None:
+    """No envelope means the question was never answered."""
+    fake = FakeAgtermctl().on(
+        "session", "text", rc=1, err="connect(/tmp/nope.sock) failed"
+    )
+
+    assert await _manager(fake).window_exists(SESSION_A) is None
+
+
+async def test_an_unrelated_refusal_is_not_absence() -> None:
+    """A refusal for some other reason says nothing about existence."""
+    fake = FakeAgtermctl().on(
+        "session", "text", out=json.dumps({"ok": False, "error": "pane is busy"})
+    )
+
+    assert await _manager(fake).window_exists(SESSION_A) is None
+
+
+async def test_presence_through_the_seam_uses_the_targeted_probe() -> None:
+    """The seam must prefer the authoritative answer over the merged listing.
+
+    The listing here omits the session entirely, which is exactly the torn read
+    the probe exists to survive: absence in the aggregate is not evidence.
+    """
+    from ccgram.multiplexer.reconciliation import window_presence
+
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on("tree", out=_tree())
+        .ok("session", "text", result={"text": "hi"})
+    )
+
+    assert await window_presence(SESSION_B, _manager(fake)) is True
+
+
+@pytest.mark.parametrize(
+    ("payload", "why"),
+    [
+        pytest.param(
+            {"message": f"no such session: {SESSION_A}"},
+            "the reason is not under the key the contract names",
+            id="wrong-key",
+        ),
+        pytest.param(
+            {"ok": False, "error": {"text": "no such session"}},
+            "the reason is not a string",
+            id="non-string-error",
+        ),
+        pytest.param(
+            {"ok": False, "error": "no such session: some-other-id"},
+            "the refusal names a different session",
+            id="other-session",
+        ),
+        pytest.param(
+            {"ok": "false", "error": f"no such session: {SESSION_A}"},
+            "ok is a string, so the envelope is not the documented one",
+            id="stringly-ok",
+        ),
+    ],
+)
+async def test_a_malformed_refusal_is_never_proof_of_absence(
+    payload: dict, why: str
+) -> None:
+    """Absence licenses deletion, so it needs the whole documented shape.
+
+    Anything looser lets a payload from a changed or broken agterm authorise
+    closing a live session's topic, which is the failure this probe exists to
+    prevent rather than introduce.
+    """
+    fake = FakeAgtermctl().on("session", "text", out=json.dumps(payload))
+
+    assert await _manager(fake).window_exists(SESSION_A) is None, why
+
+
+async def test_a_backend_without_a_probe_uses_the_listing() -> None:
+    """tmux and herdr have no targeted answer, so the seam still asks them."""
+    from ccgram.multiplexer.base import WindowRef
+    from ccgram.multiplexer.reconciliation import window_presence
+
+    class _ListingOnlyBackend:
+        async def list_windows_for_reconciliation(self) -> list[WindowRef]:
+            return [WindowRef(window_id="@5", window_name="p", cwd="/p")]
+
+    assert await window_presence("@5", _ListingOnlyBackend()) is True
+    assert await window_presence("@9", _ListingOnlyBackend()) is False
+
+
+async def test_a_probe_that_answers_nonsense_is_unknown_not_a_fallback() -> None:
+    """Once a backend claims an authoritative probe, that answer is the answer.
+
+    Falling back would reach for the aggregate listing this probe exists to
+    avoid trusting.
+    """
+    from ccgram.multiplexer.base import WindowRef
+    from ccgram.multiplexer.reconciliation import window_presence
+
+    class _BrokenProbeBackend:
+        async def window_exists(self, window_id: str):
+            return "yes"
+
+        async def list_windows_for_reconciliation(self) -> list[WindowRef]:
+            return [WindowRef(window_id="@5", window_name="p", cwd="/p")]
+
+    assert await window_presence("@5", _BrokenProbeBackend()) is None
+
+
+async def test_presence_through_the_module_facade_reaches_the_probe() -> None:
+    """Production callers hold the facade, not the backend.
+
+    The facade's type defines only __getattr__, so a static lookup on it finds
+    no methods at all and the seam would conclude this backend has no targeted
+    probe, falling back to the very aggregate the probe exists to distrust. A
+    test that passes a concrete AgtermManager cannot see that.
+    """
+    from ccgram.multiplexer import (
+        _reset_multiplexer_for_testing,
+        install_multiplexer,
+        multiplexer,
+    )
+    from ccgram.multiplexer.reconciliation import window_presence
+
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        # The aggregate omits SESSION_B: the torn read this must survive.
+        .on("tree", out=_tree())
+        .ok("session", "text", result={"text": "hi"})
+    )
+    install_multiplexer(_manager(fake))
+    try:
+        assert await window_presence(SESSION_B, multiplexer) is True
+        assert await window_presence(SESSION_B) is True
+    finally:
+        _reset_multiplexer_for_testing()

--- a/tests/ccgram/test_bootstrap.py
+++ b/tests/ccgram/test_bootstrap.py
@@ -390,3 +390,55 @@ class TestVerifyHooksInstalled:
 
         logger.info.assert_not_called()
         logger.warning.assert_not_called()
+
+
+class TestNewWindowCallbackChecksEligibility:
+    """The monitor's automatic creation sink re-reads the verdict per window.
+
+    Discovery emits a batch and this callback awaits each topic creation in
+    turn, so without a fresh read the last window in a batch is judged on a
+    listing taken before the first one's topic existed. Explicit binds go
+    straight to handle_new_window and are not affected.
+    """
+
+    @staticmethod
+    async def _callback(app):
+        with patch("ccgram.bootstrap.SessionMonitor") as monitor_cls:
+            instance = MagicMock()
+            instance.start = MagicMock()
+            monitor_cls.return_value = instance
+            await bootstrap.start_session_monitor(app)
+        return instance.set_new_window_callback.call_args[0][0]
+
+    async def _run(self, *, adoptable: bool):
+        from ccgram.session_monitor import NewWindowEvent
+
+        app = _make_app()
+        bootstrap.wire_runtime_callbacks()
+        callback = await self._callback(app)
+
+        with (
+            patch(
+                "ccgram.bootstrap._still_adoptable",
+                new_callable=AsyncMock,
+                return_value=adoptable,
+            ),
+            patch(
+                "ccgram.bootstrap._handle_new_window",
+                new_callable=AsyncMock,
+            ) as handle,
+        ):
+            await callback(
+                NewWindowEvent(
+                    window_id="@5", session_id="s", window_name="proj", cwd="/proj"
+                )
+            )
+        return handle
+
+    async def test_adoptable_window_gets_a_topic(self):
+        handle = await self._run(adoptable=True)
+        handle.assert_awaited_once()
+
+    async def test_window_that_is_no_longer_adoptable_gets_none(self):
+        handle = await self._run(adoptable=False)
+        handle.assert_not_awaited()

--- a/tests/ccgram/test_herdr_backend.py
+++ b/tests/ccgram/test_herdr_backend.py
@@ -1163,14 +1163,21 @@ async def test_implicit_workspace_is_closed_for_tab_and_session_failures(
 
 
 async def test_duplicate_live_targets_are_quarantined_without_hiding_others() -> None:
+    """Quarantined records stay unaddressable, and liveness becomes unknown.
+
+    The duplicate panes are live and ccgram may hold bindings to them, so a
+    listing that silently omits them is not an account of what exists. Handing
+    that partial subset back as complete makes those bindings look like ghosts,
+    which the audit, the polling loop and the destructive guards act on.
+    Addressing is a different question and still refuses the ambiguous target.
+    """
     duplicate = _agent(pane_id="w9:p1", tab_id="w9:t1", value="same")
     unrelated = _agent(pane_id="w9:p2", tab_id="w9:t2", value="other")
     fake = _live_fake(duplicate, duplicate, unrelated)
 
     manager = _manager(fake)
-    windows = await manager.list_windows_for_reconciliation()
-    assert windows is not None
-    assert [window.window_id for window in windows] == [_target("other")]
+
+    assert await manager.list_windows_for_reconciliation() is None
     assert await manager.find_window_by_id(_target("same")) is None
     assert await manager.find_window_by_id(_target("other")) is not None
 
@@ -1181,10 +1188,7 @@ async def test_distinct_targets_on_one_pane_are_quarantined() -> None:
     unrelated = _agent(pane_id="w9:p2", tab_id="w9:t1", value="other")
     fake = _live_fake(first, second, unrelated)
 
-    windows = await _manager(fake).list_windows_for_reconciliation()
-
-    assert windows is not None
-    assert [window.window_id for window in windows] == [_target("other")]
+    assert await _manager(fake).list_windows_for_reconciliation() is None
     assert await _manager(fake).find_window_by_id(_target("first")) is None
     assert await _manager(fake).find_window_by_id(_target("second")) is None
     assert await _manager(fake).capture_pane(_target("first")) is None
@@ -1448,7 +1452,9 @@ async def test_agent_status_and_workspace_list_fail_closed_on_malformed_fields()
     assert await _manager(malformed_workspaces).list_workspaces() == []
 
 
-async def test_reconciliation_filters_internal_workspace_and_tab_labels() -> None:
+async def test_reconciliation_keeps_internal_records_but_marks_them_unadoptable() -> (
+    None
+):
     visible = _agent(value="visible")
     internal_workspace = _agent(
         value="workspace-internal", workspace_id="internal", pane_id="w2:p2"
@@ -1478,9 +1484,21 @@ async def test_reconciliation_filters_internal_workspace_and_tab_labels() -> Non
             ),
         )
     )
-    windows = await _manager(fake).list_windows_for_reconciliation()
+    manager = _manager(fake)
+
+    # Reconciliation answers "what exists". Dropping internal records here made
+    # a bound session renamed into an internal workspace look dead, so the
+    # audit called its binding a fixable ghost and Fix closed the topic.
+    windows = await manager.list_windows_for_reconciliation()
     assert windows is not None
-    assert [(window.window_id, window.window_name) for window in windows] == [
+    assert {w.window_id: w.topic_eligible for w in windows} == {
+        _target("visible"): True,
+        _target("workspace-internal"): False,
+        _target("tab-internal"): False,
+    }
+
+    # The UI listing still hides ccgram's own panes.
+    assert [(w.window_id, w.window_name) for w in await manager.list_windows()] == [
         (_target("visible"), "workspace ▸ tab ▸ p1")
     ]
 
@@ -1520,6 +1538,15 @@ async def test_missing_label_uses_fallback_without_hiding_other_sessions() -> No
     found = await _manager(fake).find_window_by_id(_target("missing"))
     assert found is not None
     assert found.window_name.startswith("Herdr ▸ ")
+
+    # An unlabeled record cannot be shown to be non-internal, so it is kept for
+    # liveness and addressing but never offered for adoption.
+    by_id = {w.window_id: w for w in windows}
+    assert by_id[_target("missing")].topic_eligible is False
+    assert by_id[_target("visible")].topic_eligible is True
+    assert _target("missing") not in {
+        w.window_id for w in await _manager(fake).list_windows()
+    }
 
 
 async def test_malformed_prefixed_target_never_reads_agent_list() -> None:
@@ -1804,3 +1831,119 @@ async def test_list_windows_cwd_empty_when_agent_record_has_no_cwd_key() -> None
     windows = await _manager(_live_fake(agent)).list_windows()
     assert len(windows) == 1
     assert windows[0].cwd == ""
+
+
+async def test_live_records_are_stamped_adoptable() -> None:
+    """The herdr topic rules live here now, not in ``is_agent_topic_window``.
+
+    Keying that gate on a capability flag broke twice: once on
+    ``native_agent_status`` when agterm began reporting status natively, once
+    on ``native_topic_targets``, whose documented meaning is which creation
+    flow to use. Whether a record carries a guarded target and an agent label
+    is herdr's own knowledge, so herdr answers it.
+    """
+    fake = _live_fake(_agent(pane_id="w9:p1", tab_id="w9:t1", value="one"))
+
+    windows = await _manager(fake).list_windows_for_reconciliation()
+
+    assert windows is not None
+    assert [w.window_id for w in windows] == [_target("one")]
+    assert windows[0].topic_eligible is True
+    assert windows[0].window_id.startswith("herdr-session-v1-")
+
+
+async def test_a_pane_without_an_agent_is_not_listed_or_adoptable() -> None:
+    """A bare shell pane was never a herdr topic; that must not have changed."""
+    fake = _live_fake(_agent(pane_id="w9:p1", tab_id="w9:t1", value="one", agent=""))
+
+    # An agent_session present but incomplete is a malformed record, not a
+    # bare pane: herdr published something that cannot be parsed, so this
+    # snapshot cannot account for what is live and says so.
+    assert await _manager(fake).list_windows_for_reconciliation() is None
+
+
+async def test_a_pane_with_no_agent_session_keeps_the_listing_complete() -> None:
+    """A genuinely agent-less pane is not a gap in the account.
+
+    herdr publishes no agent_session for a plain shell pane. That pane was
+    never a topic and never will be, so it is skipped without making liveness
+    unknown. Treating it as a gap would make the listing unknown whenever the
+    user has an ordinary pane open, which is to say always, and nothing would
+    ever be cleaned up again.
+    """
+    bare = {
+        "terminal_id": "term-a",
+        "pane_id": "w9:p1",
+        "tab_id": "w9:t1",
+        "workspace_id": "w9",
+    }
+    live = _agent(pane_id="w9:p2", tab_id="w9:t2", value="two")
+
+    windows = await _manager(_live_fake(bare, live)).list_windows_for_reconciliation()
+
+    assert windows is not None
+    assert [window.window_id for window in windows] == [_target("two")]
+
+
+async def test_ui_listing_is_best_effort_when_agent_list_fails() -> None:
+    """The picker empties rather than raising through the handler.
+
+    Only ``list_windows_for_reconciliation`` distinguishes this from an empty
+    herdr; the selection listing has always degraded, and it must keep doing so
+    now that it no longer routes through the guarded reconciliation path.
+    """
+    fake = FakeHerdr().on("agent", "list", rc=1)
+
+    assert await _manager(fake).list_windows() == []
+    assert await _manager(fake).list_windows_for_reconciliation() is None
+
+
+async def test_ui_listing_is_best_effort_when_label_lookup_fails() -> None:
+    """Same for the workspace and tab label listings the projection needs."""
+    fake = (
+        FakeHerdr()
+        .on("agent", "list", out=_agents(_agent(value="one")))
+        .on("workspace", "list", rc=1)
+    )
+
+    assert await _manager(fake).list_windows() == []
+
+
+async def test_a_recognised_sessionless_agent_keeps_the_listing_complete() -> None:
+    """It has a terminal-derived identity, so it is addressable, so it is no gap.
+
+    Completeness means every addressable guarded target. A recognised agent
+    that has not published its composite still gets one, so the seconds after
+    every /new must not read as an incomplete account.
+    """
+    manager = _manager(_live_fake(_sessionless("term-b")))
+
+    windows = await manager.list_windows_for_reconciliation()
+
+    assert windows is not None
+    assert [w.window_id for w in windows] == [_sessionless_target("term-b")]
+
+
+async def test_an_unrecognised_sessionless_agent_does_not_blank_the_listing() -> None:
+    """Antigravity is the live case, and it is not a transient.
+
+    It is a supported provider, excluded from the terminal-fallback set, and
+    documented to stay sessionless until its first prompt creates a
+    conversation. Counting it as a gap would make reconciliation unknown for
+    every topic while one sits idle, which never resolves on its own.
+    """
+    idle_antigravity = {
+        "terminal_id": "term-x",
+        "pane_id": "w9:p9",
+        "tab_id": "w9:t9",
+        "workspace_id": "w9",
+        "agent": "antigravity",
+    }
+    bound = _agent(pane_id="w2:p1", tab_id="w2:t1", value="session-a")
+
+    windows = await _manager(
+        _live_fake(idle_antigravity, bound)
+    ).list_windows_for_reconciliation()
+
+    assert windows is not None, "an unaddressable agent is not an unaccountable gap"
+    assert [w.window_id for w in windows] == [_target("session-a")]

--- a/tests/ccgram/test_multiplexer_contract.py
+++ b/tests/ccgram/test_multiplexer_contract.py
@@ -156,3 +156,71 @@ def test_herdr_capability_values() -> None:
     assert caps.native_worktrees is True
     assert caps.supports_workspace_selection is True
     assert caps.native_topic_targets is True
+
+
+# ── window identity matching (WindowRef.matches / window_presence) ─────
+
+
+def test_window_ref_matches_is_case_insensitive() -> None:
+    """agterm UUIDs round-trip through callers that may lowercase them.
+
+    Its own ``_find_session`` case-folds for exactly this reason, so a
+    presence check that compared ids directly would report a bound window
+    gone — and every caller of ``window_presence`` takes a destructive branch
+    on a confirmed absence.
+    """
+    from ccgram.multiplexer.base import WindowRef
+
+    ref = WindowRef(window_id="ABC-DEF", window_name="proj", cwd="/p")
+
+    assert ref.matches("abc-def")
+    assert ref.matches("ABC-DEF")
+    assert not ref.matches("other")
+
+
+def test_window_ref_matches_superseded_identities() -> None:
+    """The value type's contract, ahead of any backend using it.
+
+    No backend publishes ``alias_window_ids`` today, and herdr deliberately
+    leaves them empty across a session re-key. This pins what the matcher owes
+    a backend that starts: a window persisted under a superseded id must read
+    as present, or the destructive guards fire on a live window.
+    """
+    from ccgram.multiplexer.base import WindowRef
+
+    ref = WindowRef(
+        window_id="new-id",
+        window_name="proj",
+        cwd="/p",
+        alias_window_ids=("OLD-ID",),
+        legacy_alias_window_ids=("MIGRATION-ONLY",),
+    )
+
+    assert ref.matches("old-id")
+    assert ref.matches("new-id")
+    # Legacy aliases are declared non-actionable, and window_snapshot hands
+    # the matched ref to callers that drive it.
+    assert not ref.matches("migration-only")
+
+
+async def test_window_presence_finds_a_lowercased_agterm_id() -> None:
+    """End to end through the seam helper, not just the dataclass."""
+    from ccgram.multiplexer.base import WindowRef
+    from ccgram.multiplexer.reconciliation import window_presence
+
+    class _Backend:
+        async def list_windows_for_reconciliation(self) -> list[WindowRef]:
+            return [WindowRef(window_id="9F1C2D3E-4A5B", window_name="agent", cwd="/p")]
+
+    assert await window_presence("9f1c2d3e-4a5b", _Backend()) is True
+    assert await window_presence("no-such-id", _Backend()) is False
+
+
+async def test_window_presence_is_none_when_the_backend_cannot_answer() -> None:
+    from ccgram.multiplexer.reconciliation import window_presence
+
+    class _Backend:
+        async def list_windows_for_reconciliation(self) -> None:
+            return None
+
+    assert await window_presence("@5", _Backend()) is None

--- a/tests/ccgram/test_multiplexer_tmux.py
+++ b/tests/ccgram/test_multiplexer_tmux.py
@@ -22,6 +22,7 @@ from ccgram.multiplexer.base import (
     PaneDims,
     WindowRef,
 )
+from ccgram.config import config
 from ccgram.multiplexer.tmux import TmuxManager
 
 
@@ -50,6 +51,16 @@ def test_capabilities_full_snapshot(mgr: TmuxManager) -> None:
         "supports_workspace_selection": False,
         "native_topic_targets": False,
     }
+
+
+class _FakeWindow:
+    def __init__(self, window_id: str, window_name: str) -> None:
+        self.window_id = window_id
+        self.window_name = window_name
+
+    @property
+    def active_pane(self):
+        return None
 
 
 # ── Protocol conformance ───────────────────────────────────────────────
@@ -84,6 +95,32 @@ async def test_reconciliation_listing_returns_none_without_session(
     assert mgr._server is None
 
 
+async def test_reconciliation_listing_is_complete(mgr: TmuxManager) -> None:
+    """Every window in the session is listed, adoptable or not.
+
+    The listing answers "which windows exist", and absence from it is what
+    marks a binding a ghost for /sync Fix to close. The UI listing narrows to
+    what discovery may adopt; this one must not, or renaming a bound window to
+    the hidden ``_`` form silently makes it a closure candidate.
+    """
+    session = MagicMock()
+    session.windows = [
+        _FakeWindow("@0", config.tmux_main_window_name),
+        _FakeWindow("@4", "_paused"),
+        _FakeWindow("@5", "my-project"),
+    ]
+
+    server = MagicMock()
+    server.sessions.get.return_value = session
+    mgr._server = server
+
+    windows = await mgr.list_windows_for_reconciliation()
+
+    assert windows is not None
+    assert [w.window_id for w in windows] == ["@0", "@4", "@5"]
+    assert [w.topic_eligible for w in windows] == [False, False, True]
+
+
 def test_reconciliation_window_keeps_identity_when_pane_query_fails() -> None:
     class FailedPaneWindow:
         window_id = "@7"
@@ -100,17 +137,88 @@ def test_reconciliation_window_keeps_identity_when_pane_query_fails() -> None:
     assert window.cwd == ""
 
 
+@pytest.mark.parametrize(
+    ("window_name", "window_id"),
+    [
+        ("_paused", "@4"),
+        (config.tmux_main_window_name, "@0"),
+    ],
+)
+def test_reconciliation_keeps_windows_list_windows_hides(
+    window_name: str, window_id: str
+) -> None:
+    """A window the UI listing hides is still live, and must still be listed.
+
+    Dropping it made a bound window vanish from liveness the moment it was
+    renamed to the hidden form — and a binding whose window is absent from
+    this listing is a ghost that /sync Fix offers to close. It comes back
+    ineligible so discovery still refuses it.
+    """
+    window = TmuxManager._window_ref_for_reconciliation(  # type: ignore[arg-type]
+        _FakeWindow(window_id, window_name)
+    )
+
+    assert window.window_id == window_id
+    assert window.topic_eligible is False
+
+
+def test_reconciliation_keeps_ccgram_own_window() -> None:
+    with patch.object(config, "own_window_id", "@9"):
+        window = TmuxManager._window_ref_for_reconciliation(  # type: ignore[arg-type]
+            _FakeWindow("@9", "ccgram")
+        )
+
+    assert window.window_id == "@9"
+    assert window.topic_eligible is False
+
+
+def test_reconciliation_marks_an_ordinary_window_adoptable() -> None:
+    window = TmuxManager._window_ref_for_reconciliation(  # type: ignore[arg-type]
+        _FakeWindow("@5", "my-project")
+    )
+
+    assert window.topic_eligible is True
+
+
 async def test_find_window_by_id_returns_windowref(mgr: TmuxManager) -> None:
     win = WindowRef(window_id="@3", window_name="proj", cwd="/tmp")
-    mgr.list_windows = AsyncMock(return_value=[win])  # type: ignore[method-assign]
+    mgr.list_windows_for_reconciliation = AsyncMock(return_value=[win])  # type: ignore[method-assign]
     result = await mgr.find_window_by_id("@3")
     assert result is win
     assert isinstance(result, WindowRef)
 
 
 async def test_find_window_by_id_missing_returns_none(mgr: TmuxManager) -> None:
-    mgr.list_windows = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    mgr.list_windows_for_reconciliation = AsyncMock(return_value=[])  # type: ignore[method-assign]
     assert await mgr.find_window_by_id("@99") is None
+
+
+async def test_find_window_by_id_resolves_a_window_list_windows_hides(
+    mgr: TmuxManager,
+) -> None:
+    """Addressing a known id is not discovery.
+
+    Every handler resolves an already-bound window through here. When this
+    read the adoption-filtered listing, renaming a bound window to the hidden
+    ``_`` form made it unreachable: no text delivered, no screenshot, no
+    toolbar, and nothing in the logs pointing at the rename.
+    """
+    hidden = WindowRef(
+        window_id="@3", window_name="_paused", cwd="/tmp", topic_eligible=False
+    )
+    mgr.list_windows = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    mgr.list_windows_for_reconciliation = AsyncMock(return_value=[hidden])  # type: ignore[method-assign]
+
+    assert await mgr.find_window_by_id("@3") is hidden
+
+
+async def test_find_window_by_id_none_listing_is_not_a_match(
+    mgr: TmuxManager,
+) -> None:
+    """An unconfirmed listing is not proof the window is gone, but it is also
+    not a window to drive: callers get None and retry on the next tick."""
+    mgr.list_windows_for_reconciliation = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    assert await mgr.find_window_by_id("@3") is None
 
 
 async def test_capture_pane_plain_returns_text(mgr: TmuxManager) -> None:

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -1473,3 +1473,32 @@ class TestResolveStaleIdsHerdrRestart:
 
         assert thread_router.get_window_for_thread(100, 1) == "@1"
         assert "@1" in mgr.window_states
+
+
+class TestCaseFoldedIdentityInTheAudit:
+    """A persisted id may be spelled in different case from the live listing.
+
+    agterm reports UUIDs uppercase and its own lookup case-folds, saying in so
+    many words that a caller may round-trip one lowercased. The audit compares
+    persisted ids against the live set, so an exact-string comparison marks
+    that live session dead and the repair prunes its state, bindings and
+    offsets.
+    """
+
+    def test_a_lowercased_binding_is_not_a_ghost(self) -> None:
+        from ccgram.session import SessionManager
+
+        manager = SessionManager()
+        live = "9F1C2D3E-4A5B-4C6D-8E7F-0A1B2C3D4E5F"
+
+        with patch("ccgram.session.thread_router") as router:
+            router.iter_thread_bindings.return_value = [(100, 42, live.lower())]
+            router.window_display_names = {}
+            router.group_chat_ids = {}
+            router.iter_retired_topics.return_value = []
+            with patch("ccgram.session.session_map_sync") as maps:
+                maps.load_session_map.return_value = {}
+                audit = manager.audit_state({live}, [(live, "proj")], set())
+
+        ghosts = [i for i in audit.issues if i.category == "ghost_binding"]
+        assert ghosts == [], "a live window spelled in another case is not a ghost"

--- a/tests/ccgram/test_session_map.py
+++ b/tests/ccgram/test_session_map.py
@@ -1,0 +1,18 @@
+def test_pruning_keeps_a_case_variant_live_entry() -> None:
+    """A hook-written key and a backend listing can spell one UUID differently.
+
+    Deleting the entry loses the session's provider, cwd and transcript path
+    for a session that is still running.
+    """
+    from unittest.mock import patch
+
+    from ccgram.session_map import _dead_session_map_entries
+
+    # agterm: its ids are the UUIDs whose case can differ, and tmux's @N form
+    # has no case for this to matter to.
+    with patch("ccgram.session_map.config") as cfg:
+        cfg.multiplexer_name = "agterm"
+        with patch("ccgram.session_map.session_map_prefix", return_value="agterm:"):
+            raw = {"agterm:9f1c2d3e-4a5b": {"session_id": "s1"}}
+            assert _dead_session_map_entries(raw, {"9F1C2D3E-4A5B"}) == []
+            assert _dead_session_map_entries(raw, set()) != []

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -1869,3 +1869,47 @@ class TestAdoptionIdentityFoldsCaseInTheMonitor:
 
         assert canonical_window_id("9f1c2d3e-4a5b") in lookup
         assert canonical_window_id("other-id") not in lookup
+
+
+class TestActiveCwdsUseTheCompleteListing:
+    """Transcript discovery is gated on the live cwd set.
+
+    A window missing from that set has no discoverable history at all, so it
+    must be built from every live window, not only the ones a backend would
+    auto-adopt. On agterm that means a session outside CCGRAM_AGTERM_WORKSPACES
+    keeps its /restore and history pager working.
+    """
+
+    @staticmethod
+    def _reader():
+        from ccgram.transcript_reader import TranscriptReader
+
+        return TranscriptReader.__new__(TranscriptReader)
+
+    async def test_includes_a_window_the_ui_listing_hides(self, monkeypatch) -> None:
+        from ccgram.multiplexer.base import WindowRef
+
+        excluded = WindowRef(
+            window_id="@4", window_name="_paused", cwd="/repo", topic_eligible=False
+        )
+
+        async def _complete():
+            return [excluded]
+
+        monkeypatch.setattr(
+            "ccgram.multiplexer.reconciliation.list_windows_for_reconciliation",
+            _complete,
+        )
+
+        assert await self._reader()._get_active_cwds() == {"/repo"}
+
+    async def test_unconfirmed_listing_yields_no_cwds(self, monkeypatch) -> None:
+        async def _unavailable():
+            return None
+
+        monkeypatch.setattr(
+            "ccgram.multiplexer.reconciliation.list_windows_for_reconciliation",
+            _unavailable,
+        )
+
+        assert await self._reader()._get_active_cwds() == set()

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -575,7 +575,7 @@ class TestSessionMapReadFailures:
             ),
             patch("ccgram.session_monitor.session_lifecycle") as lifecycle,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=set())
         lifecycle.reconcile.assert_not_called()
 
 
@@ -621,7 +621,7 @@ class TestPendingToolsCleanup:
             new_callable=AsyncMock,
             return_value=new_map,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=set(new_map))
 
         assert old_sid not in monitor._pending_tools
 
@@ -631,6 +631,8 @@ class TestNewWindowDetection:
         cb = AsyncMock(spec=lambda event: None)
         monitor.set_new_window_callback(cb)
         monitor._last_session_map = {}
+        # Adoption is gated on the backend's verdict from the current listing;
+        # the loop sets this before reaching here.
 
         new_map = {"@5": {"session_id": "s1", "cwd": "/proj", "window_name": "proj"}}
         with patch.object(
@@ -640,7 +642,7 @@ class TestNewWindowDetection:
             new_callable=AsyncMock,
             return_value=new_map,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=set(new_map))
 
         cb.assert_called_once()
         event = cb.call_args[0][0]
@@ -665,7 +667,9 @@ class TestNewWindowDetection:
             new_callable=AsyncMock,
             return_value=initial_map,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(
+                adoptable_window_ids=set(initial_map)
+            )
 
         cb.assert_not_called()
 
@@ -682,7 +686,7 @@ class TestNewWindowDetection:
             new_callable=AsyncMock,
             return_value=new_map,
         ):
-            await monitor._detect_and_cleanup_changes()
+            await monitor._detect_and_cleanup_changes(adoptable_window_ids=set(new_map))
 
         cb.assert_called_once()
 
@@ -706,15 +710,26 @@ _HERDR_CAPS = MultiplexerCapabilities(
     self_identify_env="HERDR_PANE_ID",
     supports_event_stream=True,
     native_worktrees=True,
+    # Production herdr sets this; without it these tests take the agterm
+    # branch and guarded-target validation regresses unnoticed.
+    native_topic_targets=True,
 )
 
 
-def _winref(window_id: str, command: str) -> WindowRef:
+def _winref(window_id: str, command: str, *, eligible: bool | None = None) -> WindowRef:
+    """A window as a backend would hand it over.
+
+    ``topic_eligible`` is the backend's verdict, so these fixtures mirror what
+    a real adapter stamps: a record with an agent is adoptable, a bare shell
+    pane is not. Passing ``eligible`` overrides that for the cases that are
+    about the flag itself.
+    """
     return WindowRef(
         window_id=window_id,
         window_name=window_id,
         cwd="/proj",
         pane_current_command=command,
+        topic_eligible=bool(command.strip()) if eligible is None else eligible,
     )
 
 
@@ -1713,3 +1728,144 @@ def _make_gemini_provider():
     from ccgram.providers.gemini import GeminiProvider
 
     return GeminiProvider()
+
+
+class TestAdoptionRespectsBackendEligibility:
+    """Every path that can create a topic honours the backend's verdict.
+
+    Three sites fire ``NewWindowEvent``: discovery, the session-map delta and
+    the known-unbound self-heal. Only the first consults
+    ``is_agent_topic_window``, so a window the backend excluded could still be
+    adopted through the other two the moment a globally installed agent hook
+    wrote a session_map entry for it.
+    """
+
+    @pytest.fixture
+    def wired(self, monkeypatch) -> None:
+        monkeypatch.setattr(SessionManager, "_save_state", lambda self: None)
+        SessionManager()
+
+    async def test_known_unbound_path_skips_an_ineligible_window(
+        self, monitor: SessionMonitor, wired
+    ) -> None:
+        cb = AsyncMock(spec=lambda event: None)
+        monitor.set_new_window_callback(cb)
+        current_map = {
+            "OUT-OF-SCOPE": {"session_id": "S1", "cwd": "/repo", "window_name": "x"}
+        }
+
+        await monitor._emit_known_unbound_window_events(current_map, set())
+
+        cb.assert_not_called()
+
+    async def test_known_unbound_path_still_surfaces_an_eligible_window(
+        self, monitor: SessionMonitor, wired
+    ) -> None:
+        cb = AsyncMock(spec=lambda event: None)
+        monitor.set_new_window_callback(cb)
+        current_map = {
+            "IN-SCOPE": {"session_id": "S1", "cwd": "/repo", "window_name": "x"}
+        }
+
+        await monitor._emit_known_unbound_window_events(current_map, {"IN-SCOPE"})
+
+        cb.assert_called_once()
+
+    async def test_delta_path_refuses_an_out_of_scope_hook_entry(
+        self, monitor: SessionMonitor, wired
+    ) -> None:
+        """Hooks are installed globally, so an agent started in any workspace
+        writes an entry. A hook entry is not permission to adopt."""
+        cb = AsyncMock(spec=lambda event: None)
+        monitor.set_new_window_callback(cb)
+        raw = {
+            "agterm:OUT-OF-SCOPE": {
+                "session_id": "S1",
+                "cwd": "/repo",
+                "window_name": "elsewhere",
+            }
+        }
+
+        await monitor._detect_and_cleanup_changes(raw, adoptable_window_ids=set())
+
+        cb.assert_not_called()
+
+    async def test_delta_path_adopts_nothing_when_no_listing_was_available(
+        self, monitor: SessionMonitor, wired
+    ) -> None:
+        """None is not "no restriction": it means ccgram has no verdict.
+
+        Inferring one from the hook entry is what the fail-open cache did.
+        """
+        cb = AsyncMock(spec=lambda event: None)
+        monitor.set_new_window_callback(cb)
+        raw = {"agterm:ANY": {"session_id": "S1", "cwd": "/repo", "window_name": "x"}}
+
+        await monitor._detect_and_cleanup_changes(raw, adoptable_window_ids=None)
+
+        cb.assert_not_called()
+
+
+class TestTheLoopPassesTheEligibleSubset:
+    """Behavioural, not source inspection.
+
+    The unit tests above prove the delta path obeys whatever verdict it is
+    given. This proves the loop gives it the *eligible* subset rather than
+    every live window, which is the mistake the parameter exists to prevent:
+    handing over the complete listing would adopt exactly the windows the
+    backend refused.
+    """
+
+    async def test_the_delta_path_receives_only_eligible_windows(
+        self, monitor: SessionMonitor, monkeypatch
+    ) -> None:
+        received: list[set[str] | None] = []
+
+        async def spy(raw=None, *, adoptable_window_ids):
+            received.append(adoptable_window_ids)
+            monitor._running = False  # one cycle is enough
+            return {}
+
+        monkeypatch.setattr(
+            "ccgram.session_monitor.list_windows_for_reconciliation",
+            AsyncMock(
+                return_value=[
+                    _winref("KEEP", "claude"),
+                    _winref("REFUSED", "claude", eligible=False),
+                ]
+            ),
+        )
+        monkeypatch.setattr(
+            "ccgram.session_monitor.read_session_map_raw", AsyncMock(return_value={})
+        )
+        monkeypatch.setattr(monitor, "_read_hook_events", AsyncMock())
+        monkeypatch.setattr(monitor, "_cleanup_all_stale_sessions", AsyncMock())
+        monkeypatch.setattr(monitor, "_detect_and_cleanup_changes", spy)
+        monitor._running = True
+
+        await monitor._monitor_loop()
+
+        assert received == [{"KEEP"}], (
+            "the loop must hand over the eligible subset, not every live window"
+        )
+
+
+class TestAdoptionIdentityFoldsCaseInTheMonitor:
+    """Session-map keys are written by the hook; the adoption set comes from
+    the backend's listing. On agterm those can spell one UUID differently, and
+    comparing raw means the window is never adopted on any cycle.
+    """
+
+    def test_the_lookup_folds_case(self) -> None:
+        from ccgram.session_monitor import _adoption_lookup
+
+        assert _adoption_lookup({"9F1C2D3E-4A5B"}) == {"9f1c2d3e-4a5b"}
+
+    def test_a_case_variant_key_is_adoptable(self) -> None:
+        from ccgram.multiplexer.base import canonical_window_id
+        from ccgram.session_monitor import _adoption_lookup
+
+        lookup = _adoption_lookup({"9F1C2D3E-4A5B"})
+
+        assert canonical_window_id("9f1c2d3e-4a5b") in lookup
+        assert canonical_window_id("other-id") not in lookup

--- a/tests/ccgram/test_status_cmd.py
+++ b/tests/ccgram/test_status_cmd.py
@@ -202,15 +202,159 @@ class TestStatusMainHerdr:
         assert "Tmux session" not in captured.out
         assert "Monitored sessions: 1" in captured.out
 
-    def test_herdr_listing_degrades_to_empty_on_backend_error(
-        self, monkeypatch
-    ) -> None:
-        # Socket unreachable / backend error must degrade to [] (best-effort),
-        # not crash `ccgram status`.
+    def test_herdr_listing_reports_unknown_on_backend_error(self, monkeypatch) -> None:
+        # Socket unreachable / backend error must not crash `ccgram status`,
+        # and must not answer []: an unreachable herdr is not an empty one, and
+        # the caller renders an empty listing as every binding dead.
         from ccgram.status_cmd import _list_herdr_windows
 
         def _boom(_name):
             raise RuntimeError("socket down")
 
         monkeypatch.setattr("ccgram.multiplexer.get_multiplexer", _boom)
-        assert _list_herdr_windows() == []
+        assert _list_herdr_windows() is None
+
+
+class TestLiveWindowsListing:
+    """The alive/dead column must read liveness, not adoptability.
+
+    Backends narrow ``list_windows`` to what discovery may auto-adopt: agterm
+    drops out-of-scope workspaces and sessions sitting at a shell, herdr drops
+    internal workspaces. A bound session that becomes merely ineligible is
+    still live, and printing it dead points /sync Fix at a healthy binding.
+    """
+
+    @staticmethod
+    def _fake_backend(monkeypatch, *, ui: list, reconciliation) -> None:
+        from ccgram.multiplexer.base import WindowRef
+
+        class _Backend:
+            async def list_windows(self) -> list[WindowRef]:
+                return ui
+
+            async def list_windows_for_reconciliation(self) -> list[WindowRef] | None:
+                return reconciliation
+
+        monkeypatch.setattr(
+            "ccgram.multiplexer.get_multiplexer", lambda _name: _Backend()
+        )
+
+    def test_live_but_ineligible_window_is_listed(self, monkeypatch) -> None:
+        from ccgram.multiplexer.base import WindowRef
+        from ccgram.status_cmd import _live_windows
+
+        excluded = WindowRef(
+            window_id="AAAA",
+            window_name="out-of-scope",
+            cwd="/repo",
+            topic_eligible=False,
+        )
+        self._fake_backend(monkeypatch, ui=[], reconciliation=[excluded])
+
+        assert _live_windows("agterm") == [{"id": "AAAA", "name": "out-of-scope"}]
+
+    def test_unconfirmed_listing_is_unknown_not_empty(self, monkeypatch) -> None:
+        from ccgram.status_cmd import _live_windows
+
+        self._fake_backend(monkeypatch, ui=[], reconciliation=None)
+
+        assert _live_windows("agterm") is None
+
+
+class TestUnreachableBackendNeverPrintsDead:
+    """An outage means every window is unknown, not that every window is gone.
+
+    ``dead`` is what /sync Fix offers to clean up, so printing it for a
+    binding whose backend simply could not be reached invites closing live
+    sessions. A *confirmed* empty listing still says dead.
+    """
+
+    @staticmethod
+    def _bound(tmp_path, monkeypatch, mux: str) -> None:
+        monkeypatch.setenv("CCGRAM_DIR", str(tmp_path))
+        monkeypatch.setenv("CCGRAM_MULTIPLEXER", mux)
+        monkeypatch.setenv("TMUX_SESSION_NAME", "ccgram")
+        state = {
+            "thread_bindings": {"12345": {"42": "@5"}},
+            "window_display_names": {"@5": "my-project"},
+        }
+        (tmp_path / "state.json").write_text(json.dumps(state))
+
+    @staticmethod
+    def _run(capsys) -> str:
+        with contextlib.suppress(SystemExit):
+            status_main()
+        return capsys.readouterr().out
+
+    def test_seam_backend_returning_none(self, tmp_path, monkeypatch, capsys) -> None:
+        self._bound(tmp_path, monkeypatch, "agterm")
+        monkeypatch.setattr("ccgram.status_cmd._list_backend_windows", lambda _: None)
+
+        out = self._run(capsys)
+
+        assert "dead" not in out
+        assert "unknown" in out
+        assert "my-project" in out
+        assert "unreachable" in out
+
+    def test_tmux_listing_failure(self, tmp_path, monkeypatch, capsys) -> None:
+        self._bound(tmp_path, monkeypatch, "tmux")
+        monkeypatch.setattr("ccgram.status_cmd._list_tmux_windows", lambda _: None)
+
+        out = self._run(capsys)
+
+        assert "dead" not in out
+        assert "unknown" in out
+        assert "my-project" in out
+
+    def test_confirmed_empty_listing_still_says_dead(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        self._bound(tmp_path, monkeypatch, "tmux")
+        monkeypatch.setattr("ccgram.status_cmd._list_tmux_windows", lambda _: [])
+
+        out = self._run(capsys)
+
+        assert "dead" in out
+        assert "unknown" not in out
+
+
+class TestTmuxListingIsUnknownOnFailure:
+    """The rendered tests stub _list_tmux_windows, so its own contract is here.
+
+    Both failure shapes must answer None: the caller renders [] as every
+    binding dead, and a tmux that is missing or wedged is not an empty server.
+    """
+
+    def test_nonzero_exit(self, monkeypatch) -> None:
+        import subprocess
+
+        from ccgram.status_cmd import _list_tmux_windows
+
+        def _failed(*_a, **_kw):
+            return subprocess.CompletedProcess([], returncode=1, stdout="", stderr="")
+
+        monkeypatch.setattr("ccgram.status_cmd.subprocess.run", _failed)
+        assert _list_tmux_windows("ccgram") is None
+
+    def test_tmux_not_installed(self, monkeypatch) -> None:
+        from ccgram.status_cmd import _list_tmux_windows
+
+        def _boom(*_a, **_kw):
+            raise FileNotFoundError("tmux")
+
+        monkeypatch.setattr("ccgram.status_cmd.subprocess.run", _boom)
+        assert _list_tmux_windows("ccgram") is None
+
+    def test_healthy_listing_is_parsed(self, monkeypatch) -> None:
+        import subprocess
+
+        from ccgram.status_cmd import _list_tmux_windows
+
+        def _ok(*_a, **_kw):
+            return subprocess.CompletedProcess(
+                [], returncode=0, stdout="@5\tmy-project\n", stderr=""
+            )
+
+        monkeypatch.setattr("ccgram.status_cmd.subprocess.run", _ok)
+        assert _list_tmux_windows("ccgram") == [{"id": "@5", "name": "my-project"}]

--- a/tests/ccgram/test_topic_mapping.py
+++ b/tests/ccgram/test_topic_mapping.py
@@ -1,7 +1,7 @@
 """Tests for the backend-neutral topic-mapping projection (Task 10).
 
 Covers:
-* ``is_agent_topic_window`` — the capability-gated discovery filter that decides
+* ``is_agent_topic_window`` — the discovery filter that decides
   whether a multiplexer window surfaces as its own Telegram topic.
 * per-session inbound routing and opaque target binding for herdr, where
   ``window_id`` is an opaque durable session target ("topic = agent session").
@@ -45,7 +45,25 @@ HERDR_CAPS = MultiplexerCapabilities(
     self_identify_env="HERDR_PANE_ID",
     supports_event_stream=True,
     native_worktrees=True,
+    native_topic_targets=True,
 )
+
+# agterm: reports agent state natively, but addresses windows by their own
+# session UUID rather than a guarded target.
+AGTERM_CAPS = MultiplexerCapabilities(
+    name="agterm",
+    ids_stable_across_restart=True,
+    exposes_pane_tty=False,
+    native_agent_status=True,
+    read_max_lines=None,
+    self_identify_env="AGTERM_SESSION_ID",
+    supports_event_stream=False,
+    native_worktrees=False,
+    supports_workspace_selection=True,
+    native_topic_targets=False,
+)
+
+AGTERM_SESSION_UUID = "157B4C8C-EFAE-40C2-BA54-9A5D7FD8B5E4"
 
 
 def _win(window_id: str, command: str = "") -> WindowRef:
@@ -69,24 +87,39 @@ class TestIsAgentTopicWindow:
     def test_tmux_surfaces_every_window(self, command: str) -> None:
         assert is_agent_topic_window(_win("@1", command), TMUX_CAPS) is True
 
-    @pytest.mark.parametrize(
-        ("command", "expected"),
-        [
-            ("claude", True),  # an agent pane is a topic
-            ("codex", True),
-            ("", False),  # a bare shell pane is NOT a topic on herdr
-            ("   ", False),  # whitespace-only label is not an agent
-        ],
-    )
-    def test_herdr_only_agent_panes(self, command: str, expected: bool) -> None:
-        assert (
-            is_agent_topic_window(_win(HERDR_TARGET, command), HERDR_CAPS) is expected
-        )
+    def test_herdr_agent_pane_is_a_topic(self) -> None:
+        """The herdr rules themselves now live in the adapter's ``_live_ref``.
 
-    def test_herdr_rejects_malformed_prefixed_target(self) -> None:
-        assert not is_agent_topic_window(
-            _win("herdr-session-v1-not-a-sha256", "claude"), HERDR_CAPS
+        Only the backend can apply them: whether a record carries a guarded
+        target and an agent label is herdr's own knowledge, and asking that
+        question here is what let it be keyed on the wrong capability twice.
+        Verified against the adapter in ``test_herdr_backend.py``.
+        """
+        assert is_agent_topic_window(_win(HERDR_TARGET, "claude"), HERDR_CAPS)
+
+    def test_a_window_the_backend_refused_is_not_a_topic(self) -> None:
+        window = WindowRef(
+            window_id=HERDR_TARGET,
+            window_name="",
+            cwd="/proj",
+            pane_current_command="claude",
+            topic_eligible=False,
         )
+        assert is_agent_topic_window(window, HERDR_CAPS) is False
+
+    def test_agterm_session_qualifies_without_a_herdr_target(self) -> None:
+        """Keying the opaque-target check on ``native_agent_status`` made every
+        agterm session permanently ineligible: a UUID never matches a target.
+
+        Whether the session is running an agent is the backend's call, carried
+        in ``topic_eligible``, because only it can read its own foreground.
+        """
+        assert is_agent_topic_window(_win(AGTERM_SESSION_UUID, "claude"), AGTERM_CAPS)
+
+    def test_agterm_session_uuid_is_not_required_to_look_like_a_herdr_target(
+        self,
+    ) -> None:
+        assert is_agent_topic_window(_win(AGTERM_SESSION_UUID, "claude"), AGTERM_CAPS)
 
 
 class TestFormatAgentTopicPrefix:
@@ -158,3 +191,37 @@ class TestHerdrSessionRouting:
         assert thread_router.get_window_for_thread(100, 12) == target_b
         assert thread_router.get_thread_for_window(100, target_a) == 11
         assert thread_router.get_thread_for_window(100, target_b) == 12
+
+
+class TestTopicEligibleFlag:
+    """Discovery consumes the reconciliation listing, not ``list_windows``.
+
+    ``session_monitor`` calls ``list_windows_for_reconciliation`` and hands that
+    same list to ``_emit_unbound_window_events``; it never calls
+    ``list_windows``. So a backend's adoption filters cannot live only in
+    ``list_windows`` — they have to travel on the window.
+    """
+
+    def test_an_ineligible_window_is_never_a_topic(self) -> None:
+        window = WindowRef(
+            window_id=AGTERM_SESSION_UUID,
+            window_name="",
+            cwd="/proj",
+            pane_current_command="claude",
+            topic_eligible=False,
+        )
+        assert is_agent_topic_window(window, AGTERM_CAPS) is False
+
+    def test_the_flag_overrides_tmux_blanket_eligibility(self) -> None:
+        window = WindowRef(
+            window_id="@1",
+            window_name="",
+            cwd="/proj",
+            pane_current_command="claude",
+            topic_eligible=False,
+        )
+        assert is_agent_topic_window(window, TMUX_CAPS) is False
+
+    def test_windows_default_to_eligible(self) -> None:
+        """Backends with nothing to exclude say nothing and stay unaffected."""
+        assert WindowRef(window_id="@1", window_name="", cwd="/p").topic_eligible

--- a/tests/integration/test_monitor_flow.py
+++ b/tests/integration/test_monitor_flow.py
@@ -229,7 +229,8 @@ async def test_nested_session_start_does_not_steal_forwarding(
 
     _append_jsonl(parent_transcript, [_make_assistant_entry("parent new")])
     _bump_mtime(parent_transcript)
-    current = await monitor._detect_and_cleanup_changes()
+    # tmux: every live window is adoptable, which the loop derives per cycle.
+    current = await monitor._detect_and_cleanup_changes(adoptable_window_ids={"@0"})
     new_messages = await monitor.check_for_updates(current)
 
     assert current["@0"]["session_id"] == parent_id
@@ -277,7 +278,7 @@ async def test_session_change_cleanup(
     (state_dir / "session_map.json").write_text(
         json.dumps({"ccgram:@0": new_map["@0"]})
     )
-    await monitor._detect_and_cleanup_changes()
+    await monitor._detect_and_cleanup_changes(adoptable_window_ids={"@0"})
 
     assert monitor.state.get_session(TEST_SESSION_ID) is None
     assert get_claude_task_snapshot("@0") is None


### PR DESCRIPTION
`find_window_by_id` answers `None` both for a window that is **gone** and for a backend that **could not be reached**. That conflation predates this work, but after #213/#214/#215 much more depends on the answer, so the callers that destroy state stop taking it.

## The seam

`window_presence` and `window_snapshot` live on the reconciliation seam: existence is the multiplexer's contract, and handlers across sync, lifecycle, text, dashboard, agent and recovery need it without importing a topic-creation module.

`window_snapshot` returns `(confirmed, window)` from **one** read, for callers that need the window as well. A presence check followed by `find_window_by_id` is a second chance to fail on an answer that is ambiguous again.

`WindowRef.matches` decides identity case-insensitively, because agterm's UUIDs round-trip through callers that may lowercase them — which is why its own `_find_session` case-folds.

## agterm can prove absence per target

Its `tree` is per-window, so the merged listing is a sequence of RPCs. But a *targeted* call is decisive: an unknown session returns a well-formed refusal naming it, while an unreachable socket produces no envelope at all.

`window_exists` reports absence only on that whole shape — `ok is False`, a string reason, naming the session asked about — and treats anything else as unknown. The seam prefers a backend that has one, resolving the module facade first: the facade's type defines only `__getattr__`, so a static lookup on it finds no methods and every caller would silently fall back.

## The guards

Each per candidate, never once per batch, because these loops span Telegram round trips:

- **autoclose** no longer closes a topic on an unreachable backend
- **ghost removal** requires the window confirmed *gone*; **dead-topic recreation** confirmed *present*, before unbinding
- **same-name rebind** aborts instead of stealing a live topic, and re-reads after its Telegram probe
- **kill** requires the kill itself to succeed before clearing the routing, so a surviving session is never stranded
- **`/agent auto`** refuses to resolve to `shell` on an unconfirmed read, which would rewrite a working session and clear its transcript bookkeeping
- **Fresh / Continue / Resume** converge on one guard separating a window that is gone, one whose agent exited to a shell (recovery is right), and one running again (the offer is stale)

## The sticky dead marker

The text handler had a second way in. Its dead marker is sticky — `tick_window` returns early once set and nothing clears it — so a confirmed live window still counted as dead and reached the unbind whenever the cached cwd had also gone stale. That is exactly an agterm session returning under the same UUID after an app restart.

Every guard fails with its check removed, and the ones that can only refuse are paired with a case proving they still act on a confirmed absence.

Last of the code series splitting #212, stacked on #215.