### PR TITLE
Fix provider transitions during dead-window recovery

### DIFF
--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -380,10 +380,12 @@ async def _handle_dead_window(
             if w.pane_current_command
             else ""
         )
-        if not bound_provider or detected_provider != bound_provider:
-            # A present pane is not proof that the bound agent still owns it.
-            # Keep the marker so pending Telegram text cannot be injected into
-            # an unrelated foreground process with Return.
+        if not detected_provider or (
+            detected_provider == "shell" and bound_provider != "shell"
+        ):
+            # A present pane is safe only when it runs a recognized agent or
+            # belongs to an explicitly shell-bound topic. Keep the marker so
+            # Telegram text cannot reach an unrelated foreground process.
             await safe_reply(
                 message,
                 "\u26a0 That session is marked as ended and nothing confirms an "

--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -68,7 +68,7 @@ from ..user_state import (
 )
 from ... import window_query
 from ...thread_router import thread_router
-from ...providers import get_provider_for_window
+from ...providers import detect_provider_from_pane, get_provider_for_window
 from ...multiplexer import multiplexer as tmux_manager
 from ...utils import handle_general_topic_message, is_general_topic, task_done_callback
 
@@ -370,24 +370,27 @@ async def _handle_dead_window(
         w is not None
         and not returned_to_shell
         and lifecycle_strategy.is_dead_notified(user_id, thread_id, window_id)
-        and not w.pane_current_command
     ):
-        # Present, marked dead, and nothing says an agent holds the pane. An
-        # empty foreground command is agterm's "unknown", not proof of an
-        # agent: it reports none for a shell holding the pane, an unreadable
-        # process group and a failed lookup alike, and detection maps all three
-        # to "". Clearing the marker here would forward the next message, and
-        # the shared send guard types it into the pane with Return, so a
-        # session restored under the same UUID as a plain shell runs it as a
-        # command. Change nothing, keep the marker and the binding, and return
-        # before the stale-cwd unbind below.
-        await safe_reply(
-            message,
-            "\u26a0 That session is marked as ended and nothing confirms an "
-            "agent is running in it. Send that again in a moment, or use "
-            "/restore to start one.",
+        bound_provider = window_query.get_window_provider(window_id)
+        detected_provider = (
+            await detect_provider_from_pane(
+                w.pane_current_command,
+                window_id=window_id,
+            )
+            if w.pane_current_command
+            else ""
         )
-        return True
+        if not bound_provider or detected_provider != bound_provider:
+            # A present pane is not proof that the bound agent still owns it.
+            # Keep the marker so pending Telegram text cannot be injected into
+            # an unrelated foreground process with Return.
+            await safe_reply(
+                message,
+                "\u26a0 That session is marked as ended and nothing confirms an "
+                "agent is running in it. Send that again in a moment, or use "
+                "/restore to start one.",
+            )
+            return True
 
     if w is not None and not returned_to_shell:
         lifecycle_strategy.clear_dead_notification(user_id, thread_id)

--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -395,7 +395,7 @@ async def _handle_dead_window(
             )
             return True
 
-        await discover_and_register_transcript(window_id, _window=w)
+        returned_to_shell = await discover_and_register_transcript(window_id, _window=w)
 
     if w is not None and not returned_to_shell:
         lifecycle_strategy.clear_dead_notification(user_id, thread_id)

--- a/src/ccgram/handlers/text/text_handler.py
+++ b/src/ccgram/handlers/text/text_handler.py
@@ -50,6 +50,7 @@ from ..messaging_pipeline.message_sender import (
     safe_reply,
 )
 from ..recovery.recovery_banner import RecoveryBanner, render_banner
+from ..recovery.transcript_discovery import discover_and_register_transcript
 from ..polling.polling_state import lifecycle_strategy
 from ..telegram_origin import (
     agent_origin_returned_to_shell,
@@ -393,6 +394,8 @@ async def _handle_dead_window(
                 "/restore to start one.",
             )
             return True
+
+        await discover_and_register_transcript(window_id, _window=w)
 
     if w is not None and not returned_to_shell:
         lifecycle_strategy.clear_dead_notification(user_id, thread_id)

--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -250,6 +250,7 @@ def _install_json_hooks(
     installed_count = 0
     already_count = 0
     predicate = _json_hook_command_predicate(provider_name)
+    hook_command = _current_hook_command(provider_name)
     for event_type in events:
         event_hooks = hooks.setdefault(event_type, [])
         if not isinstance(event_hooks, list):
@@ -259,6 +260,7 @@ def _install_json_hooks(
             )
             return 1
         if _has_matching_hook(settings, event_type, predicate):
+            _replace_hook_commands(settings, event_type, predicate, hook_command)
             already_count += 1
             continue
         event_hooks.append({"hooks": [_hook_entry(provider_name, timeout_value)]})

--- a/src/ccgram/multiplexer/herdr.py
+++ b/src/ccgram/multiplexer/herdr.py
@@ -303,7 +303,13 @@ def _parse_live_record(record: Mapping[str, object]) -> HerdrLiveRecord | None:
             "agent.list contains an incomplete live locator"
         )
     if composite is None:
-        agent = _session_field(record.get("agent"))
+        if "agent" not in record:
+            return None
+        agent = record["agent"]
+        if not isinstance(agent, str) or not agent:
+            raise HerdrMalformedRecordError(
+                "agent.list contains a malformed sessionless agent"
+            )
         terminal_id = locators["terminal_id"]
         if agent not in {"claude", "codex", "gemini"} or terminal_id is None:
             return None

--- a/src/ccgram/multiplexer/reconciliation.py
+++ b/src/ccgram/multiplexer/reconciliation.py
@@ -55,6 +55,15 @@ def _resolve_backend(backend: object | None) -> object:
     return backend
 
 
+def _targeted_presence_probe(backend: object) -> _TargetedPresenceProbe | None:
+    """Return the backend's authoritative targeted probe, when it has one."""
+    if inspect.iscoroutinefunction(
+        inspect.getattr_static(type(backend), "window_exists", None)
+    ):
+        return cast("_TargetedPresenceProbe", backend)
+    return None
+
+
 async def window_snapshot(
     window_id: str, backend: object | None = None
 ) -> tuple[bool, WindowRef | None]:
@@ -68,10 +77,22 @@ async def window_snapshot(
     instead of a presence check followed by ``find_window_by_id``: that second
     lookup is a second chance to fail, and its ``None`` is ambiguous again.
     """
+    backend = _resolve_backend(backend)
+    prober = _targeted_presence_probe(backend)
+    if prober is not None:
+        present = await prober.window_exists(window_id)
+        if not isinstance(present, bool):
+            return False, None
+        if not present:
+            return True, None
+
     windows = await list_windows_for_reconciliation(backend)
     if windows is None:
         return False, None
-    return True, next((w for w in windows if w.matches(window_id)), None)
+    window = next((w for w in windows if w.matches(window_id)), None)
+    if prober is not None and window is None:
+        return False, None
+    return True, window
 
 
 async def window_presence(window_id: str, backend: object | None = None) -> bool | None:
@@ -101,10 +122,8 @@ async def window_presence(window_id: str, backend: object | None = None) -> bool
     # plain getattr is satisfied by any test double that generates attributes
     # on demand, which would route real backends through a probe that answers
     # nothing.
-    if inspect.iscoroutinefunction(
-        inspect.getattr_static(type(backend), "window_exists", None)
-    ):
-        prober = cast("_TargetedPresenceProbe", backend)
+    prober = _targeted_presence_probe(backend)
+    if prober is not None:
         answer = await prober.window_exists(window_id)
         return answer if isinstance(answer, bool) else None
 

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -871,7 +871,9 @@ class SessionMapSync:
         destination = state.provider_name.lower() if state else ""
         if not destination or entry.provider_name.lower() != destination:
             return False
-        if self._sync_window_from_session_map(window_id, info):
+        if self._sync_window_from_session_map(
+            window_id, info, prefer_existing_primary=False
+        ):
             self._schedule_save()
         logger.debug(
             "Preserved fresh session_map entry for %s provider %s",
@@ -920,6 +922,8 @@ class SessionMapSync:
         self,
         window_id: str,
         info: dict[str, Any],
+        *,
+        prefer_existing_primary: bool = True,
     ) -> bool:
         """Sync a single window's state from session_map entry.
 
@@ -931,7 +935,11 @@ class SessionMapSync:
         # Lazy: window_state_store / thread_router proxies wired by SessionManager constructor
         from .window_state_store import window_store
 
-        effective = effective_session_map_info(window_id, info)
+        effective = (
+            effective_session_map_info(window_id, info)
+            if prefer_existing_primary
+            else info
+        )
         new_sid = effective["session_id"]
         if not new_sid:
             return False

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -852,8 +852,36 @@ class SessionMapSync:
             return False
         return True
 
+    def _preserve_destination_provider_entry(
+        self, window_id: str, info: dict[str, Any]
+    ) -> bool:
+        """Load and retain a valid entry written by the destination provider."""
+        try:
+            entry = parse_session_map_entry(info)
+        except StateFileValidationError:
+            return False
+
+        # The provider-switch callback runs after the destination provider is
+        # stored. If SessionStart won the file-lock race, keep and load its
+        # fresh entry instead of deleting the new association.
+        # Lazy: session_map and window_state_store are mutually wired at startup.
+        from .window_state_store import window_store
+
+        state = window_store.window_states.get(window_id)
+        destination = state.provider_name.lower() if state else ""
+        if not destination or entry.provider_name.lower() != destination:
+            return False
+        if self._sync_window_from_session_map(window_id, info):
+            self._schedule_save()
+        logger.debug(
+            "Preserved fresh session_map entry for %s provider %s",
+            window_id,
+            destination,
+        )
+        return True
+
     def clear_session_map_entry(self, window_id: str) -> None:
-        """Remove a window's entry from session_map.json if present."""
+        """Clear a stale entry, preserving one written by the new provider."""
         if not config.session_map_file.exists():
             return
         lock_path = config.session_map_file.with_suffix(".lock")
@@ -862,7 +890,14 @@ class SessionMapSync:
                 fcntl.flock(lock_f, fcntl.LOCK_EX)
                 try:
                     raw = json.loads(config.session_map_file.read_text())
+                    if not isinstance(raw, dict):
+                        return
                     key = f"{session_map_prefix()}{window_id}"
+                    info = raw.get(key)
+                    if isinstance(
+                        info, dict
+                    ) and self._preserve_destination_provider_entry(window_id, info):
+                        return
                     if key in raw:
                         del raw[key]
                         atomic_write_json(config.session_map_file, raw)

--- a/tests/ccgram/handlers/text/test_text_handler.py
+++ b/tests/ccgram/handlers/text/test_text_handler.py
@@ -665,6 +665,7 @@ class TestStaleDeadMarkerDoesNotOutliveTheWindow:
         ):
             mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[window])
             mock_query.is_legacy_herdr.return_value = False
+            mock_query.get_window_provider.return_value = "claude"
             # Stale cached cwd: the shape that otherwise reaches the unbind.
             mock_query.view_window.return_value = MagicMock(cwd="/nonexistent")
 
@@ -743,15 +744,17 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
         ):
             mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[window])
             mock_query.is_legacy_herdr.return_value = False
