### PR TITLE
fix: migrate Codex hooks feature flag

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -102,7 +102,7 @@ Claude task state is derived from the transcript, not from terminal footer scrap
 
 ## Codex CLI
 
-Codex CLI supports feature-flagged hooks. Install ccgram's lifecycle hooks with `ccgram hook --provider codex --install`; ccgram writes user-level `~/.codex/hooks.json` entries for `SessionStart` and `Stop` and enables `[features].codex_hooks = true` in `~/.codex/config.toml`. Transcript discovery remains as fallback and as the source of message truth.
+Codex CLI supports feature-flagged hooks. Install ccgram's lifecycle hooks with `ccgram hook --provider codex --install`; ccgram writes user-level `~/.codex/hooks.json` entries for `SessionStart` and `Stop` and enables `[features].hooks = true` in `~/.codex/config.toml`. Transcript discovery remains as fallback and as the source of message truth.
 
 ### Interactive Prompts
 

--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -283,21 +283,81 @@ def _install_json_hooks(
     return 0
 
 
-_CODEX_HOOKS_KEY_RE = re.compile(r"^\s*codex_hooks\s*=\s*(\S+)", re.MULTILINE)
+_CODEX_HOOKS_KEY_RE = re.compile(r"^\s*(hooks|codex_hooks)\s*=\s*([^,\s#]+)")
+_TOML_TABLE_HEADER_RE = re.compile(
+    r"^\s*(\[\[[^\]\r\n]+\]\]|\[[^\]\r\n]+\])(?:\s*#.*)?(?:\r?\n)?$"
+)
+
+
+def _find_codex_hook_feature_entries(
+    lines: list[str],
+) -> tuple[int | None, tuple[int, str] | None, list[tuple[int, str]]]:
+    features_header_index: int | None = None
+    current_entry: tuple[int, str] | None = None
+    legacy_entries: list[tuple[int, str]] = []
+    in_top_level_features = False
+
+    for index, line in enumerate(lines):
+        header_match = _TOML_TABLE_HEADER_RE.match(line)
+        if header_match:
+            in_top_level_features = header_match.group(1) == "[features]"
+            if in_top_level_features and features_header_index is None:
+                features_header_index = index
+            continue
+        if not in_top_level_features:
+            continue
+        key_match = _CODEX_HOOKS_KEY_RE.match(line)
+        if not key_match:
+            continue
+        entry = (index, key_match.group(2))
+        if key_match.group(1) == "hooks" and current_entry is None:
+            current_entry = entry
+        elif key_match.group(1) == "codex_hooks":
+            legacy_entries.append(entry)
+
+    return features_header_index, current_entry, legacy_entries
+
+
+def _codex_config_with_hooks(text: str) -> tuple[str, str]:
+    lines = text.splitlines(keepends=True)
+    features_header_index, current_entry, legacy_entries = (
+        _find_codex_hook_feature_entries(lines)
+    )
+
+    if current_entry:
+        value = current_entry[1]
+        remove_indexes = [index for index, _ in legacy_entries]
+    elif legacy_entries:
+        legacy_index, value = legacy_entries[0]
+        lines[legacy_index] = re.sub(
+            r"^(\s*)codex_hooks(\s*=)", r"\1hooks\2", lines[legacy_index], count=1
+        )
+        remove_indexes = [index for index, _ in legacy_entries[1:]]
+    else:
+        value = "true"
+        remove_indexes = []
+        newline = "\r\n" if "\r\n" in text else "\n"
+        if features_header_index is not None:
+            if not lines[features_header_index].endswith(("\n", "\r")):
+                lines[features_header_index] += newline
+            lines.insert(features_header_index + 1, f"hooks = true{newline}")
+        else:
+            prefix = text.rstrip("\r\n")
+            separator = newline * 2 if prefix else ""
+            lines = [f"{prefix}{separator}[features]{newline}hooks = true{newline}"]
+
+    for index in reversed(remove_indexes):
+        lines.pop(index)
+    return "".join(lines), value
 
 
 def _ensure_codex_feature_flag() -> int:
-    """Ensure user Codex config enables the hooks feature flag.
-
-    Detects any existing ``codex_hooks =`` line (spacing-tolerant). If it's
-    already truthy, no-op. If it's explicitly false, warn and refuse to
-    overwrite — the user opted out. Otherwise insert under ``[features]``.
-    """
+    """Enable Codex hooks and migrate the deprecated feature key."""
     config_file = _codex_config_file()
     if not config_file.exists():
         try:
             config_file.parent.mkdir(parents=True, exist_ok=True)
-            config_file.write_text("[features]\ncodex_hooks = true\n")
+            config_file.write_text("[features]\nhooks = true\n")
         except OSError as e:
             print(f"Error creating {config_file}: {e}", file=sys.stderr)
             return 1
@@ -307,26 +367,22 @@ def _ensure_codex_feature_flag() -> int:
     except OSError as e:
         print(f"Error reading {config_file}: {e}", file=sys.stderr)
         return 1
-    match = _CODEX_HOOKS_KEY_RE.search(text)
-    if match:
-        value = match.group(1).rstrip(",")
-        if value == "true":
-            return 0
-        print(
-            f"{config_file} has codex_hooks = {value}; set it to true and rerun.",
-            file=sys.stderr,
-        )
-        return 1
-    if "[features]" in text:
-        text = text.replace("[features]", "[features]\ncodex_hooks = true", 1)
-    else:
-        text = text.rstrip() + "\n\n[features]\ncodex_hooks = true\n"
-    try:
-        config_file.write_text(text)
-    except OSError as e:
-        print(f"Error writing {config_file}: {e}", file=sys.stderr)
-        return 1
-    return 0
+
+    updated_text, value = _codex_config_with_hooks(text)
+    if updated_text != text:
+        try:
+            config_file.write_text(updated_text)
+        except OSError as e:
+            print(f"Error writing {config_file}: {e}", file=sys.stderr)
+            return 1
+
+    if value == "true":
+        return 0
+    print(
+        f"{config_file} has hooks = {value}; set it to true and rerun.",
+        file=sys.stderr,
+    )
+    return 1
 
 
 _CODEX_HOOK_TIMEOUT_SECONDS = 5

--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -285,7 +285,7 @@ def _install_json_hooks(
 
 _CODEX_HOOKS_KEY_RE = re.compile(r"^\s*(hooks|codex_hooks)\s*=\s*([^,\s#]+)")
 _TOML_TABLE_HEADER_RE = re.compile(
-    r"^\s*(\[\[[^\]\r\n]+\]\]|\[[^\]\r\n]+\])(?:\s*#.*)?(?:\r?\n)?$"
+    r"^\s*(\[\[[^\]\r\n]+\]\]|\[[^\]\r\n]+\])\s*(?:#.*)?(?:\r?\n)?$"
 )
 
 

--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -283,7 +283,10 @@ def _install_json_hooks(
     return 0
 
 
-_CODEX_HOOKS_KEY_RE = re.compile(r"^\s*(hooks|codex_hooks)\s*=\s*([^,\s#]+)")
+_CODEX_HOOKS_KEY_RE = re.compile(
+    r"^\s*(?P<key>\"(?:hooks|codex_hooks)\"|'(?:hooks|codex_hooks)'|hooks|codex_hooks)"
+    r"\s*=\s*(?P<value>[^,\s#]+)"
+)
 _TOML_TABLE_HEADER_RE = re.compile(
     r"^\s*(\[\[[^\]\r\n]+\]\]|\[[^\]\r\n]+\])\s*(?:#.*)?(?:\r?\n)?$"
 )
@@ -309,10 +312,11 @@ def _find_codex_hook_feature_entries(
         key_match = _CODEX_HOOKS_KEY_RE.match(line)
         if not key_match:
             continue
-        entry = (index, key_match.group(2))
-        if key_match.group(1) == "hooks" and current_entry is None:
+        key = key_match.group("key").strip("\"'")
+        entry = (index, key_match.group("value"))
+        if key == "hooks" and current_entry is None:
             current_entry = entry
-        elif key_match.group(1) == "codex_hooks":
+        elif key == "codex_hooks":
             legacy_entries.append(entry)
 
     return features_header_index, current_entry, legacy_entries
@@ -330,7 +334,13 @@ def _codex_config_with_hooks(text: str) -> tuple[str, str]:
     elif legacy_entries:
         legacy_index, value = legacy_entries[0]
         lines[legacy_index] = re.sub(
-            r"^(\s*)codex_hooks(\s*=)", r"\1hooks\2", lines[legacy_index], count=1
+            r"^(?P<indent>\s*)(?P<quote>[\"']?)codex_hooks(?P=quote)(?P<equals>\s*=)",
+            lambda match: (
+                f"{match.group('indent')}{match.group('quote')}hooks"
+                f"{match.group('quote')}{match.group('equals')}"
+            ),
+            lines[legacy_index],
+            count=1,
         )
         remove_indexes = [index for index, _ in legacy_entries[1:]]
     else:

--- a/tests/ccgram/test_hook.py
+++ b/tests/ccgram/test_hook.py
@@ -10,6 +10,7 @@ import pytest
 from ccgram.hook import (
     _claude_settings_file,
     _closest_claude_ancestor,
+    _ensure_codex_feature_flag,
     _foreground_pgid_on_tty,
     _hook_status,
     _install_hook,
@@ -31,6 +32,77 @@ def _is_hook_installed(settings: dict) -> bool:
 
 def _expected_module_command() -> str:
     return f"{shlex.quote(sys.executable)} -m ccgram.main hook"
+
+
+class TestCodexFeatureFlag:
+    @pytest.mark.parametrize(
+        ("existing", "expected", "result"),
+        [
+            pytest.param(
+                "[features]\nhooks = true\n",
+                "[features]\nhooks = true\n",
+                0,
+                id="current-enabled",
+            ),
+            pytest.param(
+                "[features]\ncodex_hooks = true\n",
+                "[features]\nhooks = true\n",
+                0,
+                id="migrate-enabled",
+            ),
+            pytest.param(
+                "[features]\ncodex_hooks = true\nhooks = true\n",
+                "[features]\nhooks = true\n",
+                0,
+                id="remove-duplicate-legacy-key",
+            ),
+            pytest.param(
+                "[features]\nhooks = false\n",
+                "[features]\nhooks = false\n",
+                1,
+                id="current-disabled",
+            ),
+            pytest.param(
+                "[features]\ncodex_hooks = false\n",
+                "[features]\nhooks = false\n",
+                1,
+                id="migrate-disabled",
+            ),
+            pytest.param(
+                "[profiles.work.features]\nhooks = false\n",
+                "[profiles.work.features]\nhooks = false\n\n[features]\nhooks = true\n",
+                0,
+                id="ignore-profile-features",
+            ),
+            pytest.param(
+                "[features]\nunified_exec = true\n\n[[plugins]]\nhooks = false\n",
+                "[features]\nhooks = true\nunified_exec = true\n\n[[plugins]]\nhooks = false\n",
+                0,
+                id="stop-at-array-table",
+            ),
+        ],
+    )
+    def test_ensures_current_top_level_flag(
+        self,
+        tmp_path,
+        monkeypatch,
+        existing: str,
+        expected: str,
+        result: int,
+    ) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(existing)
+        monkeypatch.setattr("ccgram.hook._codex_config_file", lambda: config_file)
+
+        assert _ensure_codex_feature_flag() == result
+        assert config_file.read_text() == expected
+
+    def test_creates_config_with_current_flag(self, tmp_path, monkeypatch) -> None:
+        config_file = tmp_path / "config.toml"
+        monkeypatch.setattr("ccgram.hook._codex_config_file", lambda: config_file)
+
+        assert _ensure_codex_feature_flag() == 0
+        assert config_file.read_text() == "[features]\nhooks = true\n"
 
 
 class TestInstallHook:

--- a/tests/ccgram/test_hook.py
+++ b/tests/ccgram/test_hook.py
@@ -86,6 +86,18 @@ class TestCodexFeatureFlag:
                 0,
                 id="allow-trailing-header-whitespace",
             ),
+            pytest.param(
+                '[features]\n"hooks" = true\n',
+                '[features]\n"hooks" = true\n',
+                0,
+                id="preserve-quoted-current-key",
+            ),
+            pytest.param(
+                '[features]\n"codex_hooks" = true\n',
+                '[features]\n"hooks" = true\n',
+                0,
+                id="migrate-quoted-legacy-key",
+            ),
         ],
     )
     def test_ensures_current_top_level_flag(

--- a/tests/ccgram/test_hook.py
+++ b/tests/ccgram/test_hook.py
@@ -80,6 +80,12 @@ class TestCodexFeatureFlag:
                 0,
                 id="stop-at-array-table",
             ),
+            pytest.param(
+                "[features]  \nunified_exec = true\n",
+                "[features]  \nhooks = true\nunified_exec = true\n",
+                0,
+                id="allow-trailing-header-whitespace",
+            ),
         ],
     )
     def test_ensures_current_top_level_flag(


### PR DESCRIPTION
## Summary
- migrate ccgram from deprecated `[features].codex_hooks` to `[features].hooks`
- preserve explicit opt-out behavior and clean up legacy keys in the top-level `[features]` table
- update provider docs and add regression coverage

## Validation
- `make lint`
- `make deptry`
- `uv run pytest tests/ccgram/test_hook.py tests/ccgram/test_hook_provider_events.py -q`
- `uv run pytest tests/ccgram/test_hook.py::TestCodexFeatureFlag -q`

Release target: v4.10.2