### PR TITLE
fix: ignore empty transcript discovery directories

### DIFF
--- a/src/ccgram/transcript_reader.py
+++ b/src/ccgram/transcript_reader.py
@@ -819,6 +819,8 @@ class TranscriptReader:
         cwds: set[str] = set()
         windows = await list_windows_for_reconciliation()
         for w in windows or []:
+            if not w.cwd:
+                continue
             try:
                 cwds.add(str(Path(w.cwd).resolve()))
             except _PathResolveError:

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -2059,6 +2059,19 @@ class TestActiveCwdsUseTheCompleteListing:
 
         assert await self._reader()._get_active_cwds() == {"/repo"}
 
+    async def test_ignores_empty_window_cwd(self, monkeypatch) -> None:
+        from ccgram.multiplexer.base import WindowRef
+
+        async def _complete():
+            return [WindowRef(window_id="@4", window_name="unknown", cwd="")]
+
+        monkeypatch.setattr(
+            "ccgram.multiplexer.reconciliation.list_windows_for_reconciliation",
+            _complete,
+        )
+
+        assert await self._reader()._get_active_cwds() == set()
+
     async def test_unconfirmed_listing_yields_no_cwds(self, monkeypatch) -> None:
         async def _unavailable():
             return None


### PR DESCRIPTION
Skip unknown empty cwd values instead of resolving them to ccgram process cwd. Add regression coverage. Checks: session monitor tests, ruff. Closes #222.