+            mock_query.get_window_provider.return_value = "claude"
             # Stale cached cwd: the shape that reaches the unbind.
             mock_query.view_window.return_value = MagicMock(cwd="/nonexistent")
             result = await _handle_dead_window("@0", 100, 42, "hi", {}, message)
         return result, mock_router, mock_reply
 
+    @pytest.mark.parametrize("pane_command", ["", "vim", "less", "top"])
     async def test_an_unknown_foreground_keeps_the_marker_and_forwards_nothing(
-        self,
+        self, pane_command: str
     ) -> None:
-        handled, mock_router, mock_reply = await self._run("")
+        handled, mock_router, mock_reply = await self._run(pane_command)
 
         assert handled is True, "the message must not be forwarded to the pane"
         assert lifecycle_strategy.is_dead_notified(100, 42, "@0")

--- a/tests/ccgram/handlers/text/test_text_handler.py
+++ b/tests/ccgram/handlers/text/test_text_handler.py
@@ -745,6 +745,7 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
             patch(
                 f"{_TH}.discover_and_register_transcript",
                 new_callable=AsyncMock,
+                return_value=False,
             ) as mock_sync_provider,
             patch(f"{_TH}.safe_reply", new_callable=AsyncMock) as mock_reply,
         ):
@@ -781,6 +782,55 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
         assert not lifecycle_strategy.is_dead_notified(100, 42, "@0")
         mock_router.unbind_thread.assert_not_called()
         mock_sync_provider.assert_awaited_once()
+
+    async def test_an_agent_exit_during_provider_sync_enters_recovery(self) -> None:
+        lifecycle_strategy.mark_dead_notified(100, 42, "@0")
+        user_data: dict = {}
+        window = WindowRef(
+            window_id="@0",
+            window_name="project",
+            cwd="/tmp/project",
+            pane_current_command="claude",
+        )
+        message = AsyncMock()
+        message.chat.id = -100
+        with (
+            patch(f"{_TH}.tmux_manager") as mock_tm,
+            patch(f"{_TH}.window_query") as mock_query,
+            patch(f"{_TH}.thread_router") as mock_router,
+            patch(
+                f"{_TH}.agent_origin_returned_to_shell",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                f"{_TH}.discover_and_register_transcript",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(f"{_TH}.render_banner", return_value=("recovery", MagicMock())),
+            patch(f"{_TH}.safe_reply", new_callable=AsyncMock) as mock_reply,
+            patch(f"{_TH}.Path") as mock_path,
+        ):
+            mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[window])
+            mock_query.is_legacy_herdr.return_value = False
+            mock_query.get_window_provider.return_value = "claude"
+            mock_query.view_window.return_value = MagicMock(
+                cwd="/tmp/project", provider_name="claude"
+            )
+            mock_router.get_display_name.return_value = "project"
+            mock_path.return_value.is_dir.return_value = True
+
+            handled = await _handle_dead_window(
+                "@0", 100, 42, "keep this prompt", user_data, message
+            )
+
+        assert handled is True
+        assert lifecycle_strategy.is_dead_notified(100, 42, "@0")
+        assert user_data[PENDING_THREAD_TEXT] == "keep this prompt"
+        assert user_data[RECOVERY_WINDOW_ID] == "@0"
+        mock_router.unbind_thread.assert_not_called()
+        mock_reply.assert_awaited_once()
 
     async def test_a_shell_bound_topic_accepts_a_shell_foreground(self) -> None:
         handled, mock_router, _, mock_sync_provider = await self._run(

--- a/tests/ccgram/handlers/text/test_text_handler.py
+++ b/tests/ccgram/handlers/text/test_text_handler.py
@@ -724,7 +724,7 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
     @staticmethod
     async def _run(
         pane_command: str, *, bound_provider: str = "claude"
-    ) -> tuple[bool, AsyncMock, AsyncMock]:
+    ) -> tuple[bool, AsyncMock, AsyncMock, AsyncMock]:
         lifecycle_strategy.mark_dead_notified(100, 42, "@0")
         window = WindowRef(
             window_id="@0",
@@ -742,6 +742,10 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
                 new_callable=AsyncMock,
                 return_value=False,
             ),
