### PR TITLE
Fix pyright errors in the new text handler and tmux tests

### DIFF
--- a/tests/ccgram/handlers/text/test_text_handler.py
+++ b/tests/ccgram/handlers/text/test_text_handler.py
@@ -633,6 +633,7 @@ class TestDeadWindowNeedsAConfirmedRead:
 
         assert result is True
         mock_router.unbind_thread.assert_not_called()
+        assert mock_reply.await_args is not None
         assert "Could not reach" in mock_reply.await_args[0][1]
 
 
@@ -769,6 +770,7 @@ class TestUnknownAgentStateDoesNotClearTheMarker:
         assert lifecycle_strategy.is_dead_notified(100, 42, "@0")
         mock_router.unbind_thread.assert_not_called()
         mock_sync_provider.assert_not_awaited()
+        assert mock_reply.await_args is not None
         assert "nothing confirms an agent" in mock_reply.await_args[0][1]
 
     @pytest.mark.parametrize("pane_command", ["claude", "codex"])

--- a/tests/ccgram/test_multiplexer_tmux.py
+++ b/tests/ccgram/test_multiplexer_tmux.py
@@ -176,7 +176,7 @@ def test_reconciliation_keeps_windows_list_windows_hides(
     ineligible so discovery still refuses it.
     """
     window = TmuxManager._window_ref_for_reconciliation(  # type: ignore[arg-type]
-        _FakeWindow(window_id, window_name)
+        _FakeWindow(window_id, window_name)  # pyright: ignore[reportArgumentType]
     )
 
     assert window.window_id == window_id
@@ -186,7 +186,7 @@ def test_reconciliation_keeps_windows_list_windows_hides(
 def test_reconciliation_keeps_ccgram_own_window() -> None:
     with patch.object(config, "own_window_id", "@9"):
         window = TmuxManager._window_ref_for_reconciliation(  # type: ignore[arg-type]
-            _FakeWindow("@9", "ccgram")
+            _FakeWindow("@9", "ccgram")  # pyright: ignore[reportArgumentType]
         )
 
     assert window.window_id == "@9"
@@ -195,7 +195,7 @@ def test_reconciliation_keeps_ccgram_own_window() -> None:
 
 def test_reconciliation_marks_an_ordinary_window_adoptable() -> None:
     window = TmuxManager._window_ref_for_reconciliation(  # type: ignore[arg-type]
-        _FakeWindow("@5", "my-project")
+        _FakeWindow("@5", "my-project")  # pyright: ignore[reportArgumentType]
     )
 
     assert window.topic_eligible is True


### PR DESCRIPTION
Closes #238

Two asserts narrow the None-able `mock_reply.await_args` before its subscripts, and the three `_FakeWindow` argument lines get the pyright ignore matching the mypy one already present there. pyright goes from 5 errors to 0 on both files, and the 73 tests in them pass unchanged.