### PR TITLE
fix: canonicalize IDs during state maintenance

### DIFF
--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -666,12 +666,19 @@ class SessionManager:
                     )
 
         # 6. Display name drift (stored != tmux)
-        stored_names = {
-            canonical_window_id(wid): name
-            for wid, name in thread_router.window_display_names.items()
-        }
+        stored_names = sorted(thread_router.window_display_names.items())
         for wid, tmux_name in live_windows:
-            stored_name = stored_names.get(canonical_window_id(wid))
+            stored_name = thread_router.window_display_names.get(wid)
+            if stored_name is None:
+                key = canonical_window_id(wid)
+                stored_name = next(
+                    (
+                        name
+                        for stored_wid, name in stored_names
+                        if canonical_window_id(stored_wid) == key
+                    ),
+                    None,
+                )
             if stored_name and stored_name != tmux_name:
                 issues.append(
                     AuditIssue(

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -563,9 +563,7 @@ class SessionManager:
                 live_binding_count += 1
 
         session_map_wids = self._get_session_map_window_ids()
-        session_map_lookup = {
-            canonical_window_id(wid) for wid in session_map_wids
-        }
+        session_map_lookup = {canonical_window_id(wid) for wid in session_map_wids}
         bound_lookup = {canonical_window_id(wid) for wid in bound_window_ids}
 
         # 1. Legacy Herdr bindings are retained for archive/rollback but never

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -440,12 +440,14 @@ class SessionManager:
         # Collect window_ids that are "in use" (bound or have window_states)
         in_use = set(self.window_states.keys())
         in_use.update(thread_router.all_bound_window_ids())
+        in_use_lookup = {canonical_window_id(wid) for wid in in_use}
 
         # Prune window_display_names for dead windows not in use and not live
         stale_display = [
             wid
             for wid in thread_router.window_display_names
-            if canonical_window_id(wid) not in live_lookup and wid not in in_use
+            if canonical_window_id(wid) not in live_lookup
+            and canonical_window_id(wid) not in in_use_lookup
         ]
 
         # Collect all bound thread keys "user_id:thread_id"
@@ -561,6 +563,10 @@ class SessionManager:
                 live_binding_count += 1
 
         session_map_wids = self._get_session_map_window_ids()
+        session_map_lookup = {
+            canonical_window_id(wid) for wid in session_map_wids
+        }
+        bound_lookup = {canonical_window_id(wid) for wid in bound_window_ids}
 
         # 1. Legacy Herdr bindings are retained for archive/rollback but never
         # actioned or implicitly remapped. Report their explicit rebind path
@@ -596,8 +602,12 @@ class SessionManager:
 
         # 3. Orphaned display names
         in_use = set(self.window_states.keys()) | bound_window_ids
+        in_use_lookup = {canonical_window_id(wid) for wid in in_use}
         for wid in thread_router.window_display_names:
-            if canonical_window_id(wid) not in live_lookup and wid not in in_use:
+            if (
+                canonical_window_id(wid) not in live_lookup
+                and canonical_window_id(wid) not in in_use_lookup
+            ):
                 name = thread_router.get_display_name(wid)
                 issues.append(
                     AuditIssue(
@@ -624,10 +634,11 @@ class SessionManager:
 
         # 4. Stale window_states (not in session_map, not bound, not live)
         for wid in self.window_states:
+            key = canonical_window_id(wid)
             if (
-                wid not in session_map_wids
-                and wid not in bound_window_ids
-                and canonical_window_id(wid) not in live_lookup
+                key not in session_map_lookup
+                and key not in bound_lookup
+                and key not in live_lookup
             ):
                 display = self.window_states[wid].window_name or wid
                 issues.append(
@@ -639,10 +650,15 @@ class SessionManager:
                 )
 
         # 5. Stale user_window_offsets
-        known_wids = live_window_ids | bound_window_ids | set(self.window_states.keys())
+        known_lookup = {
+            canonical_window_id(wid)
+            for wid in live_window_ids
+            | bound_window_ids
+            | set(self.window_states.keys())
+        }
         for uid, offsets in user_preferences.user_window_offsets.items():
             for wid in offsets:
-                if wid not in known_wids:
+                if canonical_window_id(wid) not in known_lookup:
                     issues.append(
                         AuditIssue(
                             category="stale_offset",
@@ -652,8 +668,12 @@ class SessionManager:
                     )
 
         # 6. Display name drift (stored != tmux)
+        stored_names = {
+            canonical_window_id(wid): name
+            for wid, name in thread_router.window_display_names.items()
+        }
         for wid, tmux_name in live_windows:
-            stored_name = thread_router.window_display_names.get(wid)
+            stored_name = stored_names.get(canonical_window_id(wid))
             if stored_name and stored_name != tmux_name:
                 issues.append(
                     AuditIssue(
@@ -671,7 +691,6 @@ class SessionManager:
             canonical_window_id(wid)
             for wid in session_map_wids | set(self.window_states.keys())
         }
-        bound_lookup = {canonical_window_id(wid) for wid in bound_window_ids}
         for wid in adoptable_window_ids:
             key = canonical_window_id(wid)
             if key not in bound_lookup and key in known_lookup:
@@ -696,15 +715,19 @@ class SessionManager:
         Returns True if any changes were made.
         """
         live_lookup = {canonical_window_id(w) for w in live_window_ids}
-        session_map_wids = self._get_session_map_window_ids()
-        bound_window_ids = thread_router.all_bound_window_ids()
+        session_map_lookup = {
+            canonical_window_id(wid) for wid in self._get_session_map_window_ids()
+        }
+        bound_lookup = {
+            canonical_window_id(wid) for wid in thread_router.all_bound_window_ids()
+        }
 
         stale = [
             wid
             for wid in self.window_states
             if (
-                wid not in session_map_wids
-                and wid not in bound_window_ids
+                canonical_window_id(wid) not in session_map_lookup
+                and canonical_window_id(wid) not in bound_lookup
                 and canonical_window_id(wid) not in live_lookup
                 and not window_store.is_archived_legacy_herdr(wid)
             )

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -1478,6 +1478,18 @@ class TestAuditState:
         drift = [i for i in result.issues if i.category == "display_name_drift"]
         assert len(drift) == 1
 
+    def test_exact_display_name_spelling_takes_priority(
+        self, mgr: SessionManager
+    ) -> None:
+        thread_router.window_display_names["abc-def"] = "stale-variant"
+        thread_router.window_display_names["ABC-DEF"] = "current"
+
+        result = mgr.audit_state(
+            live_window_ids={"ABC-DEF"}, live_windows=[("ABC-DEF", "current")]
+        )
+
+        assert not any(i.category == "display_name_drift" for i in result.issues)
+
 
 class TestPruneStaleOffsets:
     def test_removes_unknown_windows(self, mgr: SessionManager) -> None:

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -1445,9 +1445,7 @@ class TestAuditState:
                 }
             )
         )
-        monkeypatch.setattr(
-            "ccgram.session.config.session_map_file", session_map_file
-        )
+        monkeypatch.setattr("ccgram.session.config.session_map_file", session_map_file)
         monkeypatch.setattr("ccgram.session.config.multiplexer_name", "agterm")
         mgr.window_states["abc-def"] = WindowState(session_id="sid", cwd="/tmp")
         thread_router.bind_thread(100, 1, "ABC-DEF")
@@ -1546,9 +1544,7 @@ class TestPruneStaleWindowStates:
                 }
             )
         )
-        monkeypatch.setattr(
-            "ccgram.session.config.session_map_file", session_map_file
-        )
+        monkeypatch.setattr("ccgram.session.config.session_map_file", session_map_file)
         monkeypatch.setattr("ccgram.session.config.multiplexer_name", "agterm")
         mgr.window_states["abc-def"] = WindowState(session_id="sid", cwd="/tmp")
 

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -1022,6 +1022,19 @@ class TestPruneStaleState:
         assert changed is False
         assert "@2" in thread_router.window_display_names
 
+    def test_keeps_case_variant_display_name_and_offset_in_use(
+        self, mgr: SessionManager
+    ) -> None:
+        thread_router.window_display_names["abc-def"] = "bound-proj"
+        thread_router.bind_thread(100, 1, "ABC-DEF")
+        user_preferences.user_window_offsets[100] = {"abc-def": 42}
+
+        changed = mgr.prune_stale_state(live_window_ids=set())
+
+        assert changed is False
+        assert thread_router.window_display_names["abc-def"] == "bound-proj"
+        assert user_preferences.user_window_offsets[100]["abc-def"] == 42
+
     def test_keeps_display_name_if_has_window_state(self, mgr: SessionManager) -> None:
         thread_router.window_display_names["@3"] = "with-state"
         mgr.window_states["@3"] = WindowState(session_id="sid")
@@ -1417,6 +1430,56 @@ class TestAuditState:
         assert len(stale) == 1
         assert stale[0].fixable
 
+    def test_case_variant_state_is_in_use_by_binding_and_session_map(
+        self, mgr: SessionManager, tmp_path, monkeypatch
+    ) -> None:
+        session_map_file = tmp_path / "session_map.json"
+        session_map_file.write_text(
+            json.dumps(
+                {
+                    "agterm:ABC-DEF": {
+                        "session_id": "sid",
+                        "cwd": "/tmp",
+                        "schema_version": 1,
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr(
+            "ccgram.session.config.session_map_file", session_map_file
+        )
+        monkeypatch.setattr("ccgram.session.config.multiplexer_name", "agterm")
+        mgr.window_states["abc-def"] = WindowState(session_id="sid", cwd="/tmp")
+        thread_router.bind_thread(100, 1, "ABC-DEF")
+
+        result = mgr.audit_state(live_window_ids=set(), live_windows=[])
+
+        assert not any(i.category == "stale_window_state" for i in result.issues)
+
+    def test_case_variant_display_and_offset_are_known(
+        self, mgr: SessionManager
+    ) -> None:
+        mgr.window_states["ABC-DEF"] = WindowState(session_id="sid", cwd="/tmp")
+        thread_router.window_display_names["abc-def"] = "project"
+        user_preferences.user_window_offsets[100] = {"abc-def": 42}
+
+        result = mgr.audit_state(live_window_ids=set(), live_windows=[])
+
+        assert not any(i.category == "orphaned_display_name" for i in result.issues)
+        assert not any(i.category == "stale_offset" for i in result.issues)
+
+    def test_case_variant_display_name_drift_is_reported(
+        self, mgr: SessionManager
+    ) -> None:
+        thread_router.window_display_names["abc-def"] = "old-name"
+
+        result = mgr.audit_state(
+            live_window_ids={"ABC-DEF"}, live_windows=[("ABC-DEF", "new-name")]
+        )
+
+        drift = [i for i in result.issues if i.category == "display_name_drift"]
+        assert len(drift) == 1
+
 
 class TestPruneStaleOffsets:
     def test_removes_unknown_windows(self, mgr: SessionManager) -> None:
@@ -1458,6 +1521,41 @@ class TestPruneStaleWindowStates:
         changed = mgr.prune_stale_window_states(live_window_ids=set())
         assert not changed
         assert "@1" in mgr.window_states
+
+    def test_keeps_state_for_case_variant_binding(self, mgr: SessionManager) -> None:
+        mgr.window_states["abc-def"] = WindowState(session_id="s1", cwd="/tmp")
+        thread_router.bind_thread(100, 1, "ABC-DEF")
+
+        changed = mgr.prune_stale_window_states(live_window_ids=set())
+
+        assert not changed
+        assert "abc-def" in mgr.window_states
+
+    def test_keeps_state_for_case_variant_session_map(
+        self, mgr: SessionManager, tmp_path, monkeypatch
+    ) -> None:
+        session_map_file = tmp_path / "session_map.json"
+        session_map_file.write_text(
+            json.dumps(
+                {
+                    "agterm:ABC-DEF": {
+                        "session_id": "sid",
+                        "cwd": "/tmp",
+                        "schema_version": 1,
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr(
+            "ccgram.session.config.session_map_file", session_map_file
+        )
+        monkeypatch.setattr("ccgram.session.config.multiplexer_name", "agterm")
+        mgr.window_states["abc-def"] = WindowState(session_id="sid", cwd="/tmp")
+
+        changed = mgr.prune_stale_window_states(live_window_ids=set())
+
+        assert not changed
+        assert "abc-def" in mgr.window_states
 
     def test_keeps_live_states(self, mgr: SessionManager) -> None:
         mgr.window_states["@1"] = WindowState(session_id="s1", cwd="/tmp")


### PR DESCRIPTION
Use canonical window identity lookup sets for audit and stale-state pruning while preserving stored spelling. Add maintenance regressions for bindings, session-map entries, names, and offsets. Checks: session tests, ruff. Closes #223.