+            patch(
+                f"{_TH}.discover_and_register_transcript",
+                new_callable=AsyncMock,
+            ) as mock_sync_provider,
             patch(f"{_TH}.safe_reply", new_callable=AsyncMock) as mock_reply,
         ):
             mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[window])
@@ -750,17 +754,20 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
             # Stale cached cwd: the shape that reaches the unbind.
             mock_query.view_window.return_value = MagicMock(cwd="/nonexistent")
             result = await _handle_dead_window("@0", 100, 42, "hi", {}, message)
-        return result, mock_router, mock_reply
+        return result, mock_router, mock_reply, mock_sync_provider
 
     @pytest.mark.parametrize("pane_command", ["", "vim", "less", "top", "bash"])
     async def test_a_non_agent_foreground_keeps_the_marker_and_forwards_nothing(
         self, pane_command: str
     ) -> None:
-        handled, mock_router, mock_reply = await self._run(pane_command)
+        handled, mock_router, mock_reply, mock_sync_provider = await self._run(
+            pane_command
+        )
 
         assert handled is True, "the message must not be forwarded to the pane"
         assert lifecycle_strategy.is_dead_notified(100, 42, "@0")
         mock_router.unbind_thread.assert_not_called()
+        mock_sync_provider.assert_not_awaited()
         assert "nothing confirms an agent" in mock_reply.await_args[0][1]
 
     @pytest.mark.parametrize("pane_command", ["claude", "codex"])
@@ -768,15 +775,29 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
         self, pane_command: str
     ) -> None:
         """Any confirmed agent is enough to resume forwarding safely."""
-        handled, mock_router, _ = await self._run(pane_command)
+        handled, mock_router, _, mock_sync_provider = await self._run(pane_command)
 
         assert handled is False, "a live agent's topic keeps forwarding"
         assert not lifecycle_strategy.is_dead_notified(100, 42, "@0")
         mock_router.unbind_thread.assert_not_called()
