### PR TITLE
fix(hook): key session_map by ccgram's session for grouped tmux sessions

### DIFF
--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -828,10 +828,13 @@ def _resolve_window_id(pane_id: str) -> tuple[str, str, str, str] | None:
 
     tmux_session_name, window_id, window_name = parts[0], parts[1], parts[2]
     pane_tty = parts[3] if len(parts) >= _TMUX_FORMAT_PARTS_WITH_TTY else ""
-    linked = parts[4] if len(parts) >= _TMUX_FORMAT_PARTS_WITH_LINKS else ""
-    key_session = tmux_session_name
-    if linked not in ("", "0", "1"):
-        key_session = _session_map_session_for(window_id, tmux_session_name)
+    # ``window_linked_sessions`` is not the signal for "needs remapping": a
+    # session *grouped* with ccgram's (``tmux new-session -t <session>``) shares
+    # its window list without linking the windows, so tmux reports 1 while the
+    # pane's session name still differs. ``_session_map_session_for``
+    # early-returns when the pane already sits in ccgram's session, so the tmux
+    # probe this once guarded is only paid when it is actually needed.
+    key_session = _session_map_session_for(window_id, tmux_session_name)
     session_window_key = f"{key_session}:{window_id}"
     return session_window_key, window_id, window_name, pane_tty
 

--- a/tests/ccgram/test_hook.py
+++ b/tests/ccgram/test_hook.py
@@ -584,7 +584,16 @@ class TestTabDelimitedParsing:
         mock_result = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=tmux_output + "\n", stderr=""
         )
-        with patch("ccgram.hook.subprocess.run", return_value=mock_result):
+
+        def _fake_run(args, **_kwargs):
+            # The session_map key probe asks ccgram's session for its window
+            # list; a blanket mock would hand it the display-message output and
+            # make every window look like it lives in ccgram's session.
+            if len(args) > 1 and args[1] == "list-windows":
+                return subprocess.CompletedProcess(args, 0, "", "")
+            return mock_result
+
+        with patch("ccgram.hook.subprocess.run", side_effect=_fake_run):
             hook_main()
 
         session_map = json.loads((tmp_path / "session_map.json").read_text())
@@ -720,6 +729,33 @@ class TestSessionMapKeyForLinkedWindow:
             "@34",
             "code",
             "/dev/ttys001",
+        )
+
+    def test_grouped_session_window_keys_under_ccgram_session(
+        self, monkeypatch
+    ) -> None:
+        """A pane in a session *grouped* with ccgram's (``tmux new-session -t
+        <session>``) shares that session's window list without linking the
+        windows, so tmux reports ``window_linked_sessions=1``. The key must
+        still resolve to ccgram's session or the binding is never found.
+        """
+        monkeypatch.setattr(config, "tmux_session_name", "ccgram")
+
+        def _fake_run(args, **_kwargs):
+            if args[1] == "display-message":
+                return subprocess.CompletedProcess(
+                    args, 0, "grouped-1234\t@1\tcode\t/dev/ttys003\t1\n", ""
+                )
+            if args[1] == "list-windows":
+                return subprocess.CompletedProcess(args, 0, "@1\n", "")
+            pytest.fail(f"unexpected command: {args}")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        assert _resolve_window_id("%1") == (
+            "ccgram:@1",
+            "@1",
+            "code",
+            "/dev/ttys003",
         )
 
     def test_unlinked_window_keeps_pane_session(self, monkeypatch) -> None:


### PR DESCRIPTION
Closes #241

## Problem

A pane attached through a tmux session *grouped* with the ccgram session is never adopted — the topic exists and its title syncs, but no transcript is ever delivered (`tracked_sessions` stays empty).

`_resolve_window_id` gated its remap on `#{window_linked_sessions}`, but a **grouped** session is not a **linked** window: `tmux new-session -t main` shares main's window *list* without linking the windows into the new session, so tmux reports `1` and the remap never fires. The hook writes `<grouped-session>:@1` while readers resolve `<ccgram-session>:@1` via `session_map_prefix()`, and the binding is invisible.

## Fix

Drop the guard and always call `_session_map_session_for`. That helper already early-returns when the pane sits in ccgram's session, so the tmux probe the guard was avoiding is only paid in the case that needs it — the guard was pure cost, and it was suppressing the one call that mattered.

## Tests

- `test_grouped_session_window_keys_under_ccgram_session` — a pane whose session differs from ccgram's while tmux reports `window_linked_sessions=1`. Watched it fail (`assert 'grouped-1234:@1' != 'ccgram:@1'`) before the fix.
- `TestTabDelimitedParsing` needed a command-aware `subprocess.run` fake. Its blanket mock returned the same stdout for every tmux command, so the new window-list probe was handed the display-message output and every window looked like it lived in ccgram's session. The assertions are unchanged; only the fake got more faithful.

`make test` and `make lint` pass (7043 passed, 32 skipped). pyright reports no new errors in `hook.py`.

## Note

`_TMUX_FORMAT_PARTS_WITH_LINKS` and the `#{window_linked_sessions}` field in the format string are now unused. I left them in place to keep the diff to the actual fix — happy to remove them if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gdfDBMrmPzYdQ9tevrsME