### PR TITLE
fix(hook): detect the provider from the executable, not any path

### DIFF
--- a/src/ccgram/hook.py
+++ b/src/ccgram/hook.py
@@ -58,6 +58,10 @@ _PATH_HOOK_MARKER = "ccgram hook"
 _TMUX_FORMAT_PARTS = 3
 _TMUX_FORMAT_PARTS_WITH_TTY = 4
 _TMUX_FORMAT_PARTS_WITH_LINKS = 5
+# Providers detectable by executable name on a tty, in precedence order. ``pi``
+# is matched separately: it is short enough to collide (pip, pipenv) and so is
+# only ever accepted as an exact basename.
+_TTY_PROVIDERS: tuple[ProviderName, ...] = ("gemini", "codex", "claude")
 
 # ps -A output is split into 5 fields: pid, ppid, pgid, stat, command.
 _PS_SNAPSHOT_FIELDS = 5
@@ -1305,12 +1309,24 @@ def _provider_from_pane_tty(pane_tty: str) -> ProviderName | None:
     except subprocess.TimeoutExpired, OSError:
         return None
     text = result.stdout.lower()
-    if "gemini" in text:
-        return "gemini"
-    if "codex" in text:
-        return "codex"
-    if "claude" in text:
-        return "claude"
+    # Prefer the executable actually running on the tty. A provider name can
+    # also appear in an unrelated *path* on some other process's command line
+    # (claude-mem's helper carries ``~/.codex/plugins/cache/claude-mem-local``
+    # on every Claude pane), and a whole-text substring scan reads that as the
+    # running agent. Basenames are checked first for that reason; the scan is
+    # kept as a fallback so wrapper launches (``node .../claude/cli.js``) that
+    # expose no provider basename still resolve as they did before.
+    executables = {
+        line.split()[0].rsplit("/", 1)[-1] for line in text.splitlines() if line.split()
+    }
+    for name in _TTY_PROVIDERS:
+        if name in executables:
+            return name
+    if "pi" in executables:
+        return "pi"
+    for name in _TTY_PROVIDERS:
+        if name in text:
+            return name
     if any(tok == "pi" or tok.endswith("/pi") for tok in text.split()):
         return "pi"
     return None

--- a/tests/ccgram/test_hook.py
+++ b/tests/ccgram/test_hook.py
@@ -1048,5 +1048,26 @@ class TestProviderFromPaneTty:
         with patch("ccgram.hook.subprocess.run", return_value=result):
             assert _provider_from_pane_tty("/dev/ttys012") == provider
 
+    def test_unrelated_path_mentioning_another_agent_is_not_the_provider(
+        self,
+    ) -> None:
+        """A provider name buried in a *path* is not a running agent.
+
+        claude-mem's helper carries ``~/.codex/plugins/cache/claude-mem-local``
+        on its command line, so a substring scan of the whole tty process list
+        reports ``codex`` for every Claude pane that has claude-mem loaded.
+        """
+        ps_text = (
+            "-zsh\n"
+            "claude --dangerously-skip-permissions\n"
+            'node -e const h=o.homedir();L(p.join(h,".codex/plugins/cache/'
+            'claude-mem-local/claude-mem"))\n'
+        )
+        result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=ps_text, stderr=""
+        )
+        with patch("ccgram.hook.subprocess.run", return_value=result):
+            assert _provider_from_pane_tty("/dev/ttys003") == "claude"
+
     def test_empty_tty_returns_none(self) -> None:
         assert _provider_from_pane_tty("") is None


### PR DESCRIPTION
Closes #242

## Problem

`_provider_from_pane_tty` substring-scans the whole `ps -t <tty> -o command=` output, which is every process on the tty rather than just the agent. The claude-mem plugin runs a helper carrying `~/.codex/plugins/cache/claude-mem-local` on its command line, and `codex` is checked before `claude` — so every Claude pane with claude-mem loaded detects as `codex`.

A provider name inside a *path* is not a running agent.

## Fix

Check executable basenames first, which is the stricter rule the function already applies to `pi` (exact basename only, so `pip` and `pipenv` cannot match). The existing substring scan is kept as a fallback, so wrapper launches that expose no provider basename — `node .../claude/cli.js` — resolve exactly as they do today.

That ordering makes the change additive in precedence: nothing that resolves correctly today starts resolving differently. Only cases that were previously answered by a path now get answered by the executable.

## Tests

- `test_unrelated_path_mentioning_another_agent_is_not_the_provider` — built from the real `ps` output of an affected pane (zsh + `claude` + the claude-mem helper). Watched it fail (`- claude / + codex`) before the fix.
- The existing `TestProviderFromPaneTty` parametrization is unchanged and still passes, including the `pip` / `pipenv` / `pip3` negatives.

`make test` and `make lint` pass (7043 passed, 32 skipped). pyright reports no new errors in `hook.py`.

The two passes pushed the function to 9 returns (`PLR0911` limit is 8), so both are loops over a new `_TTY_PROVIDERS` constant, typed `tuple[ProviderName, ...]` to keep the literal return type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gdfDBMrmPzYdQ9tevrsME