+        mock_sync_provider.assert_awaited_once()
 
     async def test_a_shell_bound_topic_accepts_a_shell_foreground(self) -> None:
-        handled, mock_router, _ = await self._run("bash", bound_provider="shell")
+        handled, mock_router, _, mock_sync_provider = await self._run(
+            "bash", bound_provider="shell"
+        )
 
         assert handled is False
         assert not lifecycle_strategy.is_dead_notified(100, 42, "@0")
         mock_router.unbind_thread.assert_not_called()
+        mock_sync_provider.assert_awaited_once()
+
+    async def test_a_shell_bound_topic_syncs_a_detected_agent(self) -> None:
+        handled, mock_router, _, mock_sync_provider = await self._run(
+            "codex", bound_provider="shell"
+        )
+
+        assert handled is False
+        assert not lifecycle_strategy.is_dead_notified(100, 42, "@0")
+        mock_router.unbind_thread.assert_not_called()
+        mock_sync_provider.assert_awaited_once()

--- a/tests/ccgram/handlers/text/test_text_handler.py
+++ b/tests/ccgram/handlers/text/test_text_handler.py
@@ -722,7 +722,9 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
     """
 
     @staticmethod
-    async def _run(pane_command: str) -> tuple[bool, AsyncMock, AsyncMock]:
+    async def _run(
+        pane_command: str, *, bound_provider: str = "claude"
+    ) -> tuple[bool, AsyncMock, AsyncMock]:
         lifecycle_strategy.mark_dead_notified(100, 42, "@0")
         window = WindowRef(
             window_id="@0",
@@ -744,14 +746,14 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
         ):
             mock_tm.list_windows_for_reconciliation = AsyncMock(return_value=[window])
             mock_query.is_legacy_herdr.return_value = False
-            mock_query.get_window_provider.return_value = "claude"
+            mock_query.get_window_provider.return_value = bound_provider
             # Stale cached cwd: the shape that reaches the unbind.
             mock_query.view_window.return_value = MagicMock(cwd="/nonexistent")
             result = await _handle_dead_window("@0", 100, 42, "hi", {}, message)
         return result, mock_router, mock_reply
 
-    @pytest.mark.parametrize("pane_command", ["", "vim", "less", "top"])
-    async def test_an_unknown_foreground_keeps_the_marker_and_forwards_nothing(
+    @pytest.mark.parametrize("pane_command", ["", "vim", "less", "top", "bash"])
+    async def test_a_non_agent_foreground_keeps_the_marker_and_forwards_nothing(
         self, pane_command: str
     ) -> None:
         handled, mock_router, mock_reply = await self._run(pane_command)
@@ -761,10 +763,20 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
         mock_router.unbind_thread.assert_not_called()
         assert "nothing confirms an agent" in mock_reply.await_args[0][1]
 
-    async def test_a_named_agent_still_clears_the_marker(self) -> None:
-        """The other side: a confirmed agent is why the clearing exists."""
-        handled, mock_router, _ = await self._run("claude")
+    @pytest.mark.parametrize("pane_command", ["claude", "codex"])
+    async def test_a_named_agent_still_clears_the_marker(
+        self, pane_command: str
+    ) -> None:
+        """Any confirmed agent is enough to resume forwarding safely."""
+        handled, mock_router, _ = await self._run(pane_command)
 
         assert handled is False, "a live agent's topic keeps forwarding"
+        assert not lifecycle_strategy.is_dead_notified(100, 42, "@0")
+        mock_router.unbind_thread.assert_not_called()
+
+    async def test_a_shell_bound_topic_accepts_a_shell_foreground(self) -> None:
+        handled, mock_router, _ = await self._run("bash", bound_provider="shell")
+
+        assert handled is False
         assert not lifecycle_strategy.is_dead_notified(100, 42, "@0")
         mock_router.unbind_thread.assert_not_called()

--- a/tests/ccgram/test_agterm_backend.py
+++ b/tests/ccgram/test_agterm_backend.py
@@ -1461,6 +1461,19 @@ async def test_presence_through_the_seam_uses_the_targeted_probe() -> None:
     assert await window_presence(SESSION_B, _manager(fake)) is True
 
 
+async def test_snapshot_does_not_treat_a_torn_listing_as_absence() -> None:
+    from ccgram.multiplexer.reconciliation import window_snapshot
+
+    fake = (
+        FakeAgtermctl()
+        .on("window", "list", out=_windows())
+        .on("tree", out=_tree())
+        .ok("session", "text", result={"text": "hi"})
+    )
+
+    assert await window_snapshot(SESSION_B, _manager(fake)) == (False, None)
+
+
 @pytest.mark.parametrize(
     ("payload", "why"),
     [

--- a/tests/ccgram/test_herdr_backend.py
+++ b/tests/ccgram/test_herdr_backend.py
@@ -1941,6 +1941,23 @@ async def test_a_recognised_sessionless_agent_keeps_the_listing_complete() -> No
     assert [w.window_id for w in windows] == [_sessionless_target("term-b")]
 
 
+@pytest.mark.parametrize("agent", [None, "", 7, {"name": "claude"}])
+async def test_a_malformed_sessionless_agent_marks_the_listing_unknown(agent) -> None:
+    malformed = {
+        "terminal_id": "term-x",
+        "pane_id": "w9:p9",
+        "tab_id": "w9:t9",
+        "workspace_id": "w9",
+        "agent": agent,
+    }
+    bound = _agent(pane_id="w2:p1", tab_id="w2:t1", value="session-a")
+
+    assert (
+        await _manager(_live_fake(malformed, bound)).list_windows_for_reconciliation()
+        is None
+    )
+
+
 async def test_an_unrecognised_sessionless_agent_does_not_blank_the_listing() -> None:
     """Antigravity is the live case, and it is not a transient.
 

