### PR TITLE
fix: preserve stable opaque IDs at startup

### DIFF
--- a/src/ccgram/multiplexer/base.py
+++ b/src/ccgram/multiplexer/base.py
@@ -270,6 +270,9 @@ class MultiplexerCapabilities:
     supports_display_name_rebind: bool = True
     """True when a stale topic may be recovered by matching its display name."""
 
+    recovers_stale_ids_by_name: bool = False
+    """True when startup may remap a missing ID by its display name (tmux)."""
+
     supports_workspace_selection: bool = False
     """True when callers can select the workspace for a new target."""
 

--- a/src/ccgram/multiplexer/tmux.py
+++ b/src/ccgram/multiplexer/tmux.py
@@ -98,6 +98,7 @@ _TMUX_CAPABILITIES = MultiplexerCapabilities(
     self_identify_env="TMUX_PANE",
     supports_event_stream=False,
     native_worktrees=False,
+    recovers_stale_ids_by_name=True,
     supports_workspace_selection=False,
     native_topic_targets=False,
 )

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -381,6 +381,7 @@ class SessionManager:
             user_preferences.user_window_offsets,
             thread_router.window_display_names,
             ids_stable=caps.ids_stable_across_restart,
+            window_id_predicate=self._is_window_id,
         )
 
         if changed:

--- a/src/ccgram/session.py
+++ b/src/ccgram/session.py
@@ -382,6 +382,9 @@ class SessionManager:
             thread_router.window_display_names,
             ids_stable=caps.ids_stable_across_restart,
             window_id_predicate=self._is_window_id,
+            recover_stale_ids_by_name=getattr(
+                caps, "recovers_stale_ids_by_name", False
+            ),
         )
 
         if changed:

--- a/src/ccgram/window_resolver.py
+++ b/src/ccgram/window_resolver.py
@@ -474,7 +474,7 @@ def resolve_stale_ids(
     window_display_names: dict,
     *,
     ids_stable: bool = True,
-    window_id_predicate: Callable[[str], bool] = is_window_id,
+    window_id_predicate: Callable[[str], bool],
 ) -> bool:
     """Re-resolve persisted window IDs against live multiplexer windows.
 

--- a/src/ccgram/window_resolver.py
+++ b/src/ccgram/window_resolver.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 
 import structlog
 
+from .multiplexer.base import canonical_window_id
+
 logger = structlog.get_logger()
 
 
@@ -351,15 +353,16 @@ def _resolve_window_states(
     live_by_name: dict[str, str],
     live_ids: set[str],
     window_id_predicate: Callable[[str], bool],
+    recover_stale_ids_by_name: bool,
 ) -> bool:
     """Re-resolve window_states dict in-place. Returns True if changed."""
     changed = False
     new_states: dict = {}
     for key, ws in window_states.items():
         if window_id_predicate(key):
-            if key in live_ids:
+            if canonical_window_id(key) in live_ids:
                 new_states[key] = ws
-            else:
+            elif recover_stale_ids_by_name:
                 display = window_display_names.get(
                     key, getattr(ws, "window_name", "") or key
                 )
@@ -397,6 +400,7 @@ def _resolve_thread_bindings(
     live_by_name: dict[str, str],
     live_ids: set[str],
     window_id_predicate: Callable[[str], bool],
+    recover_stale_ids_by_name: bool,
 ) -> bool:
     """Re-resolve thread_bindings dict in-place. Returns True if changed."""
     changed = False
@@ -404,9 +408,11 @@ def _resolve_thread_bindings(
         new_bindings: dict[int, str] = {}
         for tid, val in bindings.items():
             if window_id_predicate(val):
-                if val in live_ids:
+                if canonical_window_id(val) in live_ids:
                     new_bindings[tid] = val
-                elif new_id := live_by_name.get(display_lookup.get(val, val)):
+                elif recover_stale_ids_by_name and (
+                    new_id := live_by_name.get(display_lookup.get(val, val))
+                ):
                     logger.debug("Re-resolved thread binding %s -> %s", val, new_id)
                     new_bindings[tid] = new_id
                     window_display_names[new_id] = display_lookup.get(val, val)
@@ -442,6 +448,7 @@ def _resolve_offsets(
     live_by_name: dict[str, str],
     live_ids: set[str],
     window_id_predicate: Callable[[str], bool],
+    recover_stale_ids_by_name: bool,
 ) -> bool:
     """Re-resolve user_window_offsets dict in-place. Returns True if changed."""
     changed = False
@@ -449,9 +456,11 @@ def _resolve_offsets(
         new_offsets: dict[str, int] = {}
         for key, offset in offsets.items():
             if window_id_predicate(key):
-                if key in live_ids:
+                if canonical_window_id(key) in live_ids:
                     new_offsets[key] = offset
-                elif new_id := live_by_name.get(display_lookup.get(key, key)):
+                elif recover_stale_ids_by_name and (
+                    new_id := live_by_name.get(display_lookup.get(key, key))
+                ):
                     new_offsets[new_id] = offset
                     changed = True
                 else:
@@ -475,6 +484,7 @@ def resolve_stale_ids(
     *,
     ids_stable: bool = True,
     window_id_predicate: Callable[[str], bool],
+    recover_stale_ids_by_name: bool,
 ) -> bool:
     """Re-resolve persisted window IDs against live multiplexer windows.
 
