### PR TITLE
fix: converge case-variant session-map IDs

### DIFF
--- a/src/ccgram/handlers/hook_events.py
+++ b/src/ccgram/handlers/hook_events.py
@@ -15,6 +15,7 @@ import structlog
 from ..claude_task_state import classify_wait_message, claude_task_state
 from ..providers.base import HookEvent
 from ..session_lifecycle import session_lifecycle
+from ..multiplexer.base import canonical_window_id
 from ..session_map import session_map_prefix, strip_session_map_prefix
 from ..session_state_ports.live_session_state import has_task_snapshot
 from ..telegram_client import TelegramClient
@@ -48,9 +49,10 @@ def _resolve_users_for_window_key(
         return []
 
     results: list[tuple[int, int, str]] = []
+    wanted = canonical_window_id(window_id)
     for user_id, thread_id, bound_wid in thread_router.iter_thread_bindings():
-        if bound_wid == window_id:
-            results.append((user_id, thread_id, window_id))
+        if canonical_window_id(bound_wid) == wanted:
+            results.append((user_id, thread_id, bound_wid))
     return results
 
 
@@ -61,20 +63,21 @@ def _resolve_user_chats_for_window_key(
     window_id = strip_session_map_prefix(window_key, session_map_prefix())
     if window_id is None:
         return []
+    wanted = canonical_window_id(window_id)
     targets = [
-        (user_id, thread_id, window_id, chat_id)
+        (user_id, thread_id, bound_wid, chat_id)
         for user_id, chat_id, thread_id, bound_wid in (
             thread_router.iter_thread_bindings_with_chat()
         )
-        if bound_wid == window_id
+        if canonical_window_id(bound_wid) == wanted
     ]
     if targets:
         return targets
     # Keep compatibility with lightweight routers used by integrations.
     return [
-        (user_id, thread_id, window_id, None)
+        (user_id, thread_id, bound_wid, None)
         for user_id, thread_id, bound_wid in thread_router.iter_thread_bindings()
-        if bound_wid == window_id
+        if canonical_window_id(bound_wid) == wanted
     ]
 
 

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -408,11 +408,19 @@ async def create_topic_in_chat(
             retry_after_seconds,
         )
         return False
-    except TelegramError:
+    except TimedOut, NetworkError:
         clear_pending_creation(window_id)
         _topic_create_retry_until[chat_id] = (
             time.monotonic() + _TOPIC_CREATE_FAILURE_BACKOFF_S
         )
+        logger.exception(
+            "Failed to create topic for window %s in chat %d",
+            window_id,
+            chat_id,
+        )
+        return False
+    except TelegramError:
+        clear_pending_creation(window_id)
         logger.exception(
             "Failed to create topic for window %s in chat %d",
             window_id,

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -19,7 +19,7 @@ import time
 from pathlib import Path
 
 import structlog
-from telegram.error import NetworkError, RetryAfter, TelegramError, TimedOut
+from telegram.error import BadRequest, NetworkError, RetryAfter, TelegramError, TimedOut
 
 from ... import window_query
 from ...config import config
@@ -408,19 +408,12 @@ async def create_topic_in_chat(
             retry_after_seconds,
         )
         return False
-    except TimedOut, NetworkError:
+    except TelegramError as exc:
         clear_pending_creation(window_id)
-        _topic_create_retry_until[chat_id] = (
-            time.monotonic() + _TOPIC_CREATE_FAILURE_BACKOFF_S
-        )
-        logger.exception(
-            "Failed to create topic for window %s in chat %d",
-            window_id,
-            chat_id,
-        )
-        return False
-    except TelegramError:
-        clear_pending_creation(window_id)
+        if isinstance(exc, NetworkError) and not isinstance(exc, BadRequest):
+            _topic_create_retry_until[chat_id] = (
+                time.monotonic() + _TOPIC_CREATE_FAILURE_BACKOFF_S
+            )
         logger.exception(
             "Failed to create topic for window %s in chat %d",
             window_id,

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -49,6 +49,7 @@ _TOPIC_CREATE_RETRY_BUFFER_SECONDS = 1
 # longer outages are caught by the existing flood-control backoff.
 _TOPIC_CREATE_TRANSIENT_RETRIES = 1
 _TOPIC_CREATE_TRANSIENT_BACKOFF_S = 1.0
+_TOPIC_CREATE_FAILURE_BACKOFF_S = 30.0
 
 
 # Serializes every auto-create/rebind attempt for one window. Session-monitor,
@@ -409,6 +410,9 @@ async def create_topic_in_chat(
         return False
     except TelegramError:
         clear_pending_creation(window_id)
+        _topic_create_retry_until[chat_id] = (
+            time.monotonic() + _TOPIC_CREATE_FAILURE_BACKOFF_S
+        )
         logger.exception(
             "Failed to create topic for window %s in chat %d",
             window_id,

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -33,6 +33,7 @@ from ...session_monitor import NewWindowEvent
 from ...telegram_client import TelegramClient
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
+from ...multiplexer.base import canonical_window_id
 from ..status.topic_emoji import strip_emoji_prefix
 from .topic_probe import probe_topic_exists
 
@@ -520,7 +521,7 @@ async def handle_new_window(
     target_chat_id: int | None = None,
 ) -> bool:
     """Ensure a new window has a topic, returning whether it is bound."""
-    async with _window_topic_lock(event.window_id):
+    async with _window_topic_lock(canonical_window_id(event.window_id)):
         return await _handle_new_window_locked(
             event,
             client,

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -408,6 +408,7 @@ async def create_topic_in_chat(
         )
         return False
     except TelegramError:
+        clear_pending_creation(window_id)
         logger.exception(
             "Failed to create topic for window %s in chat %d",
             window_id,

--- a/src/ccgram/handlers/topics/topic_orchestration.py
+++ b/src/ccgram/handlers/topics/topic_orchestration.py
@@ -166,21 +166,23 @@ def register_pending_creation(window_id: str) -> None:
     """
     if not window_id:
         return
-    _pending_user_creations[window_id] = time.monotonic() + _PENDING_CREATION_TTL_S
+    key = canonical_window_id(window_id)
+    _pending_user_creations[key] = time.monotonic() + _PENDING_CREATION_TTL_S
 
 
 def clear_pending_creation(window_id: str) -> None:
     """Remove a window's pending-creation marker (idempotent)."""
-    _pending_user_creations.pop(window_id, None)
+    _pending_user_creations.pop(canonical_window_id(window_id), None)
 
 
 def _is_registered_pending_creation(window_id: str) -> bool:
     """Return whether a concrete window target is owned by a creation flow."""
-    expires_at = _pending_user_creations.get(window_id)
+    key = canonical_window_id(window_id)
+    expires_at = _pending_user_creations.get(key)
     if expires_at is None:
         return False
     if time.monotonic() >= expires_at:
-        _pending_user_creations.pop(window_id, None)
+        _pending_user_creations.pop(key, None)
         return False
     return True
 

--- a/src/ccgram/handlers/topics/window_launch_service.py
+++ b/src/ccgram/handlers/topics/window_launch_service.py
@@ -23,6 +23,7 @@ from ...session import session_manager
 from ...session_map import session_map_sync
 from ...thread_router import thread_router
 from ...multiplexer import multiplexer as tmux_manager
+from ...multiplexer.base import canonical_window_id
 from ..telegram_origin import send_telegram_to_window
 from ...user_preferences import user_preferences
 from ... import window_query
@@ -249,6 +250,8 @@ def _follow_supersession(window_id: str) -> str:
     current = window_query.resolve_window_alias(window_id)
     if current == window_id:
         return window_id
+    if canonical_window_id(current) == canonical_window_id(window_id):
+        return current
     topic_orchestration.register_pending_creation(current)
     topic_orchestration.clear_pending_creation(window_id)
     logger.info("Creation target superseded: %s -> %s", window_id, current)

--- a/src/ccgram/session_lifecycle.py
+++ b/src/ccgram/session_lifecycle.py
@@ -32,6 +32,15 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger()
 
+_SESSION_MAP_PREFIXES = frozenset({"agterm", "ccgram", "herdr", "tmux"})
+
+
+def _canonical_session_map_window_id(window_id: str) -> str:
+    prefix, separator, target = window_id.partition(":")
+    if separator and prefix in _SESSION_MAP_PREFIXES:
+        window_id = target
+    return canonical_window_id(window_id)
+
 
 def _same_transcript_path(
     old_details: dict[str, Any],
@@ -64,9 +73,9 @@ class SessionLifecycle:
 
     def resolve_session_id(self, window_id: str) -> str | None:
         """Return the session_id for window_id from the last known session_map."""
-        wanted = canonical_window_id(window_id)
+        wanted = _canonical_session_map_window_id(window_id)
         for wid, details in self._last_session_map.items():
-            if canonical_window_id(wid) == wanted:
+            if _canonical_session_map_window_id(wid) == wanted:
                 return details.get("session_id")
         return None
 
@@ -82,10 +91,10 @@ class SessionLifecycle:
         clean up its own per-session state dicts.
         """
         old_by_canonical = {
-            canonical_window_id(wid): wid for wid in self._last_session_map
+            _canonical_session_map_window_id(wid): wid for wid in self._last_session_map
         }
         converged_map = {
-            old_by_canonical.get(canonical_window_id(wid), wid): details
+            old_by_canonical.get(_canonical_session_map_window_id(wid), wid): details
             for wid, details in current_map.items()
         }
         result = ReconcileResult(current_map=converged_map)

--- a/src/ccgram/session_lifecycle.py
+++ b/src/ccgram/session_lifecycle.py
@@ -66,8 +66,7 @@ class SessionLifecycle:
         """Return the session_id for window_id from the last known session_map."""
         wanted = canonical_window_id(window_id)
         for wid, details in self._last_session_map.items():
-            candidate = wid.rsplit(":", 1)[-1]
-            if canonical_window_id(candidate) == wanted:
+            if canonical_window_id(wid) == wanted:
                 return details.get("session_id")
         return None
 
@@ -83,13 +82,10 @@ class SessionLifecycle:
         clean up its own per-session state dicts.
         """
         old_by_canonical = {
-            canonical_window_id(wid.rsplit(":", 1)[-1]): wid
-            for wid in self._last_session_map
+            canonical_window_id(wid): wid for wid in self._last_session_map
         }
         converged_map = {
-            old_by_canonical.get(
-                canonical_window_id(wid.rsplit(":", 1)[-1]), wid
-            ): details
+            old_by_canonical.get(canonical_window_id(wid), wid): details
             for wid, details in current_map.items()
         }
         result = ReconcileResult(current_map=converged_map)

--- a/src/ccgram/session_lifecycle.py
+++ b/src/ccgram/session_lifecycle.py
@@ -24,6 +24,7 @@ from .claude_task_state import (
     claude_task_state,
     remove_subagent,
 )
+from .multiplexer.base import canonical_window_id
 from .window_state_store import window_store
 
 if TYPE_CHECKING:
@@ -63,8 +64,10 @@ class SessionLifecycle:
 
     def resolve_session_id(self, window_id: str) -> str | None:
         """Return the session_id for window_id from the last known session_map."""
+        wanted = canonical_window_id(window_id)
         for wid, details in self._last_session_map.items():
-            if wid.endswith(f":{window_id}") or wid == window_id:
+            candidate = wid.rsplit(":", 1)[-1]
+            if canonical_window_id(candidate) == wanted:
                 return details.get("session_id")
         return None
 
@@ -79,14 +82,24 @@ class SessionLifecycle:
         Returns sessions to remove and new windows so the coordinator can
         clean up its own per-session state dicts.
         """
-        result = ReconcileResult(current_map=current_map)
+        old_by_canonical = {
+            canonical_window_id(wid.rsplit(":", 1)[-1]): wid
+            for wid in self._last_session_map
+        }
+        converged_map = {
+            old_by_canonical.get(
+                canonical_window_id(wid.rsplit(":", 1)[-1]), wid
+            ): details
+            for wid, details in current_map.items()
+        }
+        result = ReconcileResult(current_map=converged_map)
 
         old_windows = set(self._last_session_map.keys())
-        current_windows = set(current_map.keys())
+        current_windows = set(converged_map.keys())
 
         # Session changed: window in both maps but session_id differs
         for window_id, old_details in self._last_session_map.items():
-            new_details = current_map.get(window_id)
+            new_details = converged_map.get(window_id)
             if new_details and new_details["session_id"] != old_details["session_id"]:
                 if _same_transcript_path(old_details, new_details):
                     logger.debug(
@@ -121,9 +134,9 @@ class SessionLifecycle:
 
         # New windows
         for window_id in current_windows - old_windows:
-            result.new_windows[window_id] = current_map[window_id]
+            result.new_windows[window_id] = converged_map[window_id]
 
-        self._last_session_map = current_map
+        self._last_session_map = converged_map
         return result
 
     def handle_subagent_start(self, window_id: str, subagent_id: str, name: str) -> int:

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -159,6 +159,7 @@ def _resolve_existing_window_id(window_id: str) -> str:
     """Reuse the persisted spelling for a case-insensitive window identity."""
     # Lazy: session_map and thread_router/store are mutually wired at startup.
     from .thread_router import thread_router
+
     # Lazy: window_state_store is wired by SessionManager construction.
     from .window_state_store import is_window_store_wired, window_store
 

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -412,15 +412,19 @@ def _remove_dead_session_map_entries(
     # longer exists" while the directory was sitting there (#176). The dead
     # entry still goes; the state a live topic still points at stays until the
     # topic unbinds and ``_remove_stale_window_states`` reclaims it.
-    bound_wids = thread_router.all_bound_window_ids()
+    bound_lookup = {
+        canonical_window_id(wid) for wid in thread_router.all_bound_window_ids() if wid
+    }
     changed_state = False
     for key, window_id in dead_entries:
         logger.info("Pruning dead session_map entry: %s (window %s)", key, window_id)
         del raw[key]
         log_throttle_reset(f"preserve-primary:{window_id}")
-        if window_id not in bound_wids and window_store.has_window(window_id):
-            window_store.remove_window(window_id)
-            changed_state = True
+        if canonical_window_id(window_id) not in bound_lookup:
+            state_window_id = _resolve_existing_window_id(window_id)
+            if window_store.has_window(state_window_id):
+                window_store.remove_window(state_window_id)
+                changed_state = True
     return changed_state
 
 

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -618,7 +618,6 @@ class SessionMapSync:
         while loop.time() < deadline:
             if resolve_window_id is not None:
                 current_id = resolve_window_id(window_id)
-            key = f"{session_map_prefix()}{current_id}"
             try:
                 if config.session_map_file.exists():
                     async with aiofiles.open(config.session_map_file, "r") as f:
@@ -626,7 +625,8 @@ class SessionMapSync:
                     session_map = json.loads(content)
                     if not isinstance(session_map, dict):
                         raise ValueError("session_map root is not an object")
-                    info = session_map.get(key)
+                    key = _find_session_map_key(session_map, current_id)
+                    info = session_map.get(key) if key is not None else None
                     if isinstance(info, dict):
                         parse_session_map_entry(info)
                         logger.debug(

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -157,7 +157,9 @@ def is_backend_window_id(window_id: str) -> bool:
 
 def _resolve_existing_window_id(window_id: str) -> str:
     """Reuse the persisted spelling for a case-insensitive window identity."""
+    # Lazy: session_map and thread_router/store are mutually wired at startup.
     from .thread_router import thread_router
+    # Lazy: window_state_store is wired by SessionManager construction.
     from .window_state_store import is_window_store_wired, window_store
 
     try:

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -27,7 +27,7 @@ import os
 import shutil
 import time
 import structlog
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, cast
 
@@ -186,6 +186,19 @@ def _resolve_existing_window_id(window_id: str) -> str:
         )
     except RuntimeError:
         return window_id
+
+
+def _find_session_map_key(raw: Mapping[str, object], window_id: str) -> str | None:
+    prefix = session_map_prefix()
+    expected = f"{prefix}{window_id}"
+    if expected in raw:
+        return expected
+    wanted = canonical_window_id(window_id)
+    for key in raw:
+        candidate = strip_session_map_prefix(key, prefix)
+        if candidate is not None and canonical_window_id(candidate) == wanted:
+            return key
+    return None
 
 
 def _transcript_mtime(transcript_path: str) -> float | None:
@@ -875,9 +888,10 @@ class SessionMapSync:
         raw = await read_session_map_raw()
         if raw is None:
             return True
-        info = raw.get(f"{session_map_prefix()}{window_id}")
-        if info is None:
+        key = _find_session_map_key(raw, window_id)
+        if key is None:
             return False
+        info = raw[key]
         try:
             # The premise is that the monitor will rebuild state from this
             # entry, which only holds for entries load_session_map accepts. One
@@ -931,7 +945,9 @@ class SessionMapSync:
                     raw = json.loads(config.session_map_file.read_text())
                     if not isinstance(raw, dict):
                         return
-                    key = f"{session_map_prefix()}{window_id}"
+                    key = _find_session_map_key(raw, window_id)
+                    if key is None:
+                        return
                     info = raw.get(key)
                     if isinstance(
                         info, dict

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -163,21 +163,29 @@ def _resolve_existing_window_id(window_id: str) -> str:
     # Lazy: window_state_store is wired by SessionManager construction.
     from .window_state_store import is_window_store_wired, window_store
 
-    try:
-        candidates = [
-            wid
-            for _, _, wid in thread_router.iter_thread_bindings()
-            if wid and canonical_window_id(wid) == canonical_window_id(window_id)
-        ]
-    except RuntimeError:
-        candidates = []
+    key = canonical_window_id(window_id)
     if is_window_store_wired():
-        candidates.extend(
-            wid
-            for wid in window_store.iter_window_ids()
-            if canonical_window_id(wid) == canonical_window_id(window_id)
+        state_id = next(
+            (
+                wid
+                for wid in window_store.iter_window_ids()
+                if canonical_window_id(wid) == key
+            ),
+            None,
         )
-    return candidates[0] if candidates else window_id
+        if state_id is not None:
+            return state_id
+    try:
+        return next(
+            (
+                wid
+                for _, _, wid in thread_router.iter_thread_bindings()
+                if wid and canonical_window_id(wid) == key
+            ),
+            window_id,
+        )
+    except RuntimeError:
+        return window_id
 
 
 def _transcript_mtime(transcript_path: str) -> float | None:

--- a/src/ccgram/session_map.py
+++ b/src/ccgram/session_map.py
@@ -33,11 +33,11 @@ from typing import Any, cast
 
 import aiofiles
 
-from .multiplexer.base import canonical_window_id
 from .config import config
 from .herdr_targets import is_herdr_session_target
 from .hooks.state_files import StateFileValidationError, parse_session_map_entry
 from .utils import atomic_write_json, log_throttle_reset, log_throttled
+from .multiplexer.base import canonical_window_id
 from .window_resolver import is_window_id, session_map_prefix_for
 
 logger = structlog.get_logger()
@@ -153,6 +153,28 @@ def is_backend_window_id(window_id: str) -> bool:
     if config.multiplexer_name == "herdr":
         return is_herdr_session_target(window_id)
     return bool(window_id)
+
+
+def _resolve_existing_window_id(window_id: str) -> str:
+    """Reuse the persisted spelling for a case-insensitive window identity."""
+    from .thread_router import thread_router
+    from .window_state_store import is_window_store_wired, window_store
+
+    try:
+        candidates = [
+            wid
+            for _, _, wid in thread_router.iter_thread_bindings()
+            if wid and canonical_window_id(wid) == canonical_window_id(window_id)
+        ]
+    except RuntimeError:
+        candidates = []
+    if is_window_store_wired():
+        candidates.extend(
+            wid
+            for wid in window_store.iter_window_ids()
+            if canonical_window_id(wid) == canonical_window_id(window_id)
+        )
+    return candidates[0] if candidates else window_id
 
 
 def _transcript_mtime(transcript_path: str) -> float | None:
@@ -280,9 +302,10 @@ def parse_session_map(raw: dict[str, Any], prefix: str) -> dict[str, dict[str, A
         except StateFileValidationError as exc:
             logger.debug("Skipping invalid session_map entry %s: %s", key, exc)
             continue
-        effective = effective_session_map_info(window_name, info)
+        resolved_name = _resolve_existing_window_id(window_name)
+        effective = effective_session_map_info(resolved_name, info)
         if effective["session_id"]:
-            result[window_name] = effective
+            result[resolved_name] = effective
     return result
 
 
@@ -455,6 +478,7 @@ class SessionMapSync:
             # whether the entry passes schema validation.  Validation failures
             # are forward-compat / corruption guards; they must not delete
             # in-memory state for a window that is present in the file.
+            window_id = _resolve_existing_window_id(window_id)
             valid_wids.add(window_id)
             try:
                 # Validation gate — see the identical pattern in parse_session_map()
@@ -492,13 +516,15 @@ class SessionMapSync:
         # leaves this guard dead — sweeping the state of every bound window
         # whose provider has no hook to keep it in the session map.
         bound_wids = {wid for wid in thread_router.all_bound_window_ids() if wid}
+        valid_lookup = {canonical_window_id(wid) for wid in valid_wids}
+        bound_lookup = {canonical_window_id(wid) for wid in bound_wids}
         stale_wids = [
             w
             for w in window_store.iter_window_ids()
             if (
                 w
-                and w not in valid_wids
-                and w not in bound_wids
+                and canonical_window_id(w) not in valid_lookup
+                and canonical_window_id(w) not in bound_lookup
                 and window_store.get_session_id_for_window(w) not in old_format_sids
                 and not window_store.is_archived_legacy_herdr(w)
                 # A window being created is neither in the session map (its

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -743,11 +743,15 @@ class SessionMonitor:
         from .thread_router import thread_router
 
         caps = tmux_manager.capabilities
-        bound_window_ids = {wid for _, _, wid in thread_router.iter_thread_bindings()}
+        known_lookup = _adoption_lookup(known_window_ids)
+        bound_lookup = _adoption_lookup(
+            {wid for _, _, wid in thread_router.iter_thread_bindings()}
+        )
         for window in all_windows:
-            if window.window_id in known_window_ids:
+            window_key = canonical_window_id(window.window_id)
+            if window_key in known_lookup:
                 continue
-            if window.window_id in bound_window_ids:
+            if window_key in bound_lookup:
                 continue
             if not is_agent_topic_window(window, caps):
                 continue

--- a/src/ccgram/session_monitor.py
+++ b/src/ccgram/session_monitor.py
@@ -792,11 +792,12 @@ class SessionMonitor:
         from .thread_router import thread_router
 
         bound_window_ids = {wid for _, _, wid in thread_router.iter_thread_bindings()}
+        bound_lookup = _adoption_lookup(bound_window_ids)
         adoptable_lookup = _adoption_lookup(adoptable_window_ids)
         for window_id, details in current_map.items():
             if canonical_window_id(window_id) not in adoptable_lookup:
                 continue  # dead, or the backend says it may not be adopted
-            if window_id in bound_window_ids:
+            if canonical_window_id(window_id) in bound_lookup:
                 continue  # already has a topic
             event = NewWindowEvent(
                 window_id=window_id,
@@ -919,7 +920,9 @@ class SessionMonitor:
 
                 monitored_map = current_map
                 if all_windows is not None:
-                    live_window_ids = {w.window_id for w in all_windows}
+                    live_window_ids = {
+                        canonical_window_id(w.window_id) for w in all_windows
+                    }
                     session_map_sync.prune_session_map(live_window_ids)
                     # Pruning needs every live window; adoption needs only the
                     # ones the backend says may be adopted. The listing is
@@ -934,7 +937,7 @@ class SessionMonitor:
                     monitored_map = {
                         window_id: details
                         for window_id, details in current_map.items()
-                        if window_id in live_window_ids
+                        if canonical_window_id(window_id) in live_window_ids
                     }
 
                 # A persisted barrier must be noticed before its source is read

--- a/src/ccgram/thread_router.py
+++ b/src/ccgram/thread_router.py
@@ -30,6 +30,8 @@ import structlog
 from collections.abc import Callable, Iterator
 from typing import Any, cast
 
+from .multiplexer.base import canonical_window_id
+
 logger = structlog.get_logger()
 
 _RETIRED_TOPIC_LIMIT = 100
@@ -599,18 +601,22 @@ class ThreadRouter:
 
     def has_window(self, window_id: str) -> bool:
         """Check if any user has a binding to this window_id."""
-        return (
-            any(wid == window_id for (_, wid) in self._window_to_thread)
-            or window_id in self.chat_thread_bindings.values()
+        wanted = canonical_window_id(window_id)
+        return any(
+            canonical_window_id(wid) == wanted for (_, wid) in self._window_to_thread
+        ) or any(
+            canonical_window_id(wid) == wanted
+            for wid in self.chat_thread_bindings.values()
         )
 
     def has_window_for_user(self, user_id: int, window_id: str) -> bool:
-        return (
-            any(
-                uid == user_id and wid == window_id
-                for (uid, _chat, _thread), wid in self.chat_thread_bindings.items()
-            )
-            or self._window_to_thread.get((user_id, window_id)) is not None
+        wanted = canonical_window_id(window_id)
+        return any(
+            uid == user_id and canonical_window_id(wid) == wanted
+            for (uid, _chat, _thread), wid in self.chat_thread_bindings.items()
+        ) or any(
+            uid == user_id and canonical_window_id(wid) == wanted
+            for (uid, wid) in self._window_to_thread
         )
 
     def iter_thread_bindings_with_chat(

--- a/tests/ccgram/handlers/test_hook_events.py
+++ b/tests/ccgram/handlers/test_hook_events.py
@@ -81,9 +81,7 @@ class TestResolveUsersForWindowKey:
         monkeypatch.setattr(config, "multiplexer_name", "agterm")
         bindings((111, 42, "abc-def"))
 
-        assert _resolve_users_for_window_key("agterm:ABC-DEF") == [
-            (111, 42, "abc-def")
-        ]
+        assert _resolve_users_for_window_key("agterm:ABC-DEF") == [(111, 42, "abc-def")]
 
     @pytest.mark.parametrize(
         "window_key",

--- a/tests/ccgram/handlers/test_hook_events.py
+++ b/tests/ccgram/handlers/test_hook_events.py
@@ -75,6 +75,16 @@ class TestResolveUsersForWindowKey:
             (111, 42, "opaque:target:id")
         ]
 
+    def test_case_variant_window_key_routes_to_bound_spelling(
+        self, bindings, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(config, "multiplexer_name", "agterm")
+        bindings((111, 42, "abc-def"))
+
+        assert _resolve_users_for_window_key("agterm:ABC-DEF") == [
+            (111, 42, "abc-def")
+        ]
+
     @pytest.mark.parametrize(
         "window_key",
         [

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -709,6 +709,7 @@ class TestCreateForumTopicTransientRetry:
         # Original attempt + 1 retry = 2 calls
         assert bot.create_forum_topic.call_count == 2
         assert not _is_pending_user_creation(event.window_id)
+        assert -100500 in _topic_create_retry_until
 
 
 class TestAdoptUnboundWindows:

--- a/tests/ccgram/handlers/topics/test_topic_orchestration.py
+++ b/tests/ccgram/handlers/topics/test_topic_orchestration.py
@@ -10,6 +10,7 @@ from telegram.error import BadRequest, RetryAfter, TelegramError, TimedOut
 from ccgram.multiplexer.base import WindowRef
 from ccgram.handlers.topics.topic_orchestration import (
     collect_target_chats,
+    _is_pending_user_creation,
     _is_window_already_bound,
     _topic_create_retry_until,
     _pending_user_creations,
@@ -707,6 +708,7 @@ class TestCreateForumTopicTransientRetry:
 
         # Original attempt + 1 retry = 2 calls
         assert bot.create_forum_topic.call_count == 2
+        assert not _is_pending_user_creation(event.window_id)
 
 
 class TestAdoptUnboundWindows:

--- a/tests/ccgram/handlers/topics/test_window_launch_service.py
+++ b/tests/ccgram/handlers/topics/test_window_launch_service.py
@@ -121,6 +121,17 @@ class TestFollowSupersession:
         mock_orch.register_pending_creation.assert_not_called()
         mock_orch.clear_pending_creation.assert_not_called()
 
+    def test_case_only_supersession_keeps_the_existing_guard(self) -> None:
+        with (
+            patch(f"{_MODULE}window_query") as mock_wq,
+            patch(f"{_MODULE}topic_orchestration") as mock_orch,
+        ):
+            mock_wq.resolve_window_alias.return_value = "ABC-DEF"
+            assert _follow_supersession("abc-def") == "ABC-DEF"
+
+        mock_orch.register_pending_creation.assert_not_called()
+        mock_orch.clear_pending_creation.assert_not_called()
+
     def test_superseded_id_carries_the_creation_guard_forward(self) -> None:
         """Herdr re-keys a target mid-creation; the guard must move with it."""
         with (

--- a/tests/ccgram/test_session_lifecycle.py
+++ b/tests/ccgram/test_session_lifecycle.py
@@ -4,6 +4,36 @@ from ccgram.idle_tracker import IdleTracker
 from ccgram.session_lifecycle import SessionLifecycle
 
 
+def test_case_only_session_map_change_is_not_delete_and_create() -> None:
+    lifecycle = SessionLifecycle()
+    lifecycle.initialize(
+        {
+            "abc-def": {
+                "session_id": "sess-1",
+                "cwd": "/repo",
+                "window_name": "before",
+                "transcript_path": "/tmp/transcript.jsonl",
+            }
+        }
+    )
+
+    result = lifecycle.reconcile(
+        {
+            "ABC-DEF": {
+                "session_id": "sess-1",
+                "cwd": "/repo",
+                "window_name": "after",
+                "transcript_path": "/tmp/transcript.jsonl",
+            }
+        },
+        IdleTracker(),
+    )
+
+    assert result.sessions_to_remove == set()
+    assert result.new_windows == {}
+    assert set(result.current_map) == {"abc-def"}
+
+
 def test_same_transcript_session_refresh_preserves_monitor_state() -> None:
     lifecycle = SessionLifecycle()
     lifecycle.initialize(

--- a/tests/ccgram/test_session_map.py
+++ b/tests/ccgram/test_session_map.py
@@ -33,3 +33,21 @@ def test_existing_state_spelling_precedes_case_variant_binding() -> None:
     finally:
         session_manager.window_states.pop("abc-def", None)
         thread_router.unbind_thread(100, 7)
+
+
+async def test_session_map_read_and_clear_match_case_variant_key(
+    tmp_path, monkeypatch
+) -> None:
+    import json
+
+    from ccgram.session_map import SessionMapSync, config
+
+    path = tmp_path / "session-map.json"
+    path.write_text(json.dumps({"agterm:ABC-DEF": {"session_id": "new-session"}}))
+    monkeypatch.setattr(config, "session_map_file", path)
+    monkeypatch.setattr(config, "multiplexer_name", "agterm")
+    sync = SessionMapSync(schedule_save=lambda: None)
+
+    assert await sync.session_map_entry_may_exist("abc-def")
+    sync.clear_session_map_entry("abc-def")
+    assert json.loads(path.read_text()) == {}

--- a/tests/ccgram/test_session_map.py
+++ b/tests/ccgram/test_session_map.py
@@ -16,3 +16,20 @@ def test_pruning_keeps_a_case_variant_live_entry() -> None:
             raw = {"agterm:9f1c2d3e-4a5b": {"session_id": "s1"}}
             assert _dead_session_map_entries(raw, {"9F1C2D3E-4A5B"}) == []
             assert _dead_session_map_entries(raw, set()) != []
+
+
+def test_existing_state_spelling_precedes_case_variant_binding() -> None:
+    from ccgram.session import session_manager
+    from ccgram.session_map import _resolve_existing_window_id
+    from ccgram.thread_router import thread_router
+    from ccgram.window_state_store import WindowState
+
+    session_manager.window_states["abc-def"] = WindowState(
+        session_id="old", cwd="/repo", approval_mode="yolo"
+    )
+    thread_router.bind_thread(100, 7, "ABC-DEF")
+    try:
+        assert _resolve_existing_window_id("ABC-DEF") == "abc-def"
+    finally:
+        session_manager.window_states.pop("abc-def", None)
+        thread_router.unbind_thread(100, 7)

--- a/tests/ccgram/test_session_map.py
+++ b/tests/ccgram/test_session_map.py
@@ -35,6 +35,30 @@ def test_existing_state_spelling_precedes_case_variant_binding() -> None:
         thread_router.unbind_thread(100, 7)
 
 
+def test_dead_entry_does_not_remove_state_for_case_variant_binding() -> None:
+    from types import SimpleNamespace
+    from unittest.mock import Mock, patch
+
+    from ccgram.session_map import _remove_dead_session_map_entries
+
+    remove_window = Mock()
+    store = SimpleNamespace(
+        has_window=lambda _window_id: True, remove_window=remove_window
+    )
+    with (
+        patch(
+            "ccgram.thread_router.thread_router.all_bound_window_ids",
+            return_value={"ABC-DEF"},
+        ),
+        patch("ccgram.session_map.log_throttle_reset"),
+    ):
+        _remove_dead_session_map_entries(
+            {"agterm:abc-def": {}}, [("agterm:abc-def", "abc-def")], store
+        )
+
+    assert remove_window.call_count == 0
+
+
 async def test_session_map_read_and_clear_match_case_variant_key(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -862,6 +862,23 @@ class TestEmitUnboundWindowEvents:
         surfaced = {c.args[0].window_id for c in cb.call_args_list}
         assert surfaced == {HERDR_TARGETS["new"]}
 
+    async def test_case_variant_bound_window_is_not_rediscovered(
+        self, monitor: SessionMonitor, wired, monkeypatch
+    ) -> None:
+        thread_router.bind_thread(100, 42, "abc-def")
+        cb = AsyncMock(spec=lambda event: None)
+        monitor.set_new_window_callback(cb)
+        monkeypatch.setattr(
+            "ccgram.session_monitor.tmux_manager",
+            SimpleNamespace(capabilities=_HERDR_CAPS),
+        )
+
+        await monitor._emit_unbound_window_events(
+            [_winref("ABC-DEF", "claude")], known_window_ids=set()
+        )
+
+        cb.assert_not_awaited()
+
 
 class TestEmitKnownUnboundWindowEvents:
     """Steady-state self-heal: session_map windows not bound to a topic retry on each poll."""

--- a/tests/ccgram/test_session_monitor.py
+++ b/tests/ccgram/test_session_monitor.py
@@ -916,6 +916,25 @@ class TestEmitKnownUnboundWindowEvents:
 
         cb.assert_not_called()
 
+    async def test_case_variant_bound_window_not_re_fired(
+        self, monitor: SessionMonitor, wired
+    ) -> None:
+        thread_router.bind_thread(100, 42, "abc-def")
+        cb = AsyncMock(spec=lambda event: None)
+        monitor.set_new_window_callback(cb)
+
+        current_map = {
+            "ABC-DEF": {
+                "session_id": "S1",
+                "cwd": "/repo",
+                "window_name": "agent",
+            }
+        }
+
+        await monitor._emit_known_unbound_window_events(current_map, {"abc-def"})
+
+        cb.assert_not_called()
+
     async def test_dead_window_not_surfaced(
         self, monitor: SessionMonitor, wired
     ) -> None:


### PR DESCRIPTION
Reuse existing state or binding spelling for case-insensitive IDs, canonicalize lifecycle diffs, and route hook events to case-variant bindings. Add lifecycle and hook regressions. Checks: session-map/lifecycle/hook tests, ruff. Closes #225.