--- a/tests/ccgram/test_hook_provider_events.py
+++ b/tests/ccgram/test_hook_provider_events.py
@@ -8,8 +8,10 @@ from unittest.mock import patch
 import pytest
 
 from ccgram.hook import (
+    _current_hook_command,
     _encode_pi_cwd_dirname,
     _install_hook,
+    _install_json_hooks,
     _resolve_pi_transcript_path,
     hook_main,
 )
@@ -764,6 +766,39 @@ def test_hook_detects_claude_with_custom_config_dir(
     event = json.loads((tmp_path / "state" / "events.jsonl").read_text())
     assert event["event"] == event_name
     assert event["data"]["provider_name"] == "claude"
+
+
+def test_json_hook_install_rewrites_stale_command(tmp_path: Path) -> None:
+    hooks_file = tmp_path / "hooks.json"
+    hooks_file.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    event_type: [
+                        {
+                            "hooks": [
+                                {
+                                    "name": "ccgram-session-tracker",
+                                    "type": "command",
+                                    "command": "ccgram hook --provider codex",
+                                    "timeout": 5,
+                                }
+                            ]
+                        }
+                    ]
+                    for event_type in ("SessionStart", "Stop")
+                }
+            }
+        )
+    )
+
+    assert _install_json_hooks(hooks_file, "codex", ("SessionStart", "Stop"), 5) == 0
+
+    settings = json.loads(hooks_file.read_text())
+    for event_type in ("SessionStart", "Stop"):
+        installed = settings["hooks"][event_type][0]["hooks"]
+        assert len(installed) == 1
+        assert installed[0]["command"] == _current_hook_command("codex")
 
 
 def test_gemini_install_adds_provider_specific_hooks(

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from ccgram.session import SessionManager
-from ccgram.hooks.state_files import pending_pi_replay_key
+from ccgram.hooks.state_files import pending_pi_replay_key, serialize_session_map_entry
 from ccgram.session_map import acknowledge_replay_from_start, session_map_sync
 from ccgram.session_resolver import session_resolver
 from ccgram.thread_router import thread_router
@@ -666,6 +666,64 @@ class TestSessionMapEntryMayExist:
         monkeypatch.setattr("ccgram.session_map.config.tmux_session_name", "ccgram")
 
         assert await session_map_sync.session_map_entry_may_exist("@1") is True
+
+
+class TestProviderSwitchSessionMapRace:
+    def test_fresh_destination_entry_survives_provider_switch(
+        self, mgr: SessionManager, tmp_path, monkeypatch
+    ) -> None:
+        session_map_file = tmp_path / "session_map.json"
+        fresh_entry = serialize_session_map_entry(
+            "new-pi-session",
+            "/repo",
+            "agent",
+            "/home/user/.pi/agent/sessions/new.jsonl",
+            "pi",
+        )
+        session_map_file.write_text(json.dumps({"ccgram:@1": fresh_entry}))
+        monkeypatch.setattr(
+            "ccgram.session_map.config.session_map_file", session_map_file
+        )
+        monkeypatch.setattr("ccgram.session_map.config.tmux_session_name", "ccgram")
+
+        state = window_store.get_window_state("@1")
+        state.provider_name = "claude"
+        state.session_id = "old-claude-session"
+        state.transcript_path = "/home/user/.claude/projects/repo/old.jsonl"
+
+        mgr.set_window_provider("@1", "pi", cwd="/repo")
+
+        assert json.loads(session_map_file.read_text()) == {"ccgram:@1": fresh_entry}
+        assert state.provider_name == "pi"
+        assert state.session_id == "new-pi-session"
+        assert state.transcript_path == "/home/user/.pi/agent/sessions/new.jsonl"
+
+    def test_previous_provider_entry_is_still_cleared(
+        self, mgr: SessionManager, tmp_path, monkeypatch
+    ) -> None:
+        session_map_file = tmp_path / "session_map.json"
+        session_map_file.write_text(
+            json.dumps(
+                {
+                    "ccgram:@1": serialize_session_map_entry(
+                        "old-claude-session",
+                        "/repo",
+                        "agent",
+                        "/home/user/.claude/projects/repo/old.jsonl",
+                        "claude",
+                    )
+                }
+            )
+        )
+        monkeypatch.setattr(
+            "ccgram.session_map.config.session_map_file", session_map_file
+        )
+        monkeypatch.setattr("ccgram.session_map.config.tmux_session_name", "ccgram")
+        window_store.get_window_state("@1").provider_name = "claude"
+
+        mgr.set_window_provider("@1", "pi", cwd="/repo")
+
+        assert json.loads(session_map_file.read_text()) == {}
 
 
 class TestAcknowledgeReplayFromStart:

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -673,11 +673,17 @@ class TestProviderSwitchSessionMapRace:
         self, mgr: SessionManager, tmp_path, monkeypatch
     ) -> None:
         session_map_file = tmp_path / "session_map.json"