@@ -483,10 +493,10 @@ def resolve_stale_ids(
     ``ids_stable`` gates the strategy on the backend capability
     ``ids_stable_across_restart`` (never the backend name):
 
-    - True (tmux and agterm): window IDs survive a restart, so re-resolution
-      matches a stale ID's display name against a live window. Handles two cases —
-      old-format migration (window_name keys -> window_id keys) and stale IDs
-      (window_id gone but display name matches a live window).
+    - True (tmux and agterm): window IDs survive a ccgram restart. Old-format
+      window-name keys are migrated. Missing IDs are remapped by display name
+      only when ``recover_stale_ids_by_name`` is true (tmux); stable agterm UUIDs
+      are never redirected to a different same-named session.
     - False: bindings are durable opaque targets. A missing target can be
       temporarily unresolved and multiple live records can be ambiguous, so it
       is intentionally retained without any name, locator, or session-map
@@ -496,7 +506,7 @@ def resolve_stale_ids(
         return False
 
     live_by_name: dict[str, str] = {w.window_name: w.window_id for w in live_windows}
-    live_ids: set[str] = {w.window_id for w in live_windows}
+    live_ids: set[str] = {canonical_window_id(w.window_id) for w in live_windows}
     # Resolve every persisted map against one pre-mutation name snapshot.
     # _resolve_window_states rewrites display names first; using that mutated
     # map for bindings/offsets used to leave them pointing at stale IDs.
@@ -508,6 +518,7 @@ def resolve_stale_ids(
         live_by_name,
         live_ids,
         window_id_predicate,
+        recover_stale_ids_by_name,
     )
     changed |= _resolve_thread_bindings(
         thread_bindings,
@@ -516,6 +527,7 @@ def resolve_stale_ids(
         live_by_name,
         live_ids,
         window_id_predicate,
+        recover_stale_ids_by_name,
     )
     changed |= _resolve_offsets(
         user_window_offsets,
@@ -523,5 +535,6 @@ def resolve_stale_ids(
         live_by_name,
         live_ids,
         window_id_predicate,
+        recover_stale_ids_by_name,
     )
     return changed

--- a/src/ccgram/window_resolver.py
+++ b/src/ccgram/window_resolver.py
@@ -377,6 +377,9 @@ def _resolve_window_states(
                 else:
                     # Keep dead window state — recovery needs cwd/provider
                     new_states[key] = ws
+            else:
+                # Stable IDs never rebind by name, but recovery still needs state.
+                new_states[key] = ws
         else:
             new_id = live_by_name.get(key)
             if new_id:

--- a/src/ccgram/window_resolver.py
+++ b/src/ccgram/window_resolver.py
@@ -10,6 +10,7 @@ handler modules (no intra-package imports — safe from circular dependencies):
     that identifies the same window now.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import structlog
@@ -349,12 +350,13 @@ def _resolve_window_states(
     window_display_names: dict,
     live_by_name: dict[str, str],
     live_ids: set[str],
+    window_id_predicate: Callable[[str], bool],
 ) -> bool:
     """Re-resolve window_states dict in-place. Returns True if changed."""
     changed = False
     new_states: dict = {}
     for key, ws in window_states.items():
-        if is_window_id(key):
+        if window_id_predicate(key):
             if key in live_ids:
                 new_states[key] = ws
             else:
@@ -394,13 +396,14 @@ def _resolve_thread_bindings(
     display_lookup: dict,
     live_by_name: dict[str, str],
     live_ids: set[str],
+    window_id_predicate: Callable[[str], bool],
 ) -> bool:
     """Re-resolve thread_bindings dict in-place. Returns True if changed."""
     changed = False
     for uid, bindings in thread_bindings.items():
         new_bindings: dict[int, str] = {}
         for tid, val in bindings.items():
-            if is_window_id(val):
+            if window_id_predicate(val):
                 if val in live_ids:
                     new_bindings[tid] = val
                 elif new_id := live_by_name.get(display_lookup.get(val, val)):
@@ -438,13 +441,14 @@ def _resolve_offsets(
     display_lookup: dict,
     live_by_name: dict[str, str],
     live_ids: set[str],
+    window_id_predicate: Callable[[str], bool],
 ) -> bool:
     """Re-resolve user_window_offsets dict in-place. Returns True if changed."""
     changed = False
     for _uid, offsets in user_window_offsets.items():
         new_offsets: dict[str, int] = {}
         for key, offset in offsets.items():
-            if is_window_id(key):
+            if window_id_predicate(key):
                 if key in live_ids:
                     new_offsets[key] = offset
                 elif new_id := live_by_name.get(display_lookup.get(key, key)):
@@ -470,6 +474,7 @@ def resolve_stale_ids(
     window_display_names: dict,
     *,
     ids_stable: bool = True,
+    window_id_predicate: Callable[[str], bool] = is_window_id,
 ) -> bool:
     """Re-resolve persisted window IDs against live multiplexer windows.
 
@@ -478,8 +483,8 @@ def resolve_stale_ids(
     ``ids_stable`` gates the strategy on the backend capability
     ``ids_stable_across_restart`` (never the backend name):
 
-    - True (tmux): window IDs survive a restart, so re-resolution matches a
-      stale ID's display name against a live window. Handles two cases —
+    - True (tmux and agterm): window IDs survive a restart, so re-resolution
+      matches a stale ID's display name against a live window. Handles two cases —
       old-format migration (window_name keys -> window_id keys) and stale IDs
       (window_id gone but display name matches a live window).
     - False: bindings are durable opaque targets. A missing target can be
@@ -498,7 +503,11 @@ def resolve_stale_ids(
     display_lookup = dict(window_display_names)
 
     changed = _resolve_window_states(
-        window_states, window_display_names, live_by_name, live_ids
+        window_states,
+        window_display_names,
+        live_by_name,
+        live_ids,
+        window_id_predicate,
     )
     changed |= _resolve_thread_bindings(
         thread_bindings,
@@ -506,8 +515,13 @@ def resolve_stale_ids(
         display_lookup,
         live_by_name,
         live_ids,
+        window_id_predicate,
     )
     changed |= _resolve_offsets(
-        user_window_offsets, display_lookup, live_by_name, live_ids
+        user_window_offsets,
+        display_lookup,
+        live_by_name,
+        live_ids,
+        window_id_predicate,
     )
     return changed

--- a/tests/ccgram/test_multiplexer_tmux.py
+++ b/tests/ccgram/test_multiplexer_tmux.py
@@ -48,6 +48,7 @@ def test_capabilities_full_snapshot(mgr: TmuxManager) -> None:
         "supports_event_stream": False,
         "native_worktrees": False,
         "supports_display_name_rebind": True,
+        "recovers_stale_ids_by_name": True,
         "supports_workspace_selection": False,
         "native_topic_targets": False,
     }

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -1671,8 +1671,9 @@ class TestResolveStaleIdsHerdrRestart:
 
         await mgr.resolve_stale_ids()
 
+        assert old_id in mgr.window_states
         assert new_id not in mgr.window_states
-        assert thread_router.get_window_for_thread(100, 7) != new_id
+        assert thread_router.get_window_for_thread(100, 7) == old_id
 
     async def test_agterm_live_uuid_comparison_is_case_insensitive(
         self, mgr: SessionManager, monkeypatch

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -1652,6 +1652,52 @@ class TestResolveStaleIdsHerdrRestart:
         assert thread_router.get_window_for_thread(100, 7) == window_id
         assert user_preferences.user_window_offsets[100][window_id] == 42
 
+    async def test_agterm_missing_uuid_does_not_rebind_by_display_name(
+        self, mgr: SessionManager, monkeypatch
+    ) -> None:
+        old_id = "11111111-1111-1111-1111-111111111111"
+        new_id = "22222222-2222-2222-2222-222222222222"
+        thread_router.bind_thread(100, 7, old_id, window_name="project")
+        mgr.window_states[old_id] = WindowState(session_id="old", cwd="/repo")
+        self.map_file.write_text("{}")
+        monkeypatch.setattr("ccgram.session.config.multiplexer_name", "agterm")
+        monkeypatch.setattr(
+            "ccgram.session.tmux_manager",
+            _FakeMux(
+                ids_stable=True,
+                windows=[SimpleNamespace(window_id=new_id, window_name="project")],
+            ),
+        )
+
+        await mgr.resolve_stale_ids()
+
+        assert new_id not in mgr.window_states
+        assert thread_router.get_window_for_thread(100, 7) != new_id
+
+    async def test_agterm_live_uuid_comparison_is_case_insensitive(
+        self, mgr: SessionManager, monkeypatch
+    ) -> None:
+        stored_id = "abcdef12-3456-7890-abcd-ef1234567890"
+        live_id = stored_id.upper()
+        thread_router.bind_thread(100, 7, stored_id, window_name="project")
+        mgr.window_states[stored_id] = WindowState(session_id="S1", cwd="/repo")
+        user_preferences.user_window_offsets[100] = {stored_id: 42}
+        self.map_file.write_text("{}")
+        monkeypatch.setattr("ccgram.session.config.multiplexer_name", "agterm")
+        monkeypatch.setattr(
+            "ccgram.session.tmux_manager",
+            _FakeMux(
+                ids_stable=True,
+                windows=[SimpleNamespace(window_id=live_id, window_name="project")],
+            ),
+        )
+
+        await mgr.resolve_stale_ids()
+
+        assert stored_id in mgr.window_states
+        assert thread_router.get_window_for_thread(100, 7) == stored_id
+        assert user_preferences.user_window_offsets[100][stored_id] == 42
+
     async def test_tmux_path_is_noop_for_stable_ids(
         self, mgr: SessionManager, monkeypatch
     ) -> None:

--- a/tests/ccgram/test_session.py
+++ b/tests/ccgram/test_session.py
@@ -1631,6 +1631,27 @@ class TestResolveStaleIdsHerdrRestart:
         assert target in mgr.window_states
         assert thread_router.get_window_for_thread(100, 7) == target
 
+    async def test_agterm_stable_uuid_survives_startup_reconciliation(
+        self, mgr: SessionManager, monkeypatch
+    ) -> None:
+        window_id = "9F1C2D3E-4A5B-4C6D-8E7F-0A1B2C3D4E5F"
+        thread_router.bind_thread(100, 7, window_id, window_name="project")
+        mgr.window_states[window_id] = WindowState(session_id="S1", cwd="/repo")
+        user_preferences.user_window_offsets[100] = {window_id: 42}
+        self.map_file.write_text("{}")
+        live = [SimpleNamespace(window_id=window_id, window_name="project")]
+        monkeypatch.setattr("ccgram.session.config.multiplexer_name", "agterm")
+        monkeypatch.setattr(
+            "ccgram.session.tmux_manager",
+            _FakeMux(ids_stable=True, windows=live),
+        )
+
+        await mgr.resolve_stale_ids()
+
+        assert window_id in mgr.window_states
+        assert thread_router.get_window_for_thread(100, 7) == window_id
+        assert user_preferences.user_window_offsets[100][window_id] == 42
+
     async def test_tmux_path_is_noop_for_stable_ids(
         self, mgr: SessionManager, monkeypatch
     ) -> None:

--- a/tests/ccgram/test_window_resolver.py
+++ b/tests/ccgram/test_window_resolver.py
@@ -24,7 +24,12 @@ from ccgram.window_resolver import (
 
 
 def resolve_stale_ids(*args: Any, **kwargs: Any) -> bool:
-    return _resolve_stale_ids(*args, window_id_predicate=is_window_id, **kwargs)
+    return _resolve_stale_ids(
+        *args,
+        window_id_predicate=is_window_id,
+        recover_stale_ids_by_name=True,
+        **kwargs,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ccgram/test_window_resolver.py
+++ b/tests/ccgram/test_window_resolver.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -17,9 +18,13 @@ from ccgram.window_resolver import (
     is_window_id,
     migrate_window_aliases,
     reset_alias_redirects,
-    resolve_stale_ids,
+    resolve_stale_ids as _resolve_stale_ids,
     resolve_window_alias,
 )
+
+
+def resolve_stale_ids(*args: Any, **kwargs: Any) -> bool:
+    return _resolve_stale_ids(*args, window_id_predicate=is_window_id, **kwargs)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Pass the active backend window-ID predicate into startup reconciliation so agterm UUID state, bindings, and offsets survive. Add agterm regression. Checks: resolver/session tests, ruff. Closes #226.