+        old_transcript = tmp_path / ".claude" / "projects" / "repo" / "old.jsonl"
+        old_transcript.parent.mkdir(parents=True)
+        old_transcript.write_text("")
+        new_transcript = tmp_path / ".pi" / "agent" / "sessions" / "new.jsonl"
+        new_transcript.parent.mkdir(parents=True)
+        new_transcript.write_text("")
         fresh_entry = serialize_session_map_entry(
             "new-pi-session",
             "/repo",
             "agent",
-            "/home/user/.pi/agent/sessions/new.jsonl",
+            str(new_transcript),
             "pi",
         )
         session_map_file.write_text(json.dumps({"ccgram:@1": fresh_entry}))
@@ -689,14 +695,14 @@ class TestProviderSwitchSessionMapRace:
         state = window_store.get_window_state("@1")
         state.provider_name = "claude"
         state.session_id = "old-claude-session"
-        state.transcript_path = "/home/user/.claude/projects/repo/old.jsonl"
+        state.transcript_path = str(old_transcript)
 
         mgr.set_window_provider("@1", "pi", cwd="/repo")
 
         assert json.loads(session_map_file.read_text()) == {"ccgram:@1": fresh_entry}
         assert state.provider_name == "pi"
         assert state.session_id == "new-pi-session"
-        assert state.transcript_path == "/home/user/.pi/agent/sessions/new.jsonl"
+        assert state.transcript_path == str(new_transcript)
 
     def test_previous_provider_entry_is_still_cleared(
         self, mgr: SessionManager, tmp_path, monkeypatch


### PR DESCRIPTION
## Summary

- fail closed when an agent state cannot be identified reliably
- allow dead-marked windows to recover when one provider replaces another
- reconcile provider identity before dead-marker recovery
- preserve and synchronise a fresh destination-provider session entry across hook races
- enter recovery when an agent exits during transcript synchronisation
- migrate stale Codex/Gemini hook commands to the current absolute Python entrypoint

## Validation

- `make lint`
- `uv run pyright src/ccgram/`
- `make deptry`
- `make test` — 7006 passed, 32 skipped
- `uv run pytest tests/integration/ -m "not llm" -q` — 323 passed, 8 skipped, 13 deselected
- `make arch-guard` — 838 passed
- `make arch-check` — 0 blocking findings
- manual Herdr provider checks for Claude, Pi, and Codex
- live ccgram session-map, persisted-state, hook-event, transcript, and service-